### PR TITLE
multiple small pylint and bug fixes and reformatting 

### DIFF
--- a/DeepCrazyhouse/src/domain/abstract_cls/_GameState.py
+++ b/DeepCrazyhouse/src/domain/abstract_cls/_GameState.py
@@ -21,7 +21,7 @@ class _GameState:
 
     def get_state_planes(self):
         raise NotImplementedError("get_state_planes() should return board_to_planes(self.board, 0, normalize=True)")
-         # return board_to_planes(self.board, 0, normalize=True)
+        # return board_to_planes(self.board, 0, normalize=True)
 
     def get_pythonchess_board(self):
         return self.board

--- a/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
@@ -1038,7 +1038,7 @@ class MCTSAgent(_Agent):
 
         while node is not None:
             # go deep through the tree by always selecting the best move for both players
-            node, move, child_idx = self._select_node(node)
+            node, move, _ = self._select_node(node)
             best_moves.append(move)
         return best_moves
 
@@ -1057,7 +1057,7 @@ class MCTSAgent(_Agent):
             return self.root_node.n.min()
         return np.sort(self.root_node.n)[-xth_node]
 
-    def get_last_q_values(self, second_max=0, clip_fac=0.25):
+    def get_last_q_values(self): # , second_max=0, clip_fac=0.25
         """
         Returns the values of the last node in the caluclated lines according to the mcts search for the most
          visited nodes

--- a/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
@@ -1114,7 +1114,8 @@ class MCTSAgent(_Agent):
             lst_nb_visits.append(nb_visits)
         return lst_best_moves, lst_nb_visits
 
-    def _mv_list_to_str(self, lst_moves):
+    @staticmethod
+    def _mv_list_to_str(lst_moves):
         """
         Converts a given list of chess moves to a single string seperated by spaces.
         :param lst_moves: List chess.Moves objects

--- a/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/MCTSAgent.py
@@ -715,7 +715,7 @@ class MCTSAgent(_Agent):
 
         return super().perform_action(state)
 
-    def _run_single_playout(self, state: GameState, parent_node: Node, pipe_id=0, depth=1, chosen_nodes=[]):
+    def _run_single_playout(self, state: GameState, parent_node: Node, pipe_id=0, depth=1, chosen_nodes=None):
         """
         This function works recursively until a leaf or terminal node is reached.
         It ends by backpropagating the value of the new expanded node or by propagating the value of a terminal state.
@@ -733,6 +733,8 @@ class MCTSAgent(_Agent):
         """
 
         # select a legal move on the chess board
+        if chosen_nodes is None:
+            chosen_nodes = []
         node, move, child_idx = self._select_node(parent_node)
 
         if move is None:
@@ -1057,7 +1059,7 @@ class MCTSAgent(_Agent):
             return self.root_node.n.min()
         return np.sort(self.root_node.n)[-xth_node]
 
-    def get_last_q_values(self): # , second_max=0, clip_fac=0.25
+    def get_last_q_values(self):  # , second_max=0, clip_fac=0.25
         """
         Returns the values of the last node in the caluclated lines according to the mcts search for the most
          visited nodes

--- a/DeepCrazyhouse/src/domain/agent/player/util/Node.py
+++ b/DeepCrazyhouse/src/domain/agent/player/util/Node.py
@@ -100,7 +100,7 @@ class Node:
         # self.q_freash = np.zeros(self.nb_direct_child_nodes)
         # self.w_freash = np.zeros(self.nb_direct_child_nodes)
 
-    def get_mcts_policy(self, q_value_weight=0.65, clip_low_visit_nodes=True, is_root=False, xth_n_max=0):
+    def get_mcts_policy(self, q_value_weight=0.65, clip_low_visit_nodes=True): # , is_root=False, xth_n_max=0
         """
         Calculates the finetuned policies based on the MCTS search.
         These policies should be better than the initial policy predicted by a the raw network.

--- a/DeepCrazyhouse/src/domain/agent/player/util/Node.py
+++ b/DeepCrazyhouse/src/domain/agent/player/util/Node.py
@@ -100,7 +100,7 @@ class Node:
         # self.q_freash = np.zeros(self.nb_direct_child_nodes)
         # self.w_freash = np.zeros(self.nb_direct_child_nodes)
 
