### PR TITLE
added MCTS_STORE_STATES

### DIFF
--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -174,7 +174,11 @@ void MCTSAgent::create_new_root_node(StateObj* state)
 {
     info_string("create new tree");
     // TODO: Make sure that "inCheck=False" does not cause issues
+#ifdef MCTS_STORE_STATES
+    rootNode = new Node(state->clone(), false, searchSettings);
+#else
     rootNode = new Node(state, false, searchSettings);
+#endif
     state->get_state_planes(true, inputPlanes);
     net->predict(inputPlanes, valueOutputs, probOutputs);
     size_t tbHits = 0;

--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -82,11 +82,21 @@ double Node::get_q_sum_for_parent(const ParentNode &parent, float virtualLoss) c
     return parent.node->get_q_sum(parent.childIdxForParent, virtualLoss);
 }
 
+#ifdef MCTS_STORE_STATES
+StateObj* Node::get_state() const
+{
+    return state.get();
+}
+#endif
+
 Node::Node(StateObj* state, bool inCheck, const SearchSettings* searchSettings):
     legalActions(state->legal_actions()),
     key(state->hash_key()),
     valueSum(0),
     d(nullptr),
+#ifdef MCTS_STORE_STATES
+    state(state),
+#endif
     realVisitsSum(0),
     pliesFromNull(state->steps_from_null()),
     numberParentNodes(1),
@@ -502,6 +512,9 @@ void Node::prepare_node_for_visits()
 {
     sort_moves_by_probabilities();
     init_node_data();
+#ifdef MCTS_STORE_STATES
+    state->prepare_action();
+#endif
 }
 
 uint32_t Node::get_visits() const

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -79,6 +79,10 @@ private:
     double valueSum;
 
     unique_ptr<NodeData> d;
+#ifdef MCTS_STORE_STATES
+    unique_ptr<StateObj> state;
+#endif
+
     uint32_t realVisitsSum;
 
     // identifiers
@@ -422,6 +426,11 @@ public:
      * @brief set_as_inspected Sets the inspected variable to true
      */
     void set_as_inspected();
+
+#ifdef MCTS_STORE_STATES
+    StateObj* get_state() const;
+#endif
+
 private:
 
     uint32_t get_real_visits_for_parent(const ParentNode& parent) const;

--- a/engine/src/state.h
+++ b/engine/src/state.h
@@ -203,6 +203,13 @@ public:
     virtual void undo_action(Action action) = 0;
 
     /**
+     * @brief prepare_action Function which is called once in case of MCTS_STORE_STATES before a new action is applied in a leaf node.
+     * It can be used to store e.g. action buffers in the state which can then be used for all other legal actions.
+     * By default keep this method empty.
+     */
+    virtual void prepare_action() = 0;
+
+    /**
      * @brief number_repetitions Returns the number of times this state has already occured in the current episode
      * @return int
      */
@@ -282,7 +289,7 @@ public:
      */
     virtual Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState& result) = 0;
 
-    /*&
+    /**
      * @brief operator << Operator overload for <<
      * @param os ostream object
      * @param state state object


### PR DESCRIPTION
The #ifdef `MCTS_STORE_STATES` allows storing the states within the nodes.

This highly memory consuming but can be beneficial for environments with
a high `do_action()` runtime cost and either low memory consumption or low
total number of nodes in the search tree.