### PR TITLE
Generic State Interface

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -5,8 +5,8 @@ project(CrazyAra CXX)
 
 option(USE_PROFILING             "Build with profiling"   OFF)
 option(USE_RL                    "Build with reinforcement learning support"  OFF)
-option(USE_TENSORRT              "Build with TensorRT support"  ON)
-option(USE_MXNET                 "Build with MXNet backend (Blas/IntelMKL/CUDA/TensorRT) support"  OFF)
+option(USE_TENSORRT              "Build with TensorRT support"  OFF)
+option(USE_MXNET                 "Build with MXNet backend (Blas/IntelMKL/CUDA/TensorRT) support"  ON)
 option(USE_960                   "Build with 960 variant support"  OFF)
 option(BUILD_TESTS               "Build and run tests"  OFF)
 
@@ -144,7 +144,7 @@ if (USE_RL)
     add_definitions(-DUSE_RL)
 endif()
 
-if (USE_TENSORRT)
+if (FALSE) #USE_TENSORRT)
     # build CrazyAra with TensorRT support, requires a working TensorRT-MXNet library package
     message(STATUS "Enabled TensorRT support")
     message(STATUS "TensorRT path: $ENV{TENSORRT_PATH}")
@@ -175,7 +175,7 @@ endif()
 
 add_executable(${PROJECT_NAME} ${source_files})
 
-if (USE_TENSORRT)
+if (FALSE) #USE_TENSORRT)
     target_link_libraries(${PROJECT_NAME} nvonnxparser nvinfer cudart myelin ${CUDART_LIB} ${CUBLAS_LIB} ${CUDNN_LIB})
 endif()
 

--- a/engine/src/agents/agent.cpp
+++ b/engine/src/agents/agent.cpp
@@ -57,14 +57,14 @@ Agent::Agent(PlaySettings* playSettings, bool verbose):
 {
 }
 
-void Agent::set_search_settings(Board *pos, SearchLimits *searchLimits, EvalInfo* evalInfo)
+void Agent::set_search_settings(State *pos, SearchLimits *searchLimits, EvalInfo* evalInfo)
 {
-    this->pos = pos;
+    this->state = pos;
     this->searchLimits = searchLimits;
     this->evalInfo = evalInfo;
 }
 
-Move Agent::get_best_move()
+Action Agent::get_best_action()
 {
     return evalInfo->bestMove;
 }
@@ -74,17 +74,17 @@ void Agent::perform_action()
     evalInfo->start = chrono::steady_clock::now();
     this->evaluate_board_state();
     evalInfo->end = chrono::steady_clock::now();
-    set_best_move(pos->total_move_cout());
+    set_best_move(state->steps_from_null());
     info_score(*evalInfo);
-    info_string(pos->fen());
-    info_bestmove(UCI::move(evalInfo->bestMove, pos->is_chess960()));
+    info_string(state->fen());
+    info_bestmove(UCI::move(Move(evalInfo->bestMove), state->is_chess960()));
 }
 
 void run_agent_thread(Agent* agent)
 {
     agent->perform_action();
     // inform the agent of the move, so the tree can potentially be reused later
-    agent->apply_move_to_tree(agent->get_best_move(), true);
+    agent->apply_move_to_tree(agent->get_best_action(), true);
 }
 
 void apply_quantile_clipping(float quantile, DynamicVector<double>& policyProbSmall)

--- a/engine/src/agents/agent.h
+++ b/engine/src/agents/agent.h
@@ -29,6 +29,7 @@
 #define AGENT_H
 
 #include "../board.h"
+#include "../state.h"
 #include "../evalinfo.h"
 #include "config/searchlimits.h"
 #include "config/playsettings.h"
@@ -49,7 +50,7 @@ private:
 protected:
     SearchLimits* searchLimits;
     PlaySettings* playSettings;
-    Board* pos;
+    State* state;
     EvalInfo* evalInfo;
     bool verbose;
 
@@ -74,7 +75,7 @@ public:
      * @param limits Pointer to the search limit
      * @param evalInfo Returns the evaluation information
      */
-    void set_search_settings(Board *pos, SearchLimits* searchLimits, EvalInfo* evalInfo);
+    void set_search_settings(State *state, SearchLimits* searchLimits, EvalInfo* evalInfo);
 
     /**
      * @brief stop Stops the current search is called after "stop" from the stdin
@@ -86,9 +87,13 @@ public:
      * @param move Move which has been played
      * @param ownMove Boolean indicating if it was CrazyAra's move
      */
-    virtual void apply_move_to_tree(Move move, bool ownMove) = 0;
+    virtual void apply_move_to_tree(Action move, bool ownMove) = 0;
 
-    Move get_best_move();
+    /**
+     * @brief get_best_action Returns the best action. It is assumed this function gets called after the search.
+     * @return Action
+     */
+    Action get_best_action();
 };
 
 void run_agent_thread(Agent* agent);

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -37,7 +37,7 @@
 #include "agent.h"
 #include "../evalinfo.h"
 #include "../node.h"
-#include "../board.h"
+#include "../state.h"
 #include "../nn/neuralnetapi.h"
 #include "config/searchsettings.h"
 #include "config/searchlimits.h"
@@ -63,7 +63,7 @@ private:
     unique_ptr<TimeManager> timeManager;
 
     Node* rootNode;
-    Board* rootPos;
+    State* rootState;
     // The oldes root node stores a reference to the node with with the current root nodes is based on.
     // This is used in the case of tree reusage. The old subtree cannot be cleared immediatly because of
     // stateInfos for 3-fold repetition, but can be cleared as soon as the tree cannot be reused anymore.
@@ -119,7 +119,7 @@ public:
      */
     void print_root_node();
 
-    void apply_move_to_tree(Move move, bool ownMove) override;
+    void apply_move_to_tree(Action move, bool ownMove) override;
 
     /**
      * @brief clear_game_history Traverses all root positions for the game and calls clear_subtree() for each of them
@@ -159,7 +159,7 @@ public:
      * @param value New value to set
      */
     void update_dirichlet_epsilon(float value);
-    Board *get_root_pos() const;
+    State *get_root_state() const;
     bool is_running() const;
 
     /**
@@ -174,7 +174,7 @@ private:
      * @param pos Requested board position
      * @return Number of nodes that have already been explored before the serach
      */
-    inline size_t init_root_node(Board* pos);
+    inline size_t init_root_node(State* state);
 
     /**
      * @brief get_new_root_node Returns the pointer of the new root node for the given position in the case
@@ -183,13 +183,13 @@ private:
      * @param pos Requested board position
      * @return Pointer to root node or nullptr
      */
