### PR TITLE
pylint-fixes to everything related to imports

### DIFF
--- a/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
+++ b/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
@@ -1,11 +1,11 @@
-import numpy as np
 import glob
+import os
+from multiprocessing import Queue
 import mxnet as mx
 from mxnet import gluon
-from multiprocessing import  Queue
+import numpy as np
 from DeepCrazyhouse.configs.main_config_sample import main_config
-import os
-from DeepCrazyhouse.src.domain.crazyhouse.constants import NB_CHANNELS_FULL, BOARD_WIDTH, BOARD_HEIGHT
+from DeepCrazyhouse.src.domain.crazyhouse.constants import BOARD_HEIGHT, BOARD_WIDTH, NB_CHANNELS_FULL
 
 
 class NeuralNetAPI:

--- a/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
+++ b/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
@@ -7,7 +7,7 @@ import re
 import mxnet as mx
 from mxnet import gluon
 from multiprocessing import Process, Queue
-from DeepCrazyhouse.configs.main_config import main_config
+from DeepCrazyhouse.configs.main_config_sample import main_config
 import os
 from DeepCrazyhouse.src.domain.crazyhouse.constants import NB_CHANNELS_FULL, BOARD_WIDTH, BOARD_HEIGHT
 

--- a/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
+++ b/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
@@ -1,12 +1,8 @@
-import logging
 import numpy as np
-import time
-import json
 import glob
-import re
 import mxnet as mx
 from mxnet import gluon
-from multiprocessing import Process, Queue
+from multiprocessing import  Queue
 from DeepCrazyhouse.configs.main_config_sample import main_config
 import os
 from DeepCrazyhouse.src.domain.crazyhouse.constants import NB_CHANNELS_FULL, BOARD_WIDTH, BOARD_HEIGHT

--- a/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
+++ b/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
@@ -4,7 +4,7 @@ from multiprocessing import Queue
 import mxnet as mx
 from mxnet import gluon
 import numpy as np
-from DeepCrazyhouse.configs.main_config_sample import main_config
+from DeepCrazyhouse.configs.main_config import main_config
 from DeepCrazyhouse.src.domain.crazyhouse.constants import BOARD_HEIGHT, BOARD_WIDTH, NB_CHANNELS_FULL
 
 

--- a/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
@@ -14,25 +14,25 @@ If the evaluation for one move takes too long on your hardware you can decrease 
 For more details and the mathematical equations please take a look at src/domain/agent/README.md as well as the
 official DeepMind-papers.
 """
-
-import numpy as np
-
-from DeepCrazyhouse.src.domain.crazyhouse.output_representation import get_probs_of_move_list, value_to_centipawn
-from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
+import collections
+import cProfile
+import io
+import logging
+import math
+import pstats
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from multiprocessing import Pipe
-import logging
+from time import time
+import numpy as np
+from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
+from DeepCrazyhouse.src.domain.agent.player._Agent import _Agent
 from DeepCrazyhouse.src.domain.agent.player.util.NetPredService import NetPredService
 from DeepCrazyhouse.src.domain.agent.player.util.Node import Node
-from concurrent.futures import ThreadPoolExecutor
-from time import time
-from DeepCrazyhouse.src.domain.agent.player._Agent import _Agent
+from DeepCrazyhouse.src.domain.crazyhouse.constants import BOARD_HEIGHT, BOARD_WIDTH, NB_CHANNELS_FULL, NB_LABELS
 from DeepCrazyhouse.src.domain.crazyhouse.GameState import GameState
-import collections
-from DeepCrazyhouse.src.domain.crazyhouse.constants import NB_CHANNELS_FULL, BOARD_WIDTH, BOARD_HEIGHT, NB_LABELS
-import math
+from DeepCrazyhouse.src.domain.crazyhouse.output_representation import get_probs_of_move_list, value_to_centipawn
 
-import cProfile, pstats, io
 
 DTYPE = np.float
 

--- a/DeepCrazyhouse/src/domain/agent/player/RawNetAgent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/RawNetAgent.py
@@ -7,12 +7,11 @@ Created on 14.10.18
 The raw network uses the the single network prediction for it's evaluation.
 No mcts search is being done.
 """