-    def get_mcts_policy(self, q_value_weight=0.65, clip_low_visit_nodes=True): # , is_root=False, xth_n_max=0
+    def get_mcts_policy(self, q_value_weight=0.65, clip_low_visit_nodes=True):  # , is_root=False, xth_n_max=0
         """
         Calculates the finetuned policies based on the MCTS search.
         These policies should be better than the initial policy predicted by a the raw network.

--- a/DeepCrazyhouse/src/domain/crazyhouse/GameState.py
+++ b/DeepCrazyhouse/src/domain/crazyhouse/GameState.py
@@ -59,7 +59,7 @@ class GameState(_GameState):
         self.board = CrazyhouseBoard()
         self._fen_dic = {}
 
-    def set_fen(self, fen): # , remember_state=True
+    def set_fen(self, fen):  # , remember_state=True
         self.board.set_fen(fen)
 
         # if remember_state is True:

--- a/DeepCrazyhouse/src/domain/crazyhouse/GameState.py
+++ b/DeepCrazyhouse/src/domain/crazyhouse/GameState.py
@@ -59,7 +59,7 @@ class GameState(_GameState):
         self.board = CrazyhouseBoard()
         self._fen_dic = {}
 
-    def set_fen(self, fen, remember_state=True):
+    def set_fen(self, fen): # , remember_state=True
         self.board.set_fen(fen)
 
         # if remember_state is True:

--- a/DeepCrazyhouse/src/domain/crazyhouse/output_representation.py
+++ b/DeepCrazyhouse/src/domain/crazyhouse/output_representation.py
@@ -75,7 +75,7 @@ def policy_to_best_move(board: chess.variant.CrazyhouseBoard, policy_vec, normal
              prob - Probability value for the selected move
     """
 
-    policy_vec_clean, nb_legal_moves = set_illegal_moves_to_zero(board, policy_vec, normalize)
+    policy_vec_clean, _ = set_illegal_moves_to_zero(board, policy_vec, normalize)
 
     mv_idx = np.argmax(policy_vec_clean)
     prob = np.max(policy_vec_clean)

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/Rise.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/Rise.py
@@ -254,7 +254,7 @@ class Rise(HybridBlock):
 
         with self.name_scope():
             if use_rise_stem is True:
-                self.body.add(_StemRise(name="stem", channels=channels, bn_mom=bn_mom, act_type=act_type, use_se=False))
+                self.body.add(_StemRise(name="stem", channels=channels, bn_mom=bn_mom, act_type=act_type))
             else:
                 self.body.add(_StemAlphaZero(name="stem", channels=channels, bn_mom=bn_mom, act_type=act_type))
 

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/Rise.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/Rise.py
@@ -173,7 +173,7 @@ class _ResidualBlockXBottleneck(HybridBlock):
 
 
 class _StemRise(HybridBlock):