-    inline Node* get_root_node_from_tree(Board* pos);
+    inline Node* get_root_node_from_tree(State* state);
 
     /**
      * @brief create_new_root_node Creates a new root node for the given board position and requests the neural network for evaluation
      * @param pos Board position
      */
-    inline void create_new_root_node(Board *pos);
+    inline void create_new_root_node(State* state);
 
     /**
      * @brief delete_old_tree Clear the old tree except the gameNodes (rootNode, opponentNextRoot)

--- a/engine/src/agents/rawnetagent.h
+++ b/engine/src/agents/rawnetagent.h
@@ -59,7 +59,7 @@ public:
 
     void stop() override;
 
-    void apply_move_to_tree(Move move, bool ownMove) override;
+    void apply_move_to_tree(Action move, bool ownMove) override;
 };
 
 #endif // RAWNETAGENT_H

--- a/engine/src/board.cpp
+++ b/engine/src/board.cpp
@@ -224,7 +224,7 @@ void Board::set(const string &code, Color c, Variant v, StateInfo *si)
 }
 #endif
 
-std::string pgn_move(Move m, bool chess960, const Board& pos, const std::vector<Move>& legalMoves, bool leadsToWin, bool bookMove)
+std::string pgn_move(Move m, bool chess960, const Board& pos, const std::vector<Action>& legalMoves, bool leadsToWin, bool bookMove)
 {
     std::string move;
 
@@ -310,7 +310,7 @@ std::string pgn_move(Move m, bool chess960, const Board& pos, const std::vector<
 }
 
 
-bool is_pgn_move_ambiguous(Move m, const Board& pos, const std::vector<Move> &legalMoves, bool &isFileAmbiguous, bool &isRankAmbiguous)
+bool is_pgn_move_ambiguous(Move m, const Board& pos, const std::vector<Action> &legalMoves, bool &isFileAmbiguous, bool &isRankAmbiguous)
 {
     bool ambiguous = false;
     isFileAmbiguous = false;
@@ -318,9 +318,9 @@ bool is_pgn_move_ambiguous(Move m, const Board& pos, const std::vector<Move> &le
     const Square from = from_sq(m);
     const Square to = to_sq(m);
 
-    for (Move move: legalMoves) {
-        const Square cur_from = from_sq(move);
-        const Square cur_to = to_sq(move);
+    for (Action move: legalMoves) {
+        const Square cur_from = from_sq(Move(move));
+        const Square cur_to = to_sq(Move(move));
         if (to == cur_to && from != cur_from && pos.piece_on(from) == pos.piece_on(cur_from)) {
             ambiguous = true;
             if (file_of(from) == file_of(cur_from)) {

--- a/engine/src/board.h
+++ b/engine/src/board.h
@@ -136,7 +136,7 @@ public:
  * @param isRankAmbiguous Returns if the move is rank ambiguous (two pieces share the same rank with same destination square)
  * @return True, in case of ambiguity else false
  */
-bool is_pgn_move_ambiguous(Move m, const Board& pos, const std::vector<Move>& legalMoves, bool& isFileAmbiguous, bool& isRankAmbiguous);
+bool is_pgn_move_ambiguous(Move m, const Board& pos, const std::vector<Action>& legalMoves, bool& isFileAmbiguous, bool& isRankAmbiguous);
 
 /**
  * @brief pgnMove Converts a given move into PGN move notation.
@@ -150,7 +150,7 @@ bool is_pgn_move_ambiguous(Move m, const Board& pos, const std::vector<Move>& le
  * @param bookMove Appends " {book}" in case the move was a book move
  * @return String representation of move in PGN format
  */
-std::string pgn_move(Move m, bool chess960, const Board& pos, const std::vector<Move>& legalMoves, bool leadsToWin=false, bool bookMove=false);
+std::string pgn_move(Move m, bool chess960, const Board& pos, const std::vector<Action>& legalMoves, bool leadsToWin=false, bool bookMove=false);
 
 /**
  * @brief leads_to_terminal Checks if the next states is a terminal state if you would apply the given move

--- a/engine/src/boardstate.cpp
+++ b/engine/src/boardstate.cpp
@@ -1,0 +1,157 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License fåor more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: boardstate.h
+ * Created on 13.07.2020
+ * @author: queensgambit
+ */
+
+#include "boardstate.h"
+#include "domain/crazyhouse/inputrepresentation.h"
+
+BoardState::BoardState() : State()
+{
+    states = StateListPtr(new std::deque<StateInfo>(0));
+}
+
+BoardState::BoardState(const BoardState &b)
+{
+    board = b.board;
+    states = StateListPtr(new std::deque<StateInfo>(0));
+}
+
+vector<Action> BoardState::legal_actions() const
+{
+    vector<Action> legalMoves;
+    // generate the legal moves and save them in the list
+    for (const ExtMove& move : MoveList<LEGAL>(board)) {
+        legalMoves.push_back(Action(move));
+    }
+    return legalMoves;
+}
+
+State &BoardState::set(const string &fenStr, bool isChess960, int variant)
+{
+    states = StateListPtr(new std::deque<StateInfo>(1));
+    variant = UCI::variant_from_name(Options["UCI_Variant"]);
+    board.set(fenStr, isChess960, Variant(variant), &states->back(), nullptr);
+    return *this;
+}
+
+void BoardState::get_state_planes(bool normalize, float *inputPlanes) const
+{
+    board_to_planes(&board, board.number_repetitions(), normalize, inputPlanes);
+}
+
+unsigned int BoardState::steps_from_null() const
+{
+    return board.plies_from_null();
+}
+
+bool BoardState::is_chess960() const
+{
+    return board.is_chess960();
+}
+
+string BoardState::fen() const
+{
+    return board.fen();
+}
+
+void BoardState::do_action(Action action)
+{
+    states->emplace_back();
+    board.do_move(Move(action), states->back());
+}
+
+unsigned int BoardState::number_repetitions() const
+{
+    return board.number_repetitions();
+}
+
+int BoardState::side_to_move() const
+{
+    return board.side_to_move();
+}
+
+Key BoardState::hash_key() const
+{
+    return board.hash_key();
+}
+
+void BoardState::flip()
+{
+    board.flip();
+}
+
+Action BoardState::uci_to_action(string& uciStr) const
+{
+    return Action(UCI::to_move(board, uciStr));
+}
+
+string BoardState::action_to_san(Action action, const vector<Action>& legalActions) const
+{
+    return pgn_move(Move(action), this->is_chess960(), board, legalActions);
+}
+
+TerminalType BoardState::is_terminal(size_t numberLegalMoves, bool inCheck) const
+{
+    if (numberLegalMoves == 0) {
+#ifdef ANTI
+        if (board.is_anti()) {
+            // a stalmate is a win in antichess
+            return TERMINAL_WIN;
+        }
+#endif
+        // test if we have a check-mate
+        if (inCheck) {
+            return TERMINAL_LOSS;
+        }
+        // we reached a stalmate
+        return TERMINAL_DRAW;
+    }
+#ifdef ANTI
+    if (board.is_anti()) {
+        if (board.is_anti_win()) {
+            return TERMINAL_WIN;
+        }
+        if (board.is_anti_loss()) {
+            return TERMINAL_LOSS;
+        }
+    }
+#endif
+    if (board.can_claim_3fold_repetition() || board.is_50_move_rule_draw() || board.draw_by_insufficient_material()) {
+        // reached 3-fold-repetition or 50 moves rule draw or insufficient material
+        return TERMINAL_DRAW;
+    }
+
+    // normal game position
+    return TERMINAL_NONE;
+}
+
+bool BoardState::gives_check(Action action) const
+{
+    return board.gives_check(Move(action));
+}
+
+unique_ptr<State> BoardState::clone() const
+{
+    return make_unique<BoardState>(*this);
+}