-
-from DeepCrazyhouse.src.domain.agent.player._Agent import _Agent
+from time import time
 from DeepCrazyhouse.src.domain.abstract_cls._GameState import _GameState
 from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
+from DeepCrazyhouse.src.domain.agent.player._Agent import _Agent
 from DeepCrazyhouse.src.domain.crazyhouse.output_representation import get_probs_of_move_list, value_to_centipawn
-from time import time
 
 
 class RawNetAgent(_Agent):

--- a/DeepCrazyhouse/src/domain/agent/player/RawNetAgent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/RawNetAgent.py
@@ -13,7 +13,6 @@ from DeepCrazyhouse.src.domain.abstract_cls._GameState import _GameState
 from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
 from DeepCrazyhouse.src.domain.crazyhouse.output_representation import get_probs_of_move_list, value_to_centipawn
 from time import time
-import sys
 
 
 class RawNetAgent(_Agent):

--- a/DeepCrazyhouse/src/domain/agent/player/_Agent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/_Agent.py
@@ -6,10 +6,9 @@ Created on 14.10.18
 
 Please describe what the content of this file is about
 """
-
-from DeepCrazyhouse.src.domain.abstract_cls._GameState import _GameState
-import numpy as np
 from copy import deepcopy
+import numpy as np
+from DeepCrazyhouse.src.domain.abstract_cls._GameState import _GameState
 
 
 class _Agent:

--- a/DeepCrazyhouse/src/domain/agent/player/util/NetPredService.py
+++ b/DeepCrazyhouse/src/domain/agent/player/util/NetPredService.py
@@ -6,13 +6,12 @@ Created on 13.10.18
 
 Please describe what the content of this file is about
 """
-
-from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
 from multiprocessing import connection
 from threading import Thread
+from time import time
 import mxnet as mx
 import numpy as np
-from time import time
+from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
 
 
 class NetPredService:

--- a/DeepCrazyhouse/src/domain/agent/player/util/NetPredService.py
+++ b/DeepCrazyhouse/src/domain/agent/player/util/NetPredService.py
@@ -8,14 +8,11 @@ Please describe what the content of this file is about
 """
 
 from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
-from multiprocessing import Barrier, Pipe, connection
-import logging
+from multiprocessing import connection
 from threading import Thread
 import mxnet as mx
 import numpy as np
-from DeepCrazyhouse.src.domain.crazyhouse.output_representation import NB_LABELS, LABELS
 from time import time
-import cython
 
 
 class NetPredService:

--- a/DeepCrazyhouse/src/domain/agent/player/util/Node.py
+++ b/DeepCrazyhouse/src/domain/agent/player/util/Node.py
@@ -6,11 +6,11 @@ Created on 13.10.18
 
 Helper class which stores the statistics of all nodes and in the search tree.
 """
-
+from copy import deepcopy
 from threading import Lock
 import chess
 import numpy as np
-from copy import deepcopy
+
 
 QSIZE = 100
 

--- a/DeepCrazyhouse/src/domain/agent/player/util/Node.py
+++ b/DeepCrazyhouse/src/domain/agent/player/util/Node.py
@@ -11,7 +11,6 @@ from threading import Lock
 import chess
 import numpy as np
 from copy import deepcopy
-from collections import deque
 
 QSIZE = 100
 

--- a/DeepCrazyhouse/src/domain/crazyhouse/GameState.py
+++ b/DeepCrazyhouse/src/domain/crazyhouse/GameState.py
@@ -2,8 +2,6 @@ import chess
 from chess.variant import CrazyhouseBoard
 from DeepCrazyhouse.src.domain.crazyhouse.input_representation import board_to_planes
 from DeepCrazyhouse.src.domain.abstract_cls._GameState import _GameState
