### PR TITLE
Multiple cleaning

### DIFF
--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
@@ -92,7 +92,7 @@ class _InceptionResnetBlock(HybridBlock):
 
 class _UpsampleBlock(HybridBlock):
     def __init__(self, name, scale=2, sample_type="nearest"):
-        super(HybridBlock, self).__init__(prefix=name)
+        super().__init__(prefix=name)
         self.scale = scale
         self.sample_type = sample_type
 

--- a/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
@@ -28,7 +28,7 @@ from DeepCrazyhouse.src.domain.util import get_dic_sorted_by_key
 from DeepCrazyhouse.src.preprocessing.pgn_converter_util import get_planes_from_pgn
 
 
-class PGN2PlanesConverter(object):
+class PGN2PlanesConverter:
     """
     Class which enables the conversion from pgn-text files to a plane representation which can be used for Neural
     Networks. The representation will be exported in parallel, using compression to a dataset file (e.g. .zip)

--- a/DeepCrazyhouse/src/tools/server/game_server.py
+++ b/DeepCrazyhouse/src/tools/server/game_server.py
@@ -102,12 +102,12 @@ class ChessServer:
         if drop_piece is not None:
             from_square_idx = to_square_idx
 
-            if not (drop_piece in chess.PIECE_SYMBOLS):
+            if not drop_piece in chess.PIECE_SYMBOLS:
                 return self.serialize_game_state("drop piece name is invalid")
             drop = chess.PIECE_SYMBOLS.index(drop_piece)
 
         if promotion_piece is not None:
-            if not (promotion_piece in chess.PIECE_SYMBOLS):
+            if not promotion_piece in chess.PIECE_SYMBOLS:
                 return self.serialize_game_state("promotion piece name is invalid")
             promotion = chess.PIECE_SYMBOLS.index(promotion_piece)
 

--- a/DeepCrazyhouse/src/tools/server/game_server.py
+++ b/DeepCrazyhouse/src/tools/server/game_server.py
@@ -131,15 +131,14 @@ class ChessServer:
 
     def perform_move(self, move):
         logging.debug("perform_move(): %s", move)
-
         # check if move is valid
         if move not in list(self._gamestate.board.legal_moves):
             raise ValueError("The given move %s is invalid for the current position" % move)
         self._gamestate.apply_move(move)
-
         if self._gamestate.is_won():
             logging.debug("Checkmate")
             return False
+        return None
 
     def perform_agent_move(self):
 

--- a/DeepCrazyhouse/src/tools/server/game_server.py
+++ b/DeepCrazyhouse/src/tools/server/game_server.py
@@ -34,7 +34,7 @@ dirichlet_epsilon = 0.25
 nb_workers = 64
 
 
-class ChessServer(object):
+class ChessServer:
     def __init__(self, name):
         self.app = Flask(name)
 

--- a/DeepCrazyhouse/src/tools/visualization/plane_representation.py
+++ b/DeepCrazyhouse/src/tools/visualization/plane_representation.py
@@ -6,29 +6,24 @@ Created on 24.09.18
 
 Please describe what the content of this file is about
 """
-from DeepCrazyhouse.src.domain.crazyhouse.input_representation import (
+import numpy as np
+from DeepCrazyhouse.src.domain.util import mult_axis_by_vec
+from DeepCrazyhouse.src.domain.crazyhouse.constants import (
     BOARD_HEIGHT,
     BOARD_WIDTH,
     CHANNEL_MAPPING_CONST,
     NB_CHANNELS_POS,
     PIECES,
+    PIECES_VALUE,
     chess,
-    np,
 )
 
 
 # create vector which scales the piece values according to their crazyhouse value
 # (used in get_x_vis())
 scale_vec = np.zeros(len(chess.PIECE_TYPES))
-
-
-def fill_scale_vec():
-    global scale_vec
-    for i, p_char in enumerate(PIECES[: len(chess.PIECE_TYPES)]):
-        scale_vec[i] = PIECES_VALUE[p_char] * 2
-
-
-fill_scale_vec()
+for i, p_char in enumerate(PIECES[: len(chess.PIECE_TYPES)]):
+    scale_vec[i] = PIECES_VALUE[p_char] * 2
 
 
 def get_plane_vis(mat, normalize=False):


### PR DESCRIPTION
**Useless object inheritance fix**
-  (Object) call is not necessary on python 3 anymore since classes are children from Object class by default, calling it is redundant and actually is a minor slowdown

**Inconsistent return statements fix** 
- According to PEP8, if any return statement returns an expression, any return statements where no value is returned should explicitly state this as return None, and an explicit return statement should be present at the end of the function (if reachable)), I don't know the reasoning for it but there must be one since its a PEP8 recommendation, I'll look into it

**Fix bug on plane representation**
- PIECE_VALUES and mult_axis_by_vec weren't being called, now they are

**Remove global(Plz check)**
- I removed a global statement and 1 function that I don't think it was needed, but since it was there maybe there was a reason, please check

**Fix outdated super() call**
- It was following the Python 2.7 requirements for mother classes call, in Python 3 it isn't needed anymore so we can use a much cleaner call

**fix superfluous-parens**
- Removing unescessary parenteshis