--- a/engine/src/boardstate.cpp
+++ b/engine/src/boardstate.cpp
@@ -26,15 +26,16 @@
 #include "boardstate.h"
 #include "domain/crazyhouse/inputrepresentation.h"
 
-BoardState::BoardState() : State()
+BoardState::BoardState() : State(),
+    states(StateListPtr(new std::deque<StateInfo>(0)))
 {
-    states = StateListPtr(new std::deque<StateInfo>(0));
 }
 
-BoardState::BoardState(const BoardState &b)
+BoardState::BoardState(const BoardState &b) :
+    State(),
+    board(b.board),
+    states(StateListPtr(new std::deque<StateInfo>(0)))
 {
-    board = b.board;
-    states = StateListPtr(new std::deque<StateInfo>(0));
 }
 
 vector<Action> BoardState::legal_actions() const

--- a/engine/src/boardstate.cpp
+++ b/engine/src/boardstate.cpp
@@ -155,3 +155,9 @@ unique_ptr<State> BoardState::clone() const
 {
     return make_unique<BoardState>(*this);
 }
+
+ostream &operator<<(ostream &os, const BoardState &state)
+{
+    os << state.board;
+    return os;
+}

--- a/engine/src/boardstate.cpp
+++ b/engine/src/boardstate.cpp
@@ -156,8 +156,7 @@ unique_ptr<State> BoardState::clone() const
     return make_unique<BoardState>(*this);
 }
 
-ostream &operator<<(ostream &os, const BoardState &state)
+void BoardState::print(ostream &os) const
 {
-    os << state.board;
-    return os;
+    os << board;
 }

--- a/engine/src/boardstate.h
+++ b/engine/src/boardstate.h
@@ -1,0 +1,64 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License fåor more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: boardstate.h
+ * Created on 13.07.2020
+ * @author: queensgambit
+ *
+ * BoardState encapsulates Board and StateInfo and inherits from the abstract State class.
+ */
+
+#ifndef BOARTSTATE_H
+#define BOARTSTATE_H
+
+#include "uci.h"
+#include "state.h"
+#include "board.h"
+
+class BoardState : public State
+{
+private:
+    Board board;
+    StateListPtr states;
+
+public:
+    BoardState();
+    BoardState(const BoardState& b);
+
+    // State interface
+    vector<Action> legal_actions() const;
+    State &set(const string &fenStr, bool isChess960, int variant);
+    void get_state_planes(bool normalize, float *inputPlanes) const;
+    unsigned int steps_from_null() const;
+    bool is_chess960() const;
+    string fen() const;
+    void do_action(Action action);
+    unsigned int number_repetitions() const;
+    int side_to_move() const;
+    Key hash_key() const;
+    void flip();
+    Action uci_to_action(string& uciStr) const;
+    string action_to_san(Action action, const vector<Action>& legalActions) const;
+    TerminalType is_terminal(size_t numberLegalMoves, bool inCheck) const;
+    bool gives_check(Action action) const;
+    unique_ptr<State> clone() const;
+};
+
+#endif // BOARTSTATE_H

--- a/engine/src/boardstate.h
+++ b/engine/src/boardstate.h
@@ -59,8 +59,7 @@ public:
     TerminalType is_terminal(size_t numberLegalMoves, bool inCheck) const;
     bool gives_check(Action action) const;
     unique_ptr<State> clone() const;
-
-    friend std::ostream& operator<<(std::ostream& os, const BoardState& state);
+    void print(ostream& os) const;
 };
 
 #endif // BOARTSTATE_H

--- a/engine/src/boardstate.h
+++ b/engine/src/boardstate.h
@@ -59,6 +59,8 @@ public:
     TerminalType is_terminal(size_t numberLegalMoves, bool inCheck) const;
     bool gives_check(Action action) const;
     unique_ptr<State> clone() const;
+
+    friend std::ostream& operator<<(std::ostream& os, const BoardState& state);
 };
 
 #endif // BOARTSTATE_H

--- a/engine/src/crazyara.cpp
+++ b/engine/src/crazyara.cpp
@@ -151,7 +151,7 @@ void CrazyAra::uci_loop(int argc, char *argv[])
         else if (token == "benchmark")  benchmark(is);
         else if (token == "root")       mctsAgent->print_root_node();
         else if (token == "flip")       state->flip();
-        else if (token == "d")          cout << state << endl;
+        else if (token == "d")          cout << *(state.get()) << endl;
 #ifdef USE_RL
         else if (token == "selfplay")   selfplay(is);
         else if (token == "arena")      arena(is);

--- a/engine/src/crazyara.cpp
+++ b/engine/src/crazyara.cpp
@@ -37,7 +37,8 @@
 #include "evalinfo.h"
 #include "domain/crazyhouse/constants.h"
 #include "constants.h"
-#include "board.h"
+#include "state.h"
+#include "boardstate.h"
 #include "domain/variants.h"
 #include "optionsuci.h"
 #include "tests/benchmarkpositions.h"
@@ -52,10 +53,10 @@ using namespace std;
 
 // allocate memory
 string LABELS_MIRRORED[NB_LABELS];
