### PR TITLE
multiple cleaning and very small performance gains

### DIFF
--- a/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
+++ b/DeepCrazyhouse/src/domain/agent/NeuralNetAPI.py
@@ -2,7 +2,6 @@ import glob
 import os
 from multiprocessing import Queue
 import mxnet as mx
-from mxnet import gluon
 import numpy as np
 from DeepCrazyhouse.configs.main_config import main_config
 from DeepCrazyhouse.src.domain.crazyhouse.constants import BOARD_HEIGHT, BOARD_WIDTH, NB_CHANNELS_FULL

--- a/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
@@ -1055,8 +1055,7 @@ class MCTSAgent(_Agent):
     def get_xth_max(self, xth_node):
         if len(self.root_node.n) < xth_node:
             return self.root_node.n.min()
-        else:
-            return np.sort(self.root_node.n)[-xth_node]
+        return np.sort(self.root_node.n)[-xth_node]
 
     def get_last_q_values(self, second_max=0, clip_fac=0.25):
         """

--- a/DeepCrazyhouse/src/domain/agent/player/util/NetPredService.py
+++ b/DeepCrazyhouse/src/domain/agent/player/util/NetPredService.py
@@ -39,11 +39,10 @@ class NetPredService:
         """
         self.net = net
         self.my_pipe_endings = pipe_endings
-
         self.running = False
+        self.time_start = None
         self.thread_inference = Thread(target=self._provide_inference, args=(pipe_endings,), daemon=True)
         self.batch_size = batch_size
-
         self.batch_state_planes = batch_state_planes
         self.batch_value_results = batch_value_results
         self.batch_policy_results = batch_policy_results

--- a/DeepCrazyhouse/src/domain/agent/player/util/Node.py
+++ b/DeepCrazyhouse/src/domain/agent/player/util/Node.py
@@ -158,10 +158,9 @@ class Node:
                 #    policy[indices] = 0
 
                 return policy / sum(policy)
-            else:
-                return visit
+            return visit
 
-        elif q_value_weight > 0:
+        if q_value_weight > 0:
             # disable the q values if there's at least one child which wasn't explored
             if None in self.child_nodes:
                 q_value_weight = 0
@@ -170,13 +169,12 @@ class Node:
             # the q_value_weight is applied.
             policy = (self.n / self.n_sum) * (1 - q_value_weight) + ((self.q + 1) * 0.5) * q_value_weight
             return policy
-        else:
-            if max(self.n) == 1:
-                policy = self.n + 0.05 * self.p
-            else:
-                policy = self.n - 0.05 * self.p
 
-            return policy / sum(policy)
+        if max(self.n) == 1:
+            policy = self.n + 0.05 * self.p
+        else:
+            policy = self.n - 0.05 * self.p
+        return policy / sum(policy)
 
     def apply_dirichlet_noise_to_prior_policy(self, epsilon=0.25, alpha=0.15):
         """

--- a/DeepCrazyhouse/src/domain/crazyhouse/output_representation.py
+++ b/DeepCrazyhouse/src/domain/crazyhouse/output_representation.py
@@ -216,9 +216,8 @@ def value_to_centipawn(value):
     if np.absolute(value) >= 1.0:
         # return a constant if the given value is 1 (otherwise log will result in infinity)
         return np.sign(value) * 9999
-    else:
-        # use logaritmic scaling with basis 1.1 as a pseudo centipawn conversion
-        return -(np.sign(value) * np.log(1.0 - np.absolute(value)) / np.log(1.2)) * 100
+    # use logaritmic scaling with basis 1.1 as a pseudo centipawn conversion
+    return -(np.sign(value) * np.log(1.0 - np.absolute(value)) / np.log(1.2)) * 100
 
 
 if __name__ == "__main__":

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/Rise.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/Rise.py
@@ -278,7 +278,7 @@ class Rise(HybridBlock):
             dim_match = True
 
             # deactivate the SE for the last two blocks
-            if i == nb_res_blocksX_neck - 2 or i == nb_res_blocksX_neck - 1:
+            if i in (nb_res_blocksX_neck - 2, nb_res_blocksX_neck - 1):
                 cur_use_se = False
                 cur_res_scale_fac = res_scale_fac
             else:

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util.py
@@ -13,22 +13,20 @@ from mxnet.gluon.nn import Activation, AvgPool2D, MaxPool2D, PReLU, SELU, Swish,
 def get_act(act_type, **kwargs):
     if act_type in ["relu", "sigmoid", "softrelu", "softsign", "tanh"]:
         return Activation(act_type, **kwargs)
-    elif act_type == "prelu":
+    if act_type == "prelu":
         return PReLU(**kwargs)
-    elif act_type == "selu":
+    if act_type == "selu":
         return SELU(**kwargs)
-    elif act_type == "swish":
+    if act_type == "swish":
         return Swish(**kwargs)
-    elif act_type == "lrelu":
+    if act_type == "lrelu":
         return LeakyReLU(alpha=0.2, **kwargs)
-    else:
-        raise NotImplementedError
+    raise NotImplementedError
 
 
 def get_pool(pool_type, pool_size, strides, **kwargs):
     if pool_type == "maxpool":
         return MaxPool2D(pool_size=pool_size, strides=strides, **kwargs)
-    elif pool_type == "avgpool":
+    if pool_type == "avgpool":
         return AvgPool2D(pool_size=pool_size, strides=strides, **kwargs)
-    else:
-        raise NotImplementedError
+    raise NotImplementedError

--- a/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
@@ -90,11 +90,11 @@ class Planes2RecConverter:
             )
 
             # iterate over all board states aka. data samples in the file
-            for i in range(len(x)):
-                data = x[i].flatten()
+            for position, value in enumerate(x):
+                data = value.flatten()
                 buf = zlib.compress(data.tobytes())
                 # we only store the integer idx of the highest output
-                header = mx.recordio.IRHeader(0, [yv[i], yp[i].argmax()], idx, 0)
+                header = mx.recordio.IRHeader(0, [yv[position], yp[position].argmax()], idx, 0)
                 s = mx.recordio.pack(header, buf)
                 record.write_idx(idx, s)
                 idx += 1

--- a/DeepCrazyhouse/src/tools/visualization/plane_representation.py
+++ b/DeepCrazyhouse/src/tools/visualization/plane_representation.py
@@ -43,7 +43,7 @@ def get_plane_vis(mat, normalize=False):
     color_ch = CHANNEL_MAPPING_CONST["color"] + NB_CHANNELS_POS
 
     color_bit = int(mat[color_ch][0][0])
-    if color_bit != 0 and color_bit != 1:
+    if color_bit not in (0, 1):
         raise Exception("Invalid setting of color bit: ", color_bit)
 
     sign_bit = -1 if chess.COLOR_NAMES[color_bit] == "black" else 1


### PR DESCRIPTION
**Remove unused modules**
- After the last commit `from mxnet import gluon` is not used anymore

**Remove else-return** 
- No need to use else of elif after a return statement, since if it gets true on the statement from above the function will not even check the else(small cleaning and speed-up)

**Using in instead of 2 or more comparisons**
 - Remove repetition for comparisons using the same variable, this is cleaner and it's actually a small speed up

- f.e. `i == nb_res_blocksX_neck - 2 or i == nb_res_blocksX_neck - 1`--> `i in (nb_res_blocksX_neck - 2, nb_res_blocksX_neck - 1)`

**Using` enumerate()` instead of iterating with `range(len(x))`**
 - Cleaner and faster as well, no need to use indexation every loop. Only was changed on `DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py` file
