### PR TITLE
group similar imports and use truthy values

### DIFF
--- a/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
@@ -256,7 +256,7 @@ class MCTSAgent(_Agent):
         legal_moves = state.get_legal_moves()
 
         # consistency check
-        if len(legal_moves) == 0:
+        if not legal_moves:
             raise Exception("The given board state has no legal move available")
 
         # check first if the the current tree can be reused
@@ -856,7 +856,7 @@ class MCTSAgent(_Agent):
                     # get the current legal move of its board state
                     legal_moves = state.get_legal_moves()
 
-                    if len(legal_moves) < 1:
+                    if not legal_moves:
                         raise Exception("No legal move is available for state: %s" % state)
 
                     # extract a sparse policy vector with normalized probabilities

--- a/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
+++ b/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
@@ -10,8 +10,7 @@ import os
 import zlib
 import mxnet as mx
 import numpy as np
-from mxnet.gluon.data import dataset
-from mxnet.gluon.data.dataset import recordio
+from mxnet.gluon.data.dataset import recordio, Dataset
 from DeepCrazyhouse.configs.main_config import main_config
 from DeepCrazyhouse.src.domain.util import normalize_input_planes
 
@@ -20,7 +19,7 @@ def __getitem__(self, idx):
     return self._record.read_idx(self._record.keys[idx])
 
 
-class PGNRecordDataset(dataset.Dataset):
+class PGNRecordDataset(Dataset):
     def __init__(self, dataset_type, input_shape, normalize=True):
         """
         Constructor of the PGNRecordDataset class

--- a/DeepCrazyhouse/src/preprocessing/pgn_converter_util.py
+++ b/DeepCrazyhouse/src/preprocessing/pgn_converter_util.py
@@ -154,7 +154,7 @@ def get_planes_from_game(game, mate_in_one=False):
         board.push(move)
 
     # check if there has been any moves
-    if len(x) > 0 and len(y_value) > 0 and len(y_policy) > 0:
+    if x and y_value and y_policy:
         x = np.stack(x, axis=0)
         y_value = np.stack(y_value, axis=0)
         y_policy = np.stack(y_policy, axis=0)

--- a/DeepCrazyhouse/src/training/TrainerAgent.py
+++ b/DeepCrazyhouse/src/training/TrainerAgent.py
@@ -283,7 +283,7 @@ class TrainerAgent:
         value_out = None
 
         # safety check to prevent eternal loop
-        if len(self.ordering) == 0:
+        if not self.ordering:
             raise Exception("You must have at least one part file in your planes-dataset directory!")
 
         while True:


### PR DESCRIPTION
**group similar imports fix**

- It removes redundancy (importing 2 times the same module)

**len-as-condition pylint error fix**

- Making use of truthy value in python, its cleaner and also slightly faster as well since it doesn't call the `len()` function and doesn't make value comparisons