-unordered_map<Move, size_t, std::hash<int>> MV_LOOKUP = {};
-unordered_map<Move, size_t, std::hash<int>> MV_LOOKUP_MIRRORED = {};
-unordered_map<Move, size_t, std::hash<int>> MV_LOOKUP_CLASSIC = {};
-unordered_map<Move, size_t, std::hash<int>> MV_LOOKUP_MIRRORED_CLASSIC = {};
+unordered_map<Action, size_t, std::hash<int>> MV_LOOKUP = {};
+unordered_map<Action, size_t, std::hash<int>> MV_LOOKUP_MIRRORED = {};
+unordered_map<Action, size_t, std::hash<int>> MV_LOOKUP_CLASSIC = {};
+unordered_map<Action, size_t, std::hash<int>> MV_LOOKUP_MIRRORED_CLASSIC = {};
 
 CrazyAra::CrazyAra():
     rawAgent(nullptr),
@@ -95,14 +96,13 @@ void CrazyAra::welcome()
 
 void CrazyAra::uci_loop(int argc, char *argv[])
 {
-    Board pos;
+    unique_ptr<State> state = make_unique<BoardState>();
     string token, cmd;
     EvalInfo evalInfo;
     auto uiThread = make_shared<Thread>(0);
 
-    states = StateListPtr(new std::deque<StateInfo>(1));
     variant = UCI::variant_from_name(Options["UCI_Variant"]);
-    pos.set(StartFENs[variant], is960, variant, &states->back(), uiThread.get());
+    state->set(StartFENs[variant], is960, variant);
 
     for (int i = 1; i < argc; ++i)
         cmd += string(argv[i]) + " ";
@@ -138,8 +138,8 @@ void CrazyAra::uci_loop(int argc, char *argv[])
 				<< "uciok" << endl;
 		}
         else if (token == "setoption")  OptionsUCI::setoption(is);
