### PR TITLE
Several pylint fixes

### DIFF
--- a/DeepCrazyhouse/src/tests/full_round_trip_tests.py
+++ b/DeepCrazyhouse/src/tests/full_round_trip_tests.py
@@ -7,18 +7,17 @@ Created on 22.08.18
 Loads the plane representation for the test dataset and iterates through all board positions and moves.
 """
 
-from DeepCrazyhouse.src.domain.util import *
-from DeepCrazyhouse.src.domain.crazyhouse.input_representation import planes_to_board
-from DeepCrazyhouse.src.domain.crazyhouse.output_representation import policy_to_move
-import chess
-import chess.pgn
 import unittest
-import logging
-from DeepCrazyhouse.src.preprocessing.PGN2PlanesConverter import PGN2PlanesConverter
 from multiprocessing import Pool
 from copy import deepcopy
+import logging
+import chess
+import chess.pgn
+import numpy as np
+from DeepCrazyhouse.src.domain.crazyhouse.input_representation import planes_to_board
+from DeepCrazyhouse.src.domain.crazyhouse.output_representation import policy_to_move
+from DeepCrazyhouse.src.preprocessing.PGN2PlanesConverter import PGN2PlanesConverter
 from DeepCrazyhouse.src.preprocessing.dataset_loader import load_pgn_dataset
-
 # import the Colorer to have a nicer logging printout
 from DeepCrazyhouse.src.runtime.ColorLogger import enable_color_logging
 
@@ -122,7 +121,7 @@ class FullRoundTripTests(unittest.TestCase):
             clevel=5,
             dataset_type="test",
         )
-        self._all_pgn_sel, nb_games_sel, batch_white_won, batch_black_won, batch_draw = converter.filter_pgn()
+        self._all_pgn_sel, _, _, _, _ = converter.filter_pgn()
         print(len(self._all_pgn_sel))
 
     def test_board_states(self):
@@ -148,11 +147,11 @@ class FullRoundTripTests(unittest.TestCase):
 
             params_inp.append((pgn, x_test, start_idx))
 
-        p = Pool()
+        pool = Pool()
 
         games_ok = []
         logging.info("start board test...")
-        for game_ok, start_idx in p.map(board_single_game, params_inp):
+        for game_ok, start_idx in pool.map(board_single_game, params_inp):
             self.assertTrue(game_ok)
             if game_ok is True:
                 logging.debug("Board States - Game StartIdx %d [OK]", start_idx)
@@ -161,8 +160,8 @@ class FullRoundTripTests(unittest.TestCase):
 
             games_ok.append(games_ok)
 
-        p.close()
-        p.join()
+        pool.close()
+        pool.join()
         logging.info("board test done...")
 
     def test_moves(self):
@@ -186,11 +185,11 @@ class FullRoundTripTests(unittest.TestCase):
 
             params_inp.append((pgn, yp_test, start_idx))
 
-        p = Pool()
+        pool = Pool()
 
         games_ok = []
         logging.info("start board test...")
-        for game_ok, start_idx in p.map(moves_single_game, params_inp):
+        for game_ok, start_idx in pool.map(moves_single_game, params_inp):
             self.assertTrue(game_ok)
             if game_ok is True:
                 logging.debug("Moves - Game StartIdx %d [OK]", start_idx)
@@ -199,8 +198,8 @@ class FullRoundTripTests(unittest.TestCase):
 
             games_ok.append(games_ok)
 
-        p.close()
-        p.join()
+        pool.close()
+        pool.join()
         logging.info("move comparision test done...")
 
 

--- a/DeepCrazyhouse/src/tests/move_round_trip_test.py
+++ b/DeepCrazyhouse/src/tests/move_round_trip_test.py
@@ -7,16 +7,16 @@ Created on 25.09.18
 Tests the functionality of the LABEL and LABEL_MIRRORED list based on the conversion to board and move planes
 """
 
-import chess.variant
 import unittest
+import chess.variant
 from DeepCrazyhouse.src.domain.crazyhouse.output_representation import (
     policy_to_move,
     move_to_policy,
     policy_to_moves,
     policy_to_best_move,
 )
-from DeepCrazyhouse.src.domain.crazyhouse.constants import *
-from DeepCrazyhouse.src.domain.preprocessing.util import load_pgn_dataset
+from DeepCrazyhouse.src.domain.crazyhouse.constants import LABELS, LABELS_MIRRORED
+from DeepCrazyhouse.src.preprocessing.dataset_loader import load_pgn_dataset
 
 
 class MoveRoundTripTest(unittest.TestCase):
