### PR TITLE
Other pylint fixes and some bug fixes

### DIFF
--- a/DeepCrazyhouse/src/domain/abstract_cls/_GameState.py
+++ b/DeepCrazyhouse/src/domain/abstract_cls/_GameState.py
@@ -20,9 +20,8 @@ class _GameState:
         self.board.push(move)
 
     def get_state_planes(self):
-
         raise NotImplementedError("get_state_planes() should return board_to_planes(self.board, 0, normalize=True)")
-        return board_to_planes(self.board, 0, normalize=True)
+         # return board_to_planes(self.board, 0, normalize=True)
 
     def get_pythonchess_board(self):
         return self.board
@@ -35,7 +34,7 @@ class _GameState:
         raise NotImplementedError()
         # only a is_won() and no is_lost() function is needed because the game is over
         #  after the player found checkmate successfully
-        return self.board.is_checkmate()
+        # return self.board.is_checkmate()
 
     def get_legal_moves(self):
         return self.board.legal_moves

--- a/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
@@ -403,7 +403,7 @@ class MCTSAgent(_Agent):
         # the file crazyara.py will print the chosen line to the std output
         if self.verbose is True:
             score = "score cp %d depth %d nodes %d time %d nps %d pv %s" % (cp, depth, nodes, time_elapsed_s, nps, pv)
-            logging.info("info string %s" % score)
+            logging.info("info string %s", score)
 
         return value, legal_moves, p_vec_small, cp, depth, nodes, time_elapsed_s, nps, pv
 

--- a/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
@@ -223,7 +223,7 @@ class PGN2PlanesConverter(object):
         for game_pgn in pgns:
             # we need to create a deep copy, otherwise the end of the file is reached for later
             game_pgn_copy = deepcopy(game_pgn)
-            for offset, headers in chess.pgn.scan_headers(game_pgn_copy):
+            for offset, headers in chess.pgn.read_headers(game_pgn_copy):
                 for term_cond in self._termination_conditions:
                     if term_cond in headers["Termination"]:
                         if (
@@ -284,8 +284,6 @@ class PGN2PlanesConverter(object):
                  lst_black_won: Number of black wins in each pgn file
                  lst_draw_won: Number of draws in each pgn file
         """
-
-        total_games_exported = 0
 
         lst_all_pgn_sel = []
         lst_nb_games_sel = []

--- a/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
+++ b/DeepCrazyhouse/src/preprocessing/PGNRecordDataset.py
@@ -9,8 +9,8 @@ Utility class to load the rec dataset in the training loop of the CNN
 import os
 import zlib
 import mxnet as mx
-import numpy as np
 from mxnet.gluon.data.dataset import recordio, Dataset
+import numpy as np
 from DeepCrazyhouse.configs.main_config import main_config
 from DeepCrazyhouse.src.domain.util import normalize_input_planes
 

--- a/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
@@ -27,6 +27,7 @@ from glob import glob
 from time import time
 import mxnet as mx
 from DeepCrazyhouse.configs.main_config import main_config
+from DeepCrazyhouse.src.preprocessing.dataset_loader import load_pgn_dataset
 
 
 class Planes2RecConverter:
@@ -99,7 +100,7 @@ class Planes2RecConverter:
                 idx += 1
 
             # log the elapsed time for a single dataset part file
-            logging.debug("elapsed time %.2fs" % (time() - t_s))
+            logging.debug("elapsed time %.2fs", (time() - t_s))
 
         # close the record file
         record.close()

--- a/DeepCrazyhouse/src/preprocessing/dataset_loader.py
+++ b/DeepCrazyhouse/src/preprocessing/dataset_loader.py
@@ -79,10 +79,10 @@ def load_pgn_dataset(
     # load the zarr-files
     pgn_datasets = zarr_filepaths
     if verbose is True:
-        logging.debug("loading: %s...", zarr_filepaths[part_id])
+        logging.debug("loading: %s...", pgn_datasets[part_id])
         logging.debug("")
 
-    store = zarr.ZipStore(zarr_filepaths[part_id], mode="r")
+    store = zarr.ZipStore(pgn_datasets[part_id], mode="r")
     pgn_dataset = zarr.group(store=store)
 
     # Get the data

--- a/DeepCrazyhouse/src/tools/server/game_server.py
+++ b/DeepCrazyhouse/src/tools/server/game_server.py
@@ -152,7 +152,7 @@ class ChessServer(object):
         if self._gamestate.is_white_to_move() is False:
             value = -value
 
-        logging.debug("Value %.4f" % value)
+        logging.debug("Value %.4f", value)
 
         if move is None:
             logging.error("None move proposed!")

--- a/DeepCrazyhouse/src/training/TrainerAgent.py
+++ b/DeepCrazyhouse/src/training/TrainerAgent.py
@@ -428,7 +428,7 @@ class TrainerAgent:
                                 val_p_acc_best,
                                 k_steps_best,
                             )
-                            logging.debug("load current best model:%s" % model_path)
+                            logging.debug("load current best model:%s", model_path)
                             self._net.load_parameters(model_path, ctx=self._ctx)
                             k_steps = k_steps_best
                             logging.debug("k_step is back at %d", k_steps_best)
@@ -467,7 +467,7 @@ class TrainerAgent:
                                     # the export function saves both the architecture and the weights
                                     self._net.export(prefix, epoch=k_steps_best)
                                     print()
-                                    logging.info("Saved checkpoint to %s-%04d.params" % (prefix, k_steps_best))
+                                    logging.info("Saved checkpoint to %s-%04d.params", (prefix, k_steps_best))
 
                                 # reset the patience counter
                                 patience_cnt = 0


### PR DESCRIPTION
**fix unreachable code**
- There were 2 unreachable codes due to a `raise notimplementederror()`, I turned them into comments to remove the warning

 **fix logging not lazy** 
- It exchanges `%` for `,` Thats preferred because it's lazy. The logging library doesn't format the string at all if the level is not set to DEBUG. That means it doesn't have to do extra work unless the user really wants to see those log messages.

**Exchange scan_headers for read_headers**
- `scan_headers` was removed on python-chess 0.24 version

**Add missing imports(and grouping some others)**
- `DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py` was missing an import

- 2 mxnet module import were separated from each other on the same file

**Remove unused variables or giving use to then**
-  total_games_exported was removed it and pgn_datasets was reassigned