-        else if (token == "go")         go(&pos, is, evalInfo);
-        else if (token == "position")   position(&pos, is);
+        else if (token == "go")         go(state.get(), is, evalInfo);
+        else if (token == "position")   position(state.get(), is);
         else if (token == "ucinewgame") ucinewgame();
         else if (token == "isready") {
             if (is_ready()) {
@@ -150,8 +150,8 @@ void CrazyAra::uci_loop(int argc, char *argv[])
         // Additional custom non-UCI commands, mainly for debugging
         else if (token == "benchmark")  benchmark(is);
         else if (token == "root")       mctsAgent->print_root_node();
-        else if (token == "flip")       pos.flip();
-        else if (token == "d")          cout << pos << endl;
+        else if (token == "flip")       state->flip();
+        else if (token == "d")          cout << state << endl;
 #ifdef USE_RL
         else if (token == "selfplay")   selfplay(is);
         else if (token == "arena")      arena(is);
@@ -165,7 +165,7 @@ void CrazyAra::uci_loop(int argc, char *argv[])
     wait_to_finish_last_search();
 }
 
-void CrazyAra::go(Board *pos, istringstream &is,  EvalInfo& evalInfo) {
+void CrazyAra::go(State* state, istringstream &is,  EvalInfo& evalInfo) {
     searchLimits.reset();
     searchLimits.moveOverhead = TimePoint(Options["Move_Overhead"]);
     searchLimits.nodes = Options["Nodes"];
@@ -195,29 +195,28 @@ void CrazyAra::go(Board *pos, istringstream &is,  EvalInfo& evalInfo) {
 
     ongoingSearch = true;
     if (useRawNetwork) {
-        rawAgent->set_search_settings(pos, &searchLimits, &evalInfo);
+        rawAgent->set_search_settings(state, &searchLimits, &evalInfo);
         mainSearchThread = thread(run_agent_thread, rawAgent.get());
     }
     else {
-        mctsAgent->set_search_settings(pos, &searchLimits, &evalInfo);
+        mctsAgent->set_search_settings(state, &searchLimits, &evalInfo);
         mainSearchThread = thread(run_agent_thread, mctsAgent.get());
     }
 }
 
 void CrazyAra::go(const string& fen, string goCommand, EvalInfo& evalInfo)
 {
-    Board pos;
+    unique_ptr<State> state = make_unique<BoardState>();
+
     string token, cmd;
-    auto uiThread = make_shared<Thread>(0);
     variant = UCI::variant_from_name(Options["UCI_Variant"]);
 
-    states = StateListPtr(new std::deque<StateInfo>(1));
-    pos.set(StartFENs[variant], is960, variant, &states->back(), uiThread.get());
+    state->set(StartFENs[variant], is960, variant);
 
     istringstream is("fen " + fen);
-    position(&pos, is);
+    position(state.get(), is);
     istringstream isGoCommand(goCommand);
-    go(&pos, isGoCommand, evalInfo);
+    go(state.get(), isGoCommand, evalInfo);
     wait_to_finish_last_search();
 }
 
@@ -229,11 +228,11 @@ void CrazyAra::wait_to_finish_last_search()
     }
 }
 
-void CrazyAra::position(Board *pos, istringstream& is)
+void CrazyAra::position(State* state, istringstream& is)
 {
     wait_to_finish_last_search();
 
-    Move m;
+    Action action;
     string token, fen;
     variant = UCI::variant_from_name(Options["UCI_Variant"]);
 
@@ -250,22 +249,20 @@ void CrazyAra::position(Board *pos, istringstream& is)
         return;
 
     auto uiThread = make_shared<Thread>(0);
-    states->emplace_back();
-    pos->set(fen, is960, variant, &states->back(), uiThread.get());
-    Move lastMove = MOVE_NULL;
+    state->set(fen, is960, variant);
+    Action lastMove = ACTION_NONE;
 
     // Parse move list (if any)
-    while (is >> token && (m = UCI::to_move(*pos, token)) != MOVE_NONE)
+    while (is >> token && (action = state->uci_to_action(token)) != ACTION_NONE)
     {
-        states->emplace_back();
-        pos->do_move(m, states->back());
-        lastMove = m;
+        state->do_action(action);
+        lastMove = action;
     }
     // inform the mcts agent of the move, so the tree can potentially be reused later
     if (lastMove != MOVE_NULL && !useRawNetwork) {
         mctsAgent->apply_move_to_tree(lastMove, false);
     }
-    info_string("position", pos->fen());
+    info_string("position", state->fen());
 }
 
 void CrazyAra::benchmark(istringstream &is)
@@ -282,7 +279,8 @@ void CrazyAra::benchmark(istringstream &is)
 
     for (TestPosition pos : benchmark.positions) {
         go(pos.fen, goCommand, evalInfo);
-        string uciMove = UCI::move(evalInfo.bestMove, false);
+        // TODO: Remove cast
+        string uciMove = UCI::move(Move(evalInfo.bestMove), false);
         if (uciMove != pos.blunderMove) {
             cout << "passed      -- " << uciMove << " != " << pos.blunderMove << endl;
             passedCounter++;

--- a/engine/src/crazyara.h
+++ b/engine/src/crazyara.h
@@ -45,7 +45,6 @@
 class CrazyAra
 {
 private:
-    StateListPtr states;
     const string intro =  string("\n") +
                     string("                                  _                                           \n") +
                     string("                   _..           /   ._   _.  _        /\\   ._   _.           \n") +
@@ -126,7 +125,7 @@ public:
      * @param is List of command line arguments for the search
      * @param evalInfo Returns the evalutation information
      */
-    void go(Board* pos, istringstream& is, EvalInfo& evalInfo);
+    void go(State* state, istringstream& is, EvalInfo& evalInfo);
 
     /**
      * @brief go Wrapper function for go() which accepts a FEN string
@@ -142,7 +141,7 @@ public:
      * @param pos Position object which will be set
      * @param is List of command line arguments which describe the position
      */
-    void position(Board* pos, istringstream& is);
+    void position(State* pos, istringstream& is);
 
     /**
      * @brief benchmark Runs a list of benchmark position for a given time

--- a/engine/src/domain/crazyhouse/constants.h
+++ b/engine/src/domain/crazyhouse/constants.h
@@ -37,6 +37,7 @@
 #include <string>
 #include <unordered_map>
 #include "types.h"
+#include "../../state.h"
 #include "../../util/sfutil.h"
 #include <iostream>
 #include "policymaprepresentation.h"
@@ -6733,12 +6734,12 @@ const std::string LABELS[] = {
 
 // will be filled in init()
 // stores a mapping from Stockfish's move representation to the NN index in the policy
-extern std::unordered_map<Move, size_t, std::hash<int>> MV_LOOKUP;
-extern std::unordered_map<Move, size_t, std::hash<int>> MV_LOOKUP_MIRRORED;
+extern std::unordered_map<Action, size_t, std::hash<int>> MV_LOOKUP;
+extern std::unordered_map<Action, size_t, std::hash<int>> MV_LOOKUP_MIRRORED;
 
 // classical flattened look up tables, which are later used for policy export
-extern std::unordered_map<Move, size_t, std::hash<int>> MV_LOOKUP_CLASSIC;
-extern std::unordered_map<Move, size_t, std::hash<int>> MV_LOOKUP_MIRRORED_CLASSIC;
+extern std::unordered_map<Action, size_t, std::hash<int>> MV_LOOKUP_CLASSIC;
+extern std::unordered_map<Action, size_t, std::hash<int>> MV_LOOKUP_MIRRORED_CLASSIC;
 
 //https://stackoverflow.com/questions/23390034/c-change-global-variable-value-in-different-files
 extern std::string LABELS_MIRRORED[NB_LABELS];

--- a/engine/src/domain/crazyhouse/outputrepresentation.cpp
+++ b/engine/src/domain/crazyhouse/outputrepresentation.cpp
@@ -29,7 +29,7 @@
 using namespace std;
 
 // TODO: Change this later to blaze::HybridVector<float, MAX_NB_LEGAL_MOVES>
-void get_probs_of_move_list(const size_t batchIdx, const float* policyProb, const std::vector<Move> &legalMoves, Color sideToMove, bool normalize, DynamicVector<float> &policyProbSmall, bool selectPolicyFromPlane)
+void get_probs_of_move_list(const size_t batchIdx, const float* policyProb, const std::vector<Action>& legalMoves, Color sideToMove, bool normalize, DynamicVector<float> &policyProbSmall, bool selectPolicyFromPlane)
 {
     size_t vectorIdx;
     for (size_t mvIdx = 0; mvIdx < legalMoves.size(); ++mvIdx) {
@@ -78,7 +78,7 @@ const float* get_policy_data_batch(const size_t batchIdx, const float* probOutpu
     return probOutputs + batchIdx*NB_LABELS;
 }
 
-unordered_map<Move, size_t, std::hash<int>>& get_current_move_lookup(Color sideToMove)
+unordered_map<Action, size_t, std::hash<int>>& get_current_move_lookup(Color sideToMove)
 {
     if (sideToMove == WHITE) {
         // use the look-up table for the first player

--- a/engine/src/domain/crazyhouse/outputrepresentation.h
+++ b/engine/src/domain/crazyhouse/outputrepresentation.h
@@ -31,6 +31,7 @@
 #include "types.h"
 #include <blaze/Math.h>
 #include "constants.h"
+#include "../../state.h"
 
 using blaze::HybridVector;
 using blaze::DynamicVector;
@@ -51,7 +52,7 @@ const float*  get_policy_data_batch(const size_t batchIdx, const float* policyPr
  * @param sideToMove Current side to move
  * @return Returns either MOVE_LOOK_UP or MOVE_LOOK_UP_MIRRORED
  */
-unordered_map<Move, size_t, std::hash<int>>& get_current_move_lookup(Color sideToMove);
+unordered_map<Action, size_t, std::hash<int>>& get_current_move_lookup(Color sideToMove);
 
 /**
  * @brief get_probs_of_move_list Returns an array in which entry relates to the probability for the given move list.
@@ -65,7 +66,7 @@ unordered_map<Move, size_t, std::hash<int>>& get_current_move_lookup(Color sideT
  * @param select_policy_from_plance Sets if the policy is encoded in policy map representation
  * @return policyProbSmall - A hybrid blaze vector which stores the probabilities for the given move list
  */
-void get_probs_of_move_list(const size_t batchIdx, const float* policyProb, const std::vector<Move> &legalMoves, Color sideToMove,
+void get_probs_of_move_list(const size_t batchIdx, const float* policyProb, const std::vector<Action>& legalMoves, Color sideToMove,
                             bool normalize, DynamicVector<float> &policyProbSmall, bool select_policy_from_plance);
 
 void get_probs_of_moves(const float *data, const vector<Move>& legalMoves,

--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -46,8 +46,8 @@ void print_single_pv(std::ostream& os, const EvalInfo& evalInfo, size_t idx, siz
        << " nps " << evalInfo.calculate_nps(elapsedTimeMS)
        << " tbhits " << evalInfo.tbHits
        << " pv";
-    for (Move move: evalInfo.pv[idx]) {
-        os << " " << UCI::move(move, evalInfo.isChess960);
+    for (Action move: evalInfo.pv[idx]) {
+        os << " " << UCI::move(Move(move), evalInfo.isChess960);
     }
     os << endl;
 }
@@ -100,15 +100,15 @@ int value_to_centipawn(float value)
 
 bool set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vector<size_t>& indices)
 {
-    vector<Move> pv;
+    vector<Action> pv;
     size_t childIdx;
     if (idx == 0) {
-        childIdx = get_best_move_index(rootNode, false);
+        childIdx = get_best_action_index(rootNode, false);
     }
     else {
         childIdx = indices[idx];
     }
-    pv.push_back(rootNode->get_move(childIdx));
+    pv.push_back(rootNode->get_action(childIdx));
     const Node* nextNode = rootNode->get_child_node(childIdx);
     if (nextNode == nullptr || !nextNode->is_playout_node()) {
         evalInfo.movesToMate.resize(idx);
@@ -155,7 +155,7 @@ void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t 
     size_t bestMoveIdx;
     rootNode->get_mcts_policy(evalInfo.policyProbSmall, bestMoveIdx);
     evalInfo.policyProbSmall.resize(rootNode->get_number_child_nodes());
-    evalInfo.legalMoves = rootNode->get_legal_moves();
+    evalInfo.legalMoves = rootNode->get_legal_action();
 
     vector<size_t> indices;
     size_t maxIdx = min(evalInfo.multiPV, evalInfo.legalMoves.size());

--- a/engine/src/evalinfo.h
+++ b/engine/src/evalinfo.h
@@ -46,7 +46,7 @@ struct EvalInfo
     chrono::steady_clock::time_point start;
     chrono::steady_clock::time_point end;
     std::vector<float> bestMoveQ;
-    std::vector<Move> legalMoves;
+    std::vector<Action> legalMoves;
     DynamicVector<float> policyProbSmall;
     DynamicVector<float> childNumberVisits;
     std::vector<int> centipawns;
@@ -55,8 +55,8 @@ struct EvalInfo
     size_t nodes;
     size_t nodesPreSearch;
     bool isChess960;
-    std::vector<std::vector<Move>> pv;
-    Move bestMove;
+    std::vector<std::vector<Action>> pv;
+    Action bestMove;
     std::vector<int> movesToMate;
     size_t tbHits;
 

--- a/engine/src/manager/treemanager.cpp
+++ b/engine/src/manager/treemanager.cpp
@@ -27,11 +27,11 @@
 #include "misc.h"
 #include "../node.h"
 
-Node* pick_next_node(Move move, const Node* parentNode)
+Node* pick_next_node(Action move, const Node* parentNode)
 {
     if (parentNode != nullptr) {
         for (size_t idx = 0; idx < parentNode->get_no_visit_idx(); ++idx) {
-            if (parentNode->get_legal_moves()[idx] == move) {
+            if (parentNode->get_legal_action()[idx] == move) {
                 return parentNode->get_child_nodes()[idx];
             }
         }
@@ -39,9 +39,9 @@ Node* pick_next_node(Move move, const Node* parentNode)
     return nullptr;
 }
 
-bool same_hash_key(Node* node, Board *pos)
+bool same_hash_key(Node* node, State* state)
 {
     return node != nullptr &&
-            node->hash_key() == pos->hash_key() &&
-            node->plies_from_null() == pos->get_state_info()->pliesFromNull;
+            node->hash_key() == state->hash_key() &&
+            node->plies_from_null() == state->steps_from_null();
 }

--- a/engine/src/manager/treemanager.h
+++ b/engine/src/manager/treemanager.h
@@ -28,7 +28,8 @@
 #ifndef TREEMANAGER_H
 #define TREEMANAGER_H
 
-#include "../board.h"
+//#include "../board.h"
+#include "../state.h"
 #include "../node.h"
 
 /**
@@ -36,7 +37,7 @@
  * @param move Move
  * @param ownMove Boolean indicating if it was CrazyAra's move
  */
-Node* pick_next_node(Move move, const Node* parentNode);
+Node* pick_next_node(Action move, const Node* parentNode);
 
 /**
  * @brief same_hash_key Checks if the given node isn't a nullptr and
@@ -45,6 +46,6 @@ Node* pick_next_node(Move move, const Node* parentNode);
  * @param pos Position pointer
  * @return bool
  */
-bool same_hash_key(Node* node, Board *pos);
+bool same_hash_key(Node* node, State* state);
 
 #endif // TREEMANAGER_H

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -33,9 +33,8 @@
 #include <unordered_map>
 
 #include <blaze/Math.h>
-#include "position.h"
 #include "movegen.h"
-#include "board.h"
+#include "state.h"
 
 #include "agents/config/searchsettings.h"
 #include "nodedata.h"
@@ -53,7 +52,7 @@ private:
     mutex mtx;
 
     DynamicVector<float> policyProbSmall;
-    vector<Move> legalMoves;
+    vector<Action> legalActions;
     //    DynamicVector<bool> isCheck;
     //    DynamicVector<bool> isCapture;
 
@@ -80,7 +79,7 @@ public:
      * @param move Move which led to current board state
      * @param searchSettings Pointer to the searchSettings
      */
-    Node(Board *pos,
+    Node(State *state,
          bool inCheck,
          Node *parentNode,
          size_t childIdxForParent,
@@ -150,16 +149,16 @@ public:
     bool is_solved() const;
     bool has_forced_win() const;
 
-    Move get_move(size_t childIdx) const;
+    Action get_action(size_t childIdx) const;
     Node* get_child_node(size_t childIdx) const;
 
-    Move get_best_move() const;
+    Action get_best_action() const;
 
     /**
      * @brief get_ponder_moves Returns a list for possible ponder moves
      * @return vector of moves
      */
-    vector<Move> get_ponder_moves() const;
+    vector<Action> get_ponder_moves() const;
 
     vector<Node*> get_child_nodes() const;
     bool is_terminal() const;
@@ -260,7 +259,7 @@ public:
 
     DynamicVector<float>& get_policy_prob_small();
 
-    void set_probabilities_for_moves(const float *data, unordered_map<Move, size_t, std::hash<int>>& moveLookup);
+    void set_probabilities_for_moves(const float *data, unordered_map<Action, size_t, std::hash<int>>& moveLookup);
 
     void apply_softmax_to_policy();
 
@@ -306,7 +305,7 @@ public:
      * @return float
      */
     float updated_value_eval() const;
-    std::vector<Move> get_legal_moves() const;
+    std::vector<Action> get_legal_action() const;
     int get_checkmate_idx() const;
 
     /**
@@ -323,7 +322,7 @@ public:
      * The moves a are pushed into the pv vector.
      * @param pv Vector in which moves will be pushed.
      */
-    void get_principal_variation(vector<Move>& pv) const;
+    void get_principal_variation(vector<Action>& pv) const;
 
     /**
      * @brief mark_nodes_as_fully_expanded Sets the noVisitIdx to be the number of child nodes.
@@ -340,7 +339,7 @@ public:
 
     DynamicVector<uint32_t> get_child_number_visits() const;
     void enable_has_nn_results();
-    int plies_from_null() const;
+    uint16_t plies_from_null() const;
     bool is_tablebase() const;
     uint8_t get_node_type() const;
     uint16_t get_end_in_ply() const;
@@ -383,7 +382,7 @@ public:
     /**
      * @brief print_node_statistics Prints all node statistics of the child nodes to stdout
      */
-    void print_node_statistics(const Board* pos);
+    void print_node_statistics(const State* pos);
 
 private:
     /**
@@ -396,7 +395,7 @@ private:
      * @param pos Current board position for this node
      * @param inCheck Boolean indicating if the king is in check
      */
-    void check_for_terminal(Board* pos, bool inCheck);
+    void check_for_terminal(State* state, bool inCheck);
 
     /**
      * @brief check_for_tablebase_wdl Checks if the given board position is a tablebase position and
@@ -404,12 +403,6 @@ private:
      * @param pos Current board position for this node
      */
     void check_for_tablebase_wdl(Board* pos);
-
-    /**
-     * @brief fill_child_node_moves Generates the legal moves and save them in the list
-     * @param pos Current node position
-     */
-    void fill_child_node_moves(Board* pos);
 
     /**
      * @brief solve_for_terminal Tries to solve the current node to be a forced win, loss or draw.
@@ -509,17 +502,17 @@ private:
      * and the move probability to 0.
      * @param childIdxForParent Index for the move which will be disabled
      */
-    void disable_move(size_t childIdxForParent);
+    void disable_action(size_t childIdxForParent);
 };
 
 /**
- * @brief get_best_move_index Returns the best move index of all available moves based on the mcts policy
+ * @brief get_best_action_index Returns the best move index of all available moves based on the mcts policy
  * or solved wins / draws / losses.
  * @param curNode Current node
  * @param fast If true, then the argmax(childNumberVisits) is returned for unsolved nodes
  * @return Index for best move and child node
  */
-size_t get_best_move_index(const Node* curNode, bool fast);
+size_t get_best_action_index(const Node* curNode, bool fast);
 
 /**
  * @brief generate_dtz_values Generates the DTZ values for a given position and all legal moves.

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -61,8 +61,8 @@ class SearchThread
 {
 private:
     Node* rootNode;
-    Board* rootPos;
-    StateListPtr states;
+    State* rootState;
+
     NeuralNetAPI* netBatch;
 
     // inputPlanes stores the plane representation of all newly expanded nodes of a single mini-batch
@@ -146,14 +146,14 @@ public:
      * @param inCheck Defines if the current position sets a player in check
      * @return Returns NODE_TRANSPOSITION if a tranpsosition node was added and NODE_NEW_NODE otherwise
      */
-    NodeBackup add_new_node_to_tree(Board* newPos, Node* parentNode, size_t childIdx, bool inCheck);
+    NodeBackup add_new_node_to_tree(State* newPos, Node* parentNode, size_t childIdx, bool inCheck);
 
     /**
      * @brief reset_tb_hits Sets the number of table hits to 0
      */
     void reset_stats();
 
-    void set_root_pos(Board *value);
+    void set_root_state(State* value);
     size_t get_tb_hits() const;
 
     size_t get_avg_depth();
@@ -186,7 +186,7 @@ private:
      * @param states States list which is used for 3-fold-repetition detection
      * @return Pointer to next child to evaluate (can also be terminal or tranposition node in which case no NN eval is required)
      */
-    Node* get_new_child_to_evaluate(Board* pos, size_t& childIdx, NodeDescription& description);
+    Node* get_new_child_to_evaluate(State* state, size_t& childIdx, NodeDescription& description);
 };
 
 void run_search_thread(SearchThread *t);
@@ -197,7 +197,7 @@ void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutput
 void node_post_process_policy(Node *node, float temperature, bool isPolicyMap, const SearchSettings* searchSettings);
 void node_assign_value(Node *node, const float* valueOutputs, size_t& tbHits, size_t batchIdx);
 
-bool is_transposition_verified(const unordered_map<Key,Node*>::const_iterator& it, const StateInfo* stateInfo);
+bool is_transposition_verified(const unordered_map<Key,Node*>::const_iterator& it, const State* state);
 
 /**
  * @brief random_root_playout Uses random move exploreation from the ROOT

--- a/engine/src/state.h
+++ b/engine/src/state.h
@@ -30,10 +30,8 @@
 
 #include <vector>
 #include <string>
-#include "types.h"
-
-
-using namespace std;
+#include <cstdint>
+#include <memory>
 
 typedef uint64_t Key;
 typedef int Action;
@@ -54,7 +52,7 @@ public:
      * @brief legal_actions Returns all legal actions as a vector list
      * @return vector of legal actions
      */
-    virtual vector<Action> legal_actions() const = 0;
+    virtual std::vector<Action> legal_actions() const = 0;
 
     /**
      * @brief set Sets a new states and modifies the current state.
@@ -63,7 +61,7 @@ public:
      * @param variant Variant which the position corresponds to.
      * @return An alias to the updated state
      */
-    virtual State& set(const string& fenStr, bool isChess960, int variant) = 0;
+    virtual State& set(const std::string& fenStr, bool isChess960, int variant) = 0;
 
     /**
      * @brief get_state_planes Returns the state plane representation of the current state which can be used for NN inference.
@@ -88,7 +86,7 @@ public:
      * @brief fen Returns the fen or string description of the current state
      * @return string
      */
-    virtual string fen() const = 0;
+    virtual std::string fen() const = 0;
 
     /**
      * @brief do_action Applies a given action to the current state
@@ -124,7 +122,7 @@ public:
      * @param uciStr uci specification for the action
      * @return Action
      */
-    virtual Action uci_to_action(string& uciStr) const = 0;
+    virtual Action uci_to_action(std::string& uciStr) const = 0;
 
     /**
      * @brief action_to_san Converts a given action to SAN (pgn move notation) usign the current position and legal moves
@@ -132,7 +130,7 @@ public:
      * @param legalActions List of legal moves for the current position
      * @return SAN string
      */
-    virtual string action_to_san(Action action, const vector<Action>& legalActions) const = 0;
+    virtual std::string action_to_san(Action action, const std::vector<Action>& legalActions) const = 0;
 
     /**
      * @brief is_terminal Returns the terminal type for the current state. If the state is a non terminal state,
@@ -154,7 +152,7 @@ public:
      * @brief clone Clones the current state as a deep copy
      * @return deep copy
      */
-    virtual unique_ptr<State> clone() const = 0;
+    virtual std::unique_ptr<State> clone() const = 0;
 };
 
 

--- a/engine/src/state.h
+++ b/engine/src/state.h
@@ -1,0 +1,162 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License fåor more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: state.h
+ * Created on 13.07.2020
+ * @author: queensgambit
+ *
+ * State is an abstract class which is used in the MCTS as a generic interface for various environments.
+ */
+
+#ifndef GAMESTATE_H
+#define GAMESTATE_H
+
+#include <vector>
+#include <string>
+#include "types.h"
+
+
+using namespace std;
+
+typedef uint64_t Key;
+typedef int Action;
+const int ACTION_NONE = 0;
+
+enum TerminalType {
+    TERMINAL_LOSS,
+    TERMINAL_DRAW,
+    TERMINAL_WIN,
+    TERMINAL_NONE
+};
+
+class State
+{
+public:
+
+    /**
+     * @brief legal_actions Returns all legal actions as a vector list
+     * @return vector of legal actions
+     */
+    virtual vector<Action> legal_actions() const = 0;
+
+    /**
+     * @brief set Sets a new states and modifies the current state.
+     * @param fenStr String description about the state
+     * @param isChess960 If true 960 mode will be active
+     * @param variant Variant which the position corresponds to.
+     * @return An alias to the updated state
+     */
+    virtual State& set(const string& fenStr, bool isChess960, int variant) = 0;
+
+    /**
+     * @brief get_state_planes Returns the state plane representation of the current state which can be used for NN inference.
+     * @param normalize If true thw normalized represnetation should be returned, otherwise the raw representation
+     * @param inputPlanes Pointer to the memory array where to set the state plane representation. It is assumed that the memory has already been allocated
+     */
+    virtual void get_state_planes(bool normalize, float* inputPlanes) const = 0;
+
+    /**
+     * @brief steps_from_null Number of steps form the initial position (e.g. starting position)
+     * @return number of steps
+     */
+    virtual unsigned int steps_from_null() const = 0;
+
+    /**
+     * @brief is_chess960 Returns true if the position is a 960 random position, else false
+     * @return bool
+     */
+    virtual bool is_chess960() const = 0;
+
+    /**
+     * @brief fen Returns the fen or string description of the current state
+     * @return string
+     */
+    virtual string fen() const = 0;
+
+    /**
+     * @brief do_action Applies a given action to the current state
+     * @param action Type of action to apply. It is assumed that the action is discrete and integer format
+     */
+    virtual void do_action(Action action) = 0;
+
+    /**
+     * @brief number_repetitions Returns the number of times this state has already occured in the current episode
+     * @return int
+     */
+    virtual unsigned int number_repetitions() const = 0;
+
+    /**
+     * @brief side_to_move Returns the side to move (e.g. Color: WHITE or BLACK) in chess
+     * @return int
+     */
+    virtual int side_to_move() const = 0;
+
+    /**
+     * @brief hash_key Returns a uique identifier for the current position which can be used for accessing the hash table
+     * @return
+     */
+    virtual Key hash_key() const = 0;
+
+    /**
+     * @brief flip Flips the state along the x-axis
+     */
+    virtual void flip() = 0;
+
+    /**
+     * @brief uci_to_action Converts the given action in uci notation to an action object
+     * @param uciStr uci specification for the action
+     * @return Action
+     */
+    virtual Action uci_to_action(string& uciStr) const = 0;
+
+    /**
+     * @brief action_to_san Converts a given action to SAN (pgn move notation) usign the current position and legal moves
+     * @param action Given action
+     * @param legalActions List of legal moves for the current position
+     * @return SAN string
+     */
+    virtual string action_to_san(Action action, const vector<Action>& legalActions) const = 0;
+
+    /**
+     * @brief is_terminal Returns the terminal type for the current state. If the state is a non terminal state,
+     * then TERMINAL_NONE should be returned.
+     * @param numberLegalMoves Number of legal moves in the current position
+     * @param inCheck Boolean which defines if there is a check in the current position
+     * @return TerminalType
+     */
+    virtual TerminalType is_terminal(size_t numberLegalMoves, bool inCheck) const = 0;
+
+    /**
+     * @brief gives_check Checks if the current action is a checking move
+     * @param action Action
+     * @return bool
+     */
+    virtual bool gives_check(Action action) const = 0;
+
+    /**
+     * @brief clone Clones the current state as a deep copy
+     * @return deep copy
+     */
+    virtual unique_ptr<State> clone() const = 0;
+};
+
+
+
+#endif // GAMESTATE_H

--- a/engine/src/state.h
+++ b/engine/src/state.h
@@ -47,7 +47,6 @@ enum TerminalType {
 class State
 {
 public:
-
     /**
      * @brief legal_actions Returns all legal actions as a vector list
      * @return vector of legal actions
@@ -153,8 +152,23 @@ public:
      * @return deep copy
      */
     virtual std::unique_ptr<State> clone() const = 0;
+
+    /**
+     * @brief print Print method used for the operator <<
+     */
+    virtual void print(std::ostream&) const = 0;
+
+    /**
+     * @brief operator << Operator overload for <<
+     * @param os ostream object
+     * @param state state object
+     * @return ostream
+     */
+    friend std::ostream& operator<<(std::ostream& os, const State& state)
+    {
+        state.print(os);
+        return os;
+    }
 };
-
-
 
 #endif // GAMESTATE_H

--- a/engine/src/tests/tests.cpp
+++ b/engine/src/tests/tests.cpp
@@ -135,10 +135,10 @@ TEST_CASE("PGN_Move_Ambiguity"){
     string uci_move = "f3d2";
     Move move = UCI::to_move(pos, uci_move);
 
-    vector<Move> legalMoves;
+    vector<Action> legalMoves;
     // generate legal moves
     for (const ExtMove& move : MoveList<LEGAL>(pos)) {
-        legalMoves.push_back(move);
+        legalMoves.push_back(Action(move));
     }
     bool isRankAmbigious;
     bool isFileAmbigious;


### PR DESCRIPTION
This PR adds a generic state action interface to allow a convenient integration for non-chess environments (e.g. the [Pommerman environment](https://www.pommerman.com/)).

All environments must implement the interface as described in [state.h](engine/src/state.h).

The interface assumes the environment to be discrete and to define the actions in integer format.