@@ -35,42 +35,20 @@ class MoveRoundTripTest(unittest.TestCase):
 
     def test_move_roundtrip_black(self):
 
-        mv = chess.Move.from_uci("e7e5")
+        move = chess.Move.from_uci("e7e5")
 
-        policy_vec = move_to_policy(mv, is_white_to_move=False)
+        policy_vec = move_to_policy(move, is_white_to_move=False)
         mv_conv = policy_to_move(policy_vec, is_white_to_move=False)
 
-        self.assertTrue(LABELS_MIRRORED[policy_vec.argmax()] == mv.uci())
-        self.assertTrue(mv == mv_conv)
-
-    def test_loaded_dataset_white_move(self):
-
-        s_idcs_val, x_val, yv_val, yp_val, pgn_datasets_val = load_pgn_dataset(
-            dataset_type="test", part_id=0, print_statistics=True, print_parameters=True, normalize=True
-        )
-
-        board = chess.variant.CrazyhouseBoard()
-
-        mv_converted = policy_to_move(yp_val[0], is_white_to_move=True)
-
-        mv_converted_is_legal = False
-
-        # check if the move is legal in the starting position
-        for mv in board.legal_moves:
-            if mv == mv_converted:
-                mv_converted_is_legal = True
-
-        self.assertTrue(
-            mv_converted_is_legal,
-            msg="Convert move %s is not a legal move in the starting position for WHITE" % mv_converted.uci(),
-        )
+        self.assertTrue(LABELS_MIRRORED[policy_vec.argmax()] == move.uci())
+        self.assertTrue(move == mv_conv)
 
     def test_loaded_dataset_black_move(self):
         """
         Loads the dataset file and checks the first move policy vector for black for correctness
         :return:
         """