-import numpy as np
-import collections
 
 
 class GameState(_GameState):

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/Rise.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/Rise.py
@@ -19,7 +19,7 @@ compared to the architecture proposed by DeepMind (19 residual layers with 256 f
 On our 10,000 games benchmark dataset it achieved a lower validation error.
 """
 
-from mxnet.gluon.nn import HybridSequential, Conv2D, BatchNorm, Activation, Flatten, Dense
+from mxnet.gluon.nn import HybridSequential, Conv2D, BatchNorm
 from mxnet.gluon import HybridBlock
 from DeepCrazyhouse.src.domain.neural_net.architectures.builder_util import get_act
 from DeepCrazyhouse.src.domain.neural_net.architectures.rise_builder_util import _SqueezeExcitation

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
@@ -7,13 +7,7 @@ Created on 26.09.18
 Please describe what the content of this file is about
 """
 
-from mxnet.gluon.nn import (
-    HybridSequential,
-    Conv2D,
-    BatchNorm,
-    Dense,
-    AvgPool2D,
-)
+from mxnet.gluon.nn import HybridSequential, Conv2D, BatchNorm, Dense, AvgPool2D
 from mxnet.gluon import HybridBlock
 from mxnet.gluon.contrib.nn import HybridConcurrent
 from DeepCrazyhouse.src.domain.neural_net.architectures.builder_util import get_act

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
@@ -11,16 +11,8 @@ from mxnet.gluon.nn import (
     HybridSequential,
     Conv2D,
     BatchNorm,
-    Activation,
-    Flatten,
     Dense,
     AvgPool2D,
-    MaxPool2D,
-    PReLU,
-    SELU,
-    Swish,
-    LeakyReLU,
-    GlobalAvgPool2D,
 )
 from mxnet.gluon import HybridBlock
 from mxnet.gluon.contrib.nn import HybridConcurrent

--- a/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
@@ -23,7 +23,7 @@ import numpy as np
 import psutil
 import zarr
 from numcodecs import Blosc
-from DeepCrazyhouse.configs.main_config_sample import main_config
+from DeepCrazyhouse.configs.main_config import main_config
 from DeepCrazyhouse.src.domain.util import get_dic_sorted_by_key
 from DeepCrazyhouse.src.preprocessing.pgn_converter_util import get_planes_from_pgn
 

--- a/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
@@ -14,14 +14,11 @@ from time import time
 import io
 from multiprocessing import Process, Pool, Queue
 from copy import deepcopy
-
 from DeepCrazyhouse.src.preprocessing.pgn_converter_util import get_planes_from_pgn
 from DeepCrazyhouse.src.domain.util import get_dic_sorted_by_key
-from DeepCrazyhouse.configs.main_config import main_config
+from DeepCrazyhouse.configs.main_config_sample import main_config
 import math
-
 import numpy as np
-import json
 import logging
 import os
 import zarr

--- a/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
@@ -7,26 +7,25 @@ Created on 09.06.18
 Loads the pgn-file and calls the pgn_converter functions to create a plane represenation.
 Multiprocessing is used for loading, computing and saving.
 """
-
+import datetime
+import gc
+import io
+import logging
+import math
+import os
+import re
+from copy import deepcopy
+from multiprocessing import Pool, Process, Queue
+from time import time
 import chess.pgn
 import matplotlib.pyplot as plt
-from time import time
-import io
-from multiprocessing import Process, Pool, Queue
-from copy import deepcopy
-from DeepCrazyhouse.src.preprocessing.pgn_converter_util import get_planes_from_pgn
-from DeepCrazyhouse.src.domain.util import get_dic_sorted_by_key
-from DeepCrazyhouse.configs.main_config_sample import main_config
-import math
 import numpy as np
-import logging
-import os
+import psutil
 import zarr
 from numcodecs import Blosc
-import gc
-import psutil
-import datetime
-import re
+from DeepCrazyhouse.configs.main_config_sample import main_config
+from DeepCrazyhouse.src.domain.util import get_dic_sorted_by_key
+from DeepCrazyhouse.src.preprocessing.pgn_converter_util import get_planes_from_pgn
 
 
 class PGN2PlanesConverter(object):

--- a/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
+++ b/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
@@ -7,12 +7,11 @@ Created on 25.09.18
 Utility class to load the rec dataset in the training loop of the CNN
 """
 
-from mxnet.gluon.data.dataset import RecordFileDataset
 import zlib
 from DeepCrazyhouse.src.domain.util import normalize_input_planes
 import numpy as np
 import mxnet as mx
-from DeepCrazyhouse.configs.main_config import main_config
+from DeepCrazyhouse.configs.main_config_sample import main_config
 from mxnet.gluon.data import dataset
 from mxnet.gluon.data.dataset import recordio
 import os

--- a/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
+++ b/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
@@ -12,7 +12,7 @@ import mxnet as mx
 import numpy as np
 from mxnet.gluon.data import dataset
 from mxnet.gluon.data.dataset import recordio
-from DeepCrazyhouse.configs.main_config_sample import main_config
+from DeepCrazyhouse.configs.main_config import main_config
 from DeepCrazyhouse.src.domain.util import normalize_input_planes
 
 

--- a/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
+++ b/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
@@ -6,15 +6,14 @@ Created on 25.09.18
 
 Utility class to load the rec dataset in the training loop of the CNN
 """
-
+import os
 import zlib
-from DeepCrazyhouse.src.domain.util import normalize_input_planes
-import numpy as np
 import mxnet as mx
-from DeepCrazyhouse.configs.main_config_sample import main_config
+import numpy as np
 from mxnet.gluon.data import dataset
 from mxnet.gluon.data.dataset import recordio
-import os
+from DeepCrazyhouse.configs.main_config_sample import main_config
+from DeepCrazyhouse.src.domain.util import normalize_input_planes
 
 
 def __getitem__(self, idx):

--- a/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
@@ -26,7 +26,7 @@ import zlib
 from glob import glob
 from time import time
 import mxnet as mx
-from DeepCrazyhouse.configs.main_config_sample import main_config
+from DeepCrazyhouse.configs.main_config import main_config
 
 
 class Planes2RecConverter:

--- a/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
@@ -21,13 +21,12 @@ for i in range(3):
 record.close()
 ```
 """
-
-from DeepCrazyhouse.configs.main_config_sample import main_config
-import mxnet as mx
 import logging
-from time import time
 import zlib
 from glob import glob
+from time import time
+import mxnet as mx
+from DeepCrazyhouse.configs.main_config_sample import main_config
 
 
 class Planes2RecConverter:

--- a/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
@@ -22,8 +22,7 @@ record.close()
 ```
 """
 
-import DeepCrazyhouse.src.runtime.Colorer
-from DeepCrazyhouse.configs.main_config import main_config
+from DeepCrazyhouse.configs.main_config_sample import main_config
 import mxnet as mx
 import logging
 from time import time

--- a/DeepCrazyhouse/src/preprocessing/dataset_loader.py
+++ b/DeepCrazyhouse/src/preprocessing/dataset_loader.py
@@ -11,7 +11,7 @@ import logging
 import chess
 import numpy as np
 import zarr
-from DeepCrazyhouse.configs.main_config_sample import main_config
+from DeepCrazyhouse.configs.main_config import main_config
 from DeepCrazyhouse.src.domain.crazyhouse.constants import (
     CHANNEL_MAPPING_CONST,
     CHANNEL_MAPPING_POS,

--- a/DeepCrazyhouse/src/preprocessing/pgn_converter_util.py
+++ b/DeepCrazyhouse/src/preprocessing/pgn_converter_util.py
@@ -7,12 +7,9 @@ Created on 09.06.18
 Converts a given board state defined by a python-chess object to the plane representation which can be learned by a CNN
 """
 
-from collections import deque
-
 import numpy as np
 import chess.pgn
-
-from DeepCrazyhouse.src.domain.crazyhouse.output_representation import move_to_policy, mirror_move
+from DeepCrazyhouse.src.domain.crazyhouse.output_representation import move_to_policy
 from DeepCrazyhouse.src.domain.crazyhouse.input_representation import board_to_planes
 
 # constant which defines how many meta data items will be stored in a matrix

--- a/DeepCrazyhouse/src/tools/server/game_server.py
+++ b/DeepCrazyhouse/src/tools/server/game_server.py
@@ -1,7 +1,6 @@
 from flask import Flask, send_from_directory, request
 import chess
 import json
-
 from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
 from DeepCrazyhouse.src.domain.agent.player.RawNetAgent import RawNetAgent
 from DeepCrazyhouse.src.domain.agent.player.MCTSAgent import MCTSAgent

--- a/DeepCrazyhouse/src/tools/server/game_server.py
+++ b/DeepCrazyhouse/src/tools/server/game_server.py
@@ -1,11 +1,12 @@
-from flask import Flask, send_from_directory, request
-import chess
 import json
-from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
-from DeepCrazyhouse.src.domain.agent.player.RawNetAgent import RawNetAgent
-from DeepCrazyhouse.src.domain.agent.player.MCTSAgent import MCTSAgent
-from DeepCrazyhouse.src.domain.crazyhouse.GameState import GameState
 import logging
+import chess
+from flask import Flask, request, send_from_directory
+from DeepCrazyhouse.src.domain.agent.NeuralNetAPI import NeuralNetAPI
+from DeepCrazyhouse.src.domain.agent.player.MCTSAgent import MCTSAgent
+from DeepCrazyhouse.src.domain.agent.player.RawNetAgent import RawNetAgent
+from DeepCrazyhouse.src.domain.crazyhouse.GameState import GameState
+
 
 file_lookup = {"A": 0, "B": 1, "C": 2, "D": 3, "E": 4, "F": 5, "G": 6, "H": 7}
 rank_lookup = {"1": 0, "2": 1, "3": 2, "4": 3, "5": 4, "6": 5, "7": 6, "8": 7}

--- a/DeepCrazyhouse/src/training/TrainerAgent.py
+++ b/DeepCrazyhouse/src/training/TrainerAgent.py
@@ -11,7 +11,7 @@ import logging
 import random
 from time import time
 from tqdm import tqdm_notebook
-from DeepCrazyhouse.src.domain.preprocessing.util import load_pgn_dataset
+from DeepCrazyhouse.src.preprocessing.dataset_loader import load_pgn_dataset
 import mxnet as mx
 from mxnet import gluon
 from mxnet import nd, autograd

--- a/DeepCrazyhouse/src/training/TrainerAgent.py
+++ b/DeepCrazyhouse/src/training/TrainerAgent.py
@@ -6,18 +6,16 @@ Created on 27.09.18
 
 Definition of the main training loop done in keras.
 """
-
+import datetime
 import logging
 import random
 from time import time
+import mxnet as mx
+from mxnet import autograd, gluon, nd
+import numpy as np
+from mxboard import SummaryWriter
 from tqdm import tqdm_notebook
 from DeepCrazyhouse.src.preprocessing.dataset_loader import load_pgn_dataset
-import mxnet as mx
-from mxnet import gluon
-from mxnet import nd, autograd
-import datetime
-from mxboard import SummaryWriter
-import numpy as np
 
 
 def acc_sign(y_true, y_pred):

--- a/crazyara.py
+++ b/crazyara.py
@@ -12,7 +12,6 @@ http://wbec-ridderkerk.nl/html/UCIProtocol.html
 from __future__ import print_function
 import sys
 import chess.pgn
-
 import traceback
 import collections
 import numpy as np

--- a/etc/sf_self_play/sf_cz_game_generator.py
+++ b/etc/sf_self_play/sf_cz_game_generator.py
@@ -44,47 +44,56 @@ variant = None
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Sf self play game generator v%.1f' % version)
+    parser = argparse.ArgumentParser(description="Sf self play game generator v%.1f" % version)
 
     username = getpass.getuser()
 
     # check for os
-    if os.name == 'nt':
+    if os.name == "nt":
         # add .exe for windows
-        def_cutechess_cli = 'cutechess-cli.exe'
-        def_sf_path = 'C:/Programs/crazyhouse_engines/stockfish/stockfish-x86_64-modern.exe'
+        def_cutechess_cli = "cutechess-cli.exe"
+        def_sf_path = "C:/Programs/crazyhouse_engines/stockfish/stockfish-x86_64-modern.exe"
     else:
         # linux or mac
-        def_cutechess_cli = 'cutechess-cli'
-        def_sf_path = '/home/%s/Programs/crazyhouse_engines/stockfish/stockfish-x86_64-modern' % username
+        def_cutechess_cli = "cutechess-cli"
+        def_sf_path = "/home/%s/Programs/crazyhouse_engines/stockfish/stockfish-x86_64-modern" % username
 
+    parser.add_argument(
+        "--cutechess_cli_path",
+        default=def_cutechess_cli,
+        type=str,
+        help="cutechess executable path (default: %s)" % def_cutechess_cli,
+    )
 
-    parser.add_argument('--cutechess_cli_path',
-                        default=def_cutechess_cli, type=str,
-                        help='cutechess executable path (default: %s)' % def_cutechess_cli)
+    parser.add_argument(
+        "--sf_path", default=def_sf_path, type=str, help="cutechess executable path (default: %s)" % def_sf_path
+    )
 
-    parser.add_argument('--sf_path',
-                        default=def_sf_path, type=str,
-                        help='cutechess executable path (default: %s)' % def_sf_path)
-
-    parser.add_argument('--opening_book_path',
-                        default='1k_cz_lichess_startpos.pgn', type=str,
-                        help='opening book path (default: 1k_cz_lichess_startpos.pgn')
+    parser.add_argument(
+        "--opening_book_path",
+        default="1k_cz_lichess_startpos.pgn",
+        type=str,
+        help="opening book path (default: 1k_cz_lichess_startpos.pgn",
+    )
 
     # create the output file based on the username
-    def_pgnout_path ='sf_vs_sf_' + username + '.pgn'
-    parser.add_argument('--pgnout_path',
-                        default=def_pgnout_path, type=str,
-                        help='filepath where the games will be stored (default: %s)' % def_pgnout_path)
+    def_pgnout_path = "sf_vs_sf_" + username + ".pgn"
+    parser.add_argument(
+        "--pgnout_path",
+        default=def_pgnout_path,
+        type=str,
+        help="filepath where the games will be stored (default: %s)" % def_pgnout_path,
+    )
 
-    parser.add_argument('--threads', type=int,
-                        default=max(multiprocessing.cpu_count()-1, 1),
-                        help='number of threads for generating games (default: %d number of cores-1 detected by python)'
-                             % max(multiprocessing.cpu_count()-1, 1))
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=max(multiprocessing.cpu_count() - 1, 1),
+        help="number of threads for generating games (default: %d number of cores-1 detected by python)"
+        % max(multiprocessing.cpu_count() - 1, 1),
+    )
 
-    parser.add_argument('--hash', type=int,
-                        default=def_hash,
-                        help='hash size in mb (default: %d)' % def_hash)
+    parser.add_argument("--hash", type=int, default=def_hash, help="hash size in mb (default: %d)" % def_hash)
 
     available_variants = "'3check': Three-check Chess\
                         '5check': Five-check Chess\
@@ -107,9 +116,12 @@ def main():
                         'racingkings': Racing Kings Chess\
                         'standard': Standard Chess."
 
-    parser.add_argument('--variant',
-                        default='crazyhouse', type=str,
-                        help="define the chess variant (default: crazyhouse)" + available_variants)
+    parser.add_argument(
+        "--variant",
+        default="crazyhouse",
+        type=str,
+        help="define the chess variant (default: crazyhouse)" + available_variants,
+    )
 
     args = parser.parse_args()
 
@@ -119,8 +131,8 @@ def main():
     # start the self play learning loop
     while True:
         # use a random fixed number of nodes for white and black on every move
-        random_nodes_white = NB_NODES * random.random() * RANDOM_FACTOR_NODES * random.choice([-1,1])
-        random_nodes_black = NB_NODES * random.random() * RANDOM_FACTOR_NODES * random.choice([-1,1])
+        random_nodes_white = NB_NODES * random.random() * RANDOM_FACTOR_NODES * random.choice([-1, 1])
+        random_nodes_black = NB_NODES * random.random() * RANDOM_FACTOR_NODES * random.choice([-1, 1])
 
         current_nodes_white = int(NB_NODES + random_nodes_white)
         current_nodes_black = int(NB_NODES + random_nodes_black)
@@ -133,21 +145,40 @@ def main():
         t = time.localtime()
 
         # description of the current game
-        event = 'Game %d - Nodes: %d-%d - Hash: %d' % (
-            i + 1, current_nodes_white, current_nodes_black, args.hash)
+        event = "Game %d - Nodes: %d-%d - Hash: %d" % (i + 1, current_nodes_white, current_nodes_black, args.hash)
 
         for current_nodes in [current_nodes_white, current_nodes_black]:
-            sf_engine_cmd.append(' -engine cmd=' + args.sf_path + ' tc=inf nodes=' + str(current_nodes) +
-                                 ' option.Hash=' + str(args.hash) + ' option.Threads=' + str(args.threads) +
-                                 ' depth=' + str(MAX_DEPTH) + ' proto=uci')
+            sf_engine_cmd.append(
+                " -engine cmd="
+                + args.sf_path
+                + " tc=inf nodes="
+                + str(current_nodes)
+                + " option.Hash="
+                + str(args.hash)
+                + " option.Threads="
+                + str(args.threads)
+                + " depth="
+                + str(MAX_DEPTH)
+                + " proto=uci"
+            )
 
-        game_cmd = ' -variant ' + str(args.variant) + ' -event ' + '"' + event + '"' + \
-                   ' -openings file=' + args.opening_book_path + ' order=random -pgnout ' + args.pgnout_path
+        game_cmd = (
+            " -variant "
+            + str(args.variant)
+            + " -event "
+            + '"'
+            + event
+            + '"'
+            + " -openings file="
+            + args.opening_book_path
+            + " order=random -pgnout "
+            + args.pgnout_path
+        )
 
         cmd_str = args.cutechess_cli_path + sf_engine_cmd[0] + sf_engine_cmd[1] + game_cmd
 
         # print the current game description
-        print('%s - %s - Threads: %d' % (time.asctime(t), event, args.threads))
+        print("%s - %s - Threads: %d" % (time.asctime(t), event, args.threads))
 
         # start the game with the cutechess-cli
         p = subprocess.Popen(cmd_str, shell=True)


### PR DESCRIPTION
**Import error fixes:**
- Fix everything that prevented the module to be imported f.e `DeepCrazyhouse.configs.main_config` don't exist so I changed to `DeepCrazyhouse.configs.main_config_sample`

**Unused import fixes:**
- Remove every unused module or method

**Wrong import error fixes:**
- The suggested order is - standard modules -> third-party modules -> internal project modules(used isort module to do it)

Test it, it could have caused some minor errors, its rare but happens

Includes reformatting of sf_cz_game_generator.py