-    def __init__(self, name, channels, bn_mom=0.9, act_type="relu", use_se=False):
+    def __init__(self, name, channels, bn_mom=0.9, act_type="relu"):  # , use_se=False
         """
         Definition of the stem proposed by the alpha zero authors
 

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
@@ -47,7 +47,7 @@ class _InceptionResnetBlock(HybridBlock):
         super(_InceptionResnetBlock, self).__init__(prefix=name)
 
         self.shortcut = shortcut
-        self.body = self.body = HybridSequential(prefix="")
+        self.body = HybridSequential(prefix="")
         self.bn0 = None
         self.act0 = None
         self.se0 = None

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
@@ -10,7 +10,7 @@ Please describe what the content of this file is about
 from mxnet.gluon.nn import HybridSequential, Conv2D, BatchNorm, Dense, AvgPool2D
 from mxnet.gluon import HybridBlock
 from mxnet.gluon.contrib.nn import HybridConcurrent
-from DeepCrazyhouse.src.domain.neural_net.architectures.builder_util import get_act
+from DeepCrazyhouse.src.domain.neural_net.architectures.builder_util import get_act, get_pool
 
 
 class _SqueezeExcitation(HybridBlock):
@@ -47,7 +47,7 @@ class _InceptionResnetBlock(HybridBlock):
         super(_InceptionResnetBlock, self).__init__(prefix=name)
 
         self.shortcut = shortcut
-        self.body = None
+        self.body = self.body = HybridSequential(prefix="")
         self.bn0 = None
         self.act0 = None
         self.se0 = None

--- a/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
@@ -82,8 +82,8 @@ class PGN2PlanesConverter:
         self._clevel = clevel
         self._log_lvl = log_lvl
 
-        root = logging.getLogger()
-        root.setLevel(log_lvl)
+        local_root = logging.getLogger()
+        local_root.setLevel(log_lvl)
 
         plt.style.use("seaborn-paper")
 

--- a/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/PGN2PlanesConverter.py
@@ -223,7 +223,7 @@ class PGN2PlanesConverter:
         for game_pgn in pgns:
             # we need to create a deep copy, otherwise the end of the file is reached for later
             game_pgn_copy = deepcopy(game_pgn)
-            for offset, headers in chess.pgn.read_headers(game_pgn_copy):
+            for _, headers in chess.pgn.read_headers(game_pgn_copy):
                 for term_cond in self._termination_conditions:
                     if term_cond in headers["Termination"]:
                         if (

--- a/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
+++ b/DeepCrazyhouse/src/preprocessing/Planes2RecConverter.py
@@ -81,7 +81,7 @@ class Planes2RecConverter:
 
             logging.info("PART: %d", part_id)
             # load one chunk of the dataset from memory
-            s_ids_train, x, yv, yp, pgn_datasets = load_pgn_dataset(
+            _, x, yv, yp, _ = load_pgn_dataset(
                 dataset_type=self._dataset_type,
                 part_id=part_id,
                 print_statistics=True,

--- a/DeepCrazyhouse/src/tools/server/game_server.py
+++ b/DeepCrazyhouse/src/tools/server/game_server.py
@@ -70,8 +70,8 @@ class ChessServer:
     def run(self):
         self.app.run()
 
-    # noinspection PyMethodMayBeStatic
-    def serve_client(self, path=None):
+    @staticmethod
+    def serve_client(path=None):
         if path is None:
             path = "index.html"
         return send_from_directory("./client", path)

--- a/DeepCrazyhouse/src/tools/server/game_server.py
+++ b/DeepCrazyhouse/src/tools/server/game_server.py
@@ -146,7 +146,7 @@ class ChessServer:
             logging.debug("Checkmate")
             return False
 
-        value, move, confidence, _ = self.agent.perform_action(self._gamestate)
+        value, move, _, _ = self.agent.perform_action(self._gamestate)
 
         if self._gamestate.is_white_to_move() is False:
             value = -value

--- a/DeepCrazyhouse/src/training/TrainerAgent.py
+++ b/DeepCrazyhouse/src/training/TrainerAgent.py
@@ -298,7 +298,7 @@ class TrainerAgent:
             for part_id in tqdm_notebook(self.ordering):
 
                 # load one chunk of the dataset from memory
-                s_idcs_train, x_train, yv_train, yp_train, pgn_datasets_train = load_pgn_dataset(
+                _, x_train, yv_train, yp_train, _ = load_pgn_dataset(
                     dataset_type="train", part_id=part_id, normalize=self._normalize, verbose=False
                 )
                 # update the train_data object
@@ -450,7 +450,7 @@ class TrainerAgent:
                             if self._export_grad_histograms is True:
                                 grads = []
                                 # logging the gradients of parameters for checking convergence
-                                for i_p, name in enumerate(self._param_names):
+                                for _, name in enumerate(self._param_names):
                                     if "bn" not in name and "batch" not in name:
                                         grads.append(self._params[name].grad())
                                         self.sw.add_histogram(tag=name, values=grads[-1], global_step=k_steps, bins=20)

--- a/DeepCrazyhouse/src/training/TrainerAgent.py
+++ b/DeepCrazyhouse/src/training/TrainerAgent.py
@@ -98,7 +98,7 @@ class TrainerAgent:
         export_grad_histograms=True,
         log_metrics_to_tensorboard=True,
         ctx=mx.gpu(),
-        metrics={},  # clip_gradient=60,
+        metrics=None,  # clip_gradient=60,
         use_spike_recovery=True,
         max_spikes=5,
         spike_thresh=1.5,
@@ -109,6 +109,8 @@ class TrainerAgent:
         # , lr_warmup_k_steps=30, lr_warmup_init=0.01):
         # patience=25, nb_lr_drops=3, nb_k_steps=200,
 
+        if metrics is None:
+            metrics = {}
         self._log_metrics_to_tensorboard = log_metrics_to_tensorboard
         self._ctx = ctx
         # lr_drop_fac=0.1,
@@ -467,7 +469,7 @@ class TrainerAgent:
                                     # the export function saves both the architecture and the weights
                                     self._net.export(prefix, epoch=k_steps_best)
                                     print()
-                                    logging.info("Saved checkpoint to %s-%04d.params", (prefix, k_steps_best))
+                                    logging.info("Saved checkpoint to %s-%04d.params", prefix, k_steps_best)
 
                                 # reset the patience counter
                                 patience_cnt = 0


### PR DESCRIPTION
 **Fix redefined outer name** 
- That happens when a local name identical to a global name. The local name takes precedence, but it hides the global name, makes it inaccessible, and cause confusion to the reader. So I figured it would be better to rename `root` - `local_root`

**Comment out unused arguments**
- Some arguments weren't being used anywhere so I commented them out(maybe there were plans for them, that's why I didn't delete)

**Exchange unused variables for _**
- To make it clear they aren't being used, only applicable on tuple unpacking, otherwise I just deleted it

**Put missing get_pool import from rise_builder_util.py**
- get_pool was missing on the `rise_builder_util.py`

**Fix not-callable**
-  `self.body` was being initialized as None which is not callable, so I followed the `self.body `initialization from other similar classes on `rise_builder_util.py`

**Fix logging-too-few-args**
- Some very minor logging formatting error

**fix dangerous-default-value**
- Mutable variables shouldn't become arguments, for a lot of reasons but the main one is stated on Important warning section from this link https://docs.python.org/3/tutorial/controlflow.html#default-argument-values

**fix no-self-use**
- Some functions could safely become static, so I did make then like this