-        s_idcs_val, x_val, yv_val, yp_val, pgn_datasets_val = load_pgn_dataset(
+        _, _, _, yp_val, _ = load_pgn_dataset(
             dataset_type="test", part_id=0, print_statistics=True, print_parameters=True, normalize=True
         )
 
@@ -95,8 +73,8 @@ class MoveRoundTripTest(unittest.TestCase):
             mv_converted_is_legal = False
 
             # check if the move is legal in the starting position
-            for mv in board.legal_moves:
-                if mv == mv_converted:
+            for move in board.legal_moves:
+                if move == mv_converted:
                     mv_converted_is_legal = True
 
             self.assertTrue(
@@ -109,7 +87,7 @@ class MoveRoundTripTest(unittest.TestCase):
         Loads the dataset file and checks the first move policy vector for white for correctness
         :return:
         """
-        s_idcs_val, x_val, yv_val, yp_val, pgn_datasets_val = load_pgn_dataset(
+        _, _, _, yp_val, _ = load_pgn_dataset(
             dataset_type="test", part_id=0, print_statistics=True, print_parameters=True, normalize=True
         )
 
@@ -132,8 +110,8 @@ class MoveRoundTripTest(unittest.TestCase):
             mv_converted_is_legal = False
 
             # check if the move is legal in the starting position
-            for mv in board.legal_moves:
-                if mv == mv_converted:
+            for move in board.legal_moves:
+                if move == mv_converted:
                     mv_converted_is_legal = True
 
             self.assertTrue(

--- a/DeepCrazyhouse/src/training/lr_schedules/lr_schedules.py
+++ b/DeepCrazyhouse/src/training/lr_schedules/lr_schedules.py
@@ -11,8 +11,6 @@ https://mxnet.incubator.apache.org/tutorials/gluon/learning_rate_schedules_advan
 
 import copy
 import math
-import mxnet as mx
-import numpy as np
 import matplotlib.pyplot as plt
 
 

--- a/DeepCrazyhouse/src/training/lr_schedules/lr_schedules.py
+++ b/DeepCrazyhouse/src/training/lr_schedules/lr_schedules.py
@@ -66,8 +66,7 @@ class LinearWarmUp:
     def __call__(self, iteration):
         if iteration <= self.length:
             return iteration * (self.finish_lr - self.start_lr) / (self.length) + self.start_lr
-        else:
-            return self.schedule(iteration - self.length)
+        return self.schedule(iteration - self.length)
 
 
 class CyclicalSchedule:
@@ -115,8 +114,7 @@ class CosineAnnealingSchedule:
             unit_cycle = (1 + math.cos(iteration * math.pi / self.cycle_length)) / 2
             adjusted_cycle = (unit_cycle * (self.max_lr - self.min_lr)) + self.min_lr
             return adjusted_cycle
-        else:
-            return self.min_lr
+        return self.min_lr
 
 
 class LinearCoolDown:
@@ -138,10 +136,9 @@ class LinearCoolDown:
     def __call__(self, iteration):
         if iteration <= self.start_idx:
             return self.schedule(iteration)
-        elif iteration <= self.finish_idx:
+        if iteration <= self.finish_idx:
             return (iteration - self.start_idx) * (self.finish_lr - self.start_lr) / (self.length) + self.start_lr
-        else:
-            return self.finish_lr
+        return self.finish_lr
 
 
 class OneCycleSchedule:

--- a/DeepCrazyhouse/src/training/lr_schedules/lr_schedules.py
+++ b/DeepCrazyhouse/src/training/lr_schedules/lr_schedules.py
@@ -194,10 +194,10 @@ class MomentumSchedule:
         self.max_momentum = max_momentum
 
     def __call__(self, iteration):
-        lr = self.lr_schedule(iteration)
+        learning_rate = self.lr_schedule(iteration)
 
         # calculate percentage factor
-        perc = (lr - self.min_lr) / (self.max_lr - self.min_lr)
+        perc = (learning_rate - self.min_lr) / (self.max_lr - self.min_lr)
         # invert the percentage factor and apply it
         momentum = self.max_momentum - perc * (self.max_momentum - self.min_momentum)
         return momentum

--- a/crazyara.py
+++ b/crazyara.py
@@ -77,12 +77,11 @@ class CrazyAra:
         }
         try:
             self.log_file = open(self.log_file_path, "w")
-        except:
+        except IOError:
             self.log_file = None
             # print out the error message
-            self.traceback_text = traceback.format_exc()
             print("info string An error occurred while trying to open the self.log_file %s" % self.log_file_path)
-            print(self.traceback_text)
+            traceback.print_exc()
 
         self.intro = """
                                               _                                           
@@ -122,10 +121,10 @@ class CrazyAra:
     def write_score_to_file(self, score: str):
         # score_file = open(score_file_path, 'w')
 
-        with open(self.score_file_path, "w") as file:
-            file.seek(0)
-            file.write(score)
-            file.truncate()
+        with open(self.score_file_path, "w") as selected_file:
+            selected_file.seek(0)
+            selected_file.write(score)
+            selected_file.truncate()
 
     def log(self, text: str):
         if self.log_file:
@@ -329,8 +328,8 @@ class CrazyAra:
         if self.enable_lichess_debug_msg:
             try:
                 self.write_score_to_file(self.score)
-            except Exception:
-                pass
+            except IOError:
+                traceback.print_exc()
         # print out the search information
         self.log_print("info %s" % self.score)
 
@@ -628,10 +627,9 @@ class CrazyAra:
                     else:
                         # give the user a message that the command was ignored
                         print("info string Unknown command: %s" % line)
-                except:
+                except IOError:
                     # log the error message to the log-file and exit the script
-                    traceback_text = traceback.format_exc()
-                    self.log_print(traceback_text)
+                    traceback.print_exc()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Focusing on the main file and on files that weren't graded by pylint previously.

**Fixes related to imports**
- Fix wrong import order(standard -> third-party -> local)
- Remove unused modules
- Don't use wildcard imports

**Fix some errors related to naming conventions**
- Module names should use snake case(don't confuse with classes naming which should be CamelCase)
- Unused variables that can't be removed(tuple-unpacking f.e), should become `_`

**Remove repeated method**
- `test_loaded_dataset_white_move` was referenced twice, so the latest wasn't being used, I removed the most incomplete one(plz check - I don't know if I should have just renamed it or which one I should have kept)

**Remove else and elif after returns**
- No need for these checks, since the return statement stops the function anyway

**Don't make bare or broad try-except guards**
- I exchanged them by IOERROR(happens when opening files), it is better to be specific when making these error handling guards, because if you use a naked except clause, you might end up catching exceptions other than the ones you expect to catch, this can hide bugs(making it really hard to fix later) or make it harder to debug programs when they aren't doing what you expect.

**Use traceback built-in**
- For printing errors use `traceback.print_exc()`