### PR TITLE
Refactor Training Code and make training in Gluon the new default

### DIFF
--- a/DeepCrazyhouse/configs/main_config_template.py
+++ b/DeepCrazyhouse/configs/main_config_template.py
@@ -47,6 +47,13 @@ main_config = {
     # the weight directory contains the of the network in mxnet .params format
     "model_weights_dir": "/home/demo_user/models/Crazyhouse/params/",
 
+    # layer name of the value output layer (e.g. value_tanh0 for legacy crazyhouse networks and value_out for newer
+    # networks)
+    "value_output": "value_out",
+    # layer name of the policy output layer without softmax applied (e.g. flatten0 for legacy crazyhouse networks
+    # policy_out for newer networks)
+    "policy_output": "policy_out",
+
     # Active mode for different input & output representations.
     # Each mode is only compatible with a certain network input-/output representation:
     # Available modes:  0: MODE_CRAZYHOUSE    (crazyhouse only mode, no 960) available versions [1]

--- a/DeepCrazyhouse/configs/train_config_template.py
+++ b/DeepCrazyhouse/configs/train_config_template.py
@@ -6,73 +6,116 @@ Created on 01.11.19
 
 Training configuration file
 """
+from dataclasses import dataclass
 
-#  div factor is a constant which can be used to reduce the batch size and learning rate respectively
-# use a value higher 1 if you encounter memory allocation errors
-div_factor = 2
+@dataclass
+class TrainConfig:
+    """Class which stores all training configuration"""
 
-train_config = {
-    # set the context on CPU, switch to GPU if there is one available (strongly recommended for training)
-    "context": "gpu",
-    "cpu_count": 4,
-    "device_id": 11,
-    # set a specific seed value for reproducibility
-    "seed": 42,
+    # div factor is a constant which can be used to reduce the batch size and learning rate respectively
+    # use a value higher 1 if you encounter memory allocation errors
+    div_factor: int = 2
 
-    "export_weights": True,
-    "log_metrics_to_tensorboard": True,
-    "export_grad_histograms": True,
-    # batch_steps = 1000 means for example that every 1000 batches the validation set gets processed
-    "batch_steps": 100 * div_factor,  # this defines how often a new checkpoint will be saved and the metrics evaluated
-    # k_steps_initial defines how many steps have been trained before
-    # (k_steps_initial != 0 if you continue training from a checkpoint)
-    "k_steps_initial": 0,  # 498
-    # these are the weights to continue training with
-    # symbol_file = 'model_init-symbol.json' #model-1.19246-0.603-symbol.json'
-    # params_file = 'model_init-0000.params' #model-1.19246-0.603-0223.params'
-    "symbol_file": 'model-1.19246-0.603-symbol.json',
-    "params_file": 'model-1.19246-0.603-0223.params',
-
-    "batch_size": int(1024 / div_factor),
     # 1024 # the batch_size needed to be reduced to 1024 in order to fit in the GPU 1080Ti
     # 4096 was originally used in the paper -> works slower for current GPU
     # 2048 was used in the paper Mastering the game of Go without human knowledge and fits in GPU memory
-    # typically if you half the batch_size, you should double the lr
-    #
+    # typically if you half the batch_size you should double the lr
+    batch_size: int = int(1024 / div_factor)
+
+    # batch_steps = 1000 means for example that every 1000 batches the validation set gets processed
+    batch_steps: int = 100 * div_factor  # this defines how often a new checkpoint will be saved and the metrics evaluated
+
+    # set the context on CPU switch to GPU if there is one available (strongly recommended for training)
+    context: str = "gpu"
+
+    cpu_count: int = 4
+
+    # current working directory. If None it calls os.getcwd()
+    cwd: str = None
+
+    device_id: int = 0
+
+    discount: float = 1.0
+
+    export_weights: bool = True
+
+    export_grad_histograms: bool = True
+
+    # Boolean if the policy data is also defined in select_policy_from_plane representation
+    is_policy_from_plane_data: bool = False
+
+    log_metrics_to_tensorboard: bool = True
+
+    # k_steps_initial defines how many steps have been trained before
+    # (k_steps_initial != 0 if you continue training from a checkpoint)
+    k_steps_initial: int = 0  # 498
+    # these are the weights to continue training with
+    # symbol_file = 'model_init-symbol.json' #model-1.19246-0.603-symbol.json'
+    # params_file = 'model_init-0000.params' #model-1.19246-0.603-0223.params'
+    symbol_file: str = 'model-1.19246-0.603-symbol.json'
+    params_file: str = 'model-1.19246-0.603-0223.params'
+
     # # optimization parameters
-    "optimizer_name": "nag",
-    "max_lr": 0.1 / div_factor,  # 0.35 / div_factor
-    "min_lr": 0.00001 / div_factor,  # 0.2 / div_factor  # 0.00001
-    "max_momentum": 0.95,
-    "min_momentum": 0.8,
-    # loads a previous checkpoint if the loss increased significantly
-    "use_spike_recovery": True,
+    optimizer_name: str = "nag"
+    max_lr: float = 0.1 / div_factor  # 0.35 / div_factor
+    min_lr: float = 0.00001 / div_factor  # 0.2 / div_factor  # 0.00001
+    max_momentum: float = 0.95
+    min_momentum: float = 0.8
     # stop training as soon as max_spikes has been reached
-    "max_spikes": 20,
-    # define spike threshold when the detection will be triggered
-    "spike_thresh": 1.5,
-    # weight decay
-    "wd": 1e-4,
-    # dropout_rate = 0  # 0.2
-    # weight the value loss a lot lower than the policy loss in order to prevent overfitting
-    "val_loss_factor": 0.5,  # 0.01
-    "policy_loss_factor": 1,  # 0.99
+    max_spikes: int = 20
+
+    # name initials which are used to identify running training processes with rtpt
+    # prefix for the process name in order to identify the process on a server
+    name_initials: str = "JC"
+
+    nb_parts: int = None
+
+    normalize: bool = True  # define whether to normalize input data to [01]
+    nb_epochs: str = 1  # define how many epochs the network will be trained
+
+    policy_loss_factor: float = 1  # 0.99
+
+    # layer name of the policy output layer without softmax applied (e.g. flatten0 for legacy crazyhouse networks
+    # policy_out for newer networks)
+    policy_output: str = "policy_out"
+
     # ratio for mixing the value return with the corresponding q-value
     # for a ratio of 0 no q-value information will be used
-    "q_value_ratio": 0.15,
-    "discount": 1.0,
+    q_value_ratio: float = 0.15
 
-    "normalize": True,  # define whether to normalize input data to [0,1]
-    "nb_epochs": 1,  # define how many epochs the network will be trained
+    # set a specific seed value for reproducibility
+    seed: int = 42
+    select_policy_from_plane: bool = True  # Boolean if potential legal moves will be selected from final policy output
 
-    "select_policy_from_plane": True,  # Boolean if potential legal moves will be selected from final policy output
+    # define spike threshold when the detection will be triggered
+    spike_thresh: float = 1.5
+
     # Boolean if the policy target is one-hot encoded (sparse=True) or a target distribution (sparse=False)
-    "sparse_policy_label": False,
-    # use_mxnet_style = True  # Decide between mxnet and gluon style for training
-    # layer name of the value output layer (e.g. "value_tanh0" for legacy crazyhouse networks and "value_out" for newer
+    sparse_policy_label: bool = False
+
+    # total of training iterations
+    total_it: int = None
+
+    use_mxnet_style = True  # Decide between mxnet and gluon style for training
+
+    # loads a previous checkpoint if the loss increased significantly
+    use_spike_recovery: bool = True
+    # weight the value loss a lot lower than the policy loss in order to prevent overfitting
+    val_loss_factor: float = 0.5  # 0.01
+
+    # layer name of the value output layer (e.g. value_tanh0 for legacy crazyhouse networks and value_out for newer
     # networks)
-    "value_output": "value_out",
-    # layer name of the policy output layer without softmax applied (e.g. "flatten0" for legacy crazyhouse networks
-    # "policy_out" for newer networks)
-    "policy_output": "policy_out",
-}
+    value_output: str = "value_out"
+
+    # weight decay
+    wd: float = 1e-4
+    # dropout_rate = 0  # 0.2
+
+
+@dataclass
+class TrainObjects:
+    """Defines training objects which must be set before the training"""
+    lr_schedule: object = None  # learning rate schedule
+    momentum_schedule: object = None
+    metrics: object = None
+    variant_metrics: object = None

--- a/DeepCrazyhouse/configs/train_config_template.py
+++ b/DeepCrazyhouse/configs/train_config_template.py
@@ -37,6 +37,8 @@ class TrainConfig:
 
     discount: float = 1.0
 
+    dropout_rate: float = 0
+
     export_weights: bool = True
 
     export_grad_histograms: bool = True
@@ -50,10 +52,10 @@ class TrainConfig:
     # (k_steps_initial != 0 if you continue training from a checkpoint)
     k_steps_initial: int = 0  # 498
     # these are the weights to continue training with
-    # symbol_file = 'model_init-symbol.json' #model-1.19246-0.603-symbol.json'
-    # params_file = 'model_init-0000.params' #model-1.19246-0.603-0223.params'
-    symbol_file: str = 'model-1.19246-0.603-symbol.json'
-    params_file: str = 'model-1.19246-0.603-0223.params'
+    # symbol_file = 'model_init-symbol.json' # model-1.19246-0.603-symbol.json'
+    # params_file = 'model_init-0000.params' # model-1.19246-0.603-0223.params'
+    symbol_file: str = ''
+    params_file: str = ''
 
     # # optimization parameters
     optimizer_name: str = "nag"
@@ -101,7 +103,6 @@ class TrainConfig:
 
     # weight decay
     wd: float = 1e-4
-    # dropout_rate = 0  # 0.2
 
 
 @dataclass

--- a/DeepCrazyhouse/configs/train_config_template.py
+++ b/DeepCrazyhouse/configs/train_config_template.py
@@ -8,6 +8,7 @@ Training configuration file
 """
 from dataclasses import dataclass
 
+
 @dataclass
 class TrainConfig:
     """Class which stores all training configuration"""
@@ -30,7 +31,7 @@ class TrainConfig:
 
     cpu_count: int = 4
 
-    # current working directory. If None it calls os.getcwd()
+    #  Current working directory (must end with "/"). If None it calls os.getcwd()
     cwd: str = None
 
     device_id: int = 0

--- a/DeepCrazyhouse/configs/train_config_template.py
+++ b/DeepCrazyhouse/configs/train_config_template.py
@@ -75,10 +75,6 @@ class TrainConfig:
 
     policy_loss_factor: float = 1  # 0.99
 
-    # layer name of the policy output layer without softmax applied (e.g. flatten0 for legacy crazyhouse networks
-    # policy_out for newer networks)
-    policy_output: str = "policy_out"
-
     # ratio for mixing the value return with the corresponding q-value
     # for a ratio of 0 no q-value information will be used
     q_value_ratio: float = 0.15
@@ -102,10 +98,6 @@ class TrainConfig:
     use_spike_recovery: bool = True
     # weight the value loss a lot lower than the policy loss in order to prevent overfitting
     val_loss_factor: float = 0.5  # 0.01
-
-    # layer name of the value output layer (e.g. value_tanh0 for legacy crazyhouse networks and value_out for newer
-    # networks)
-    value_output: str = "value_out"
 
     # weight decay
     wd: float = 1e-4

--- a/DeepCrazyhouse/configs/train_config_template.py
+++ b/DeepCrazyhouse/configs/train_config_template.py
@@ -115,7 +115,7 @@ class TrainConfig:
 @dataclass
 class TrainObjects:
     """Defines training objects which must be set before the training"""
-    lr_schedule: object = None  # learning rate schedule
-    momentum_schedule: object = None
-    metrics: object = None
-    variant_metrics: object = None
+    lr_schedule = None  # learning rate schedule
+    momentum_schedule = None
+    metrics = None
+    variant_metrics = None

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util_symbol.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util_symbol.py
@@ -39,6 +39,7 @@ def channel_squeeze_excitation(data, channels, name, ratio=16, act_type="relu", 
     """
     return channel_attention_module(data, channels, name, ratio, act_type, use_hard_sigmoid, pool_type="avg")
 
+
 def get_stem(data, channels, act_type):
     """
     Creates the convolution stem before the residual head
@@ -95,6 +96,7 @@ def value_head(data, channels_value_head=4, value_kernelsize=1, act_type='relu',
     value_out = get_act(data=value_out, act_type=act_type, name='value_act1')
     value_out = mx.sym.FullyConnected(data=value_out, num_hidden=1, name='value_fc1')
     value_out = get_act(data=value_out, act_type='tanh', name=main_config["value_output"])
+    value_out = mx.sym.LinearRegressionOutput(data=value_out, name='value', grad_scale=grad_scale_value)
     return value_out
 
 
@@ -124,11 +126,13 @@ def policy_head(data, channels, act_type, channels_policy_head, select_policy_fr
                                     no_bias=no_bias, name="policy_conv1")
     if select_policy_from_plane:
         policy_out = mx.sym.flatten(data=policy_out, name=main_config["policy_output"])
+        policy_out = mx.sym.SoftmaxOutput(data=policy_out, name='policy', grad_scale=grad_scale_policy)
     else:
         policy_out = mx.sym.BatchNorm(data=policy_out, name='policy_bn1')
         policy_out = get_act(data=policy_out, act_type=act_type, name='policy_act1')
         policy_out = mx.sym.Flatten(data=policy_out, name='policy_flatten0')
         policy_out = mx.sym.FullyConnected(data=policy_out, num_hidden=n_labels, name=main_config["policy_output"])
+        policy_out = mx.sym.SoftmaxOutput(data=policy_out, name='policy', grad_scale=grad_scale_policy)
 
     return policy_out
 

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util_symbol.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util_symbol.py
@@ -8,7 +8,7 @@ Utility methods for building the neural network using MXNet symbol API
 """
 
 import mxnet as mx
-from DeepCrazyhouse.configs.train_config import train_config
+from DeepCrazyhouse.configs.main_config import main_config
 
 
 def get_act(data, act_type, name):
@@ -94,7 +94,7 @@ def value_head(data, channels_value_head=4, value_kernelsize=1, act_type='relu',
     value_out = mx.sym.FullyConnected(data=value_flatten, num_hidden=value_fc_size, name='value_fc0')
     value_out = get_act(data=value_out, act_type=act_type, name='value_act1')
     value_out = mx.sym.FullyConnected(data=value_out, num_hidden=1, name='value_fc1')
-    value_out = get_act(data=value_out, act_type='tanh', name=train_config['value_output'])
+    value_out = get_act(data=value_out, act_type='tanh', name=main_config["value_output"])
     value_out = mx.sym.LinearRegressionOutput(data=value_out, name='value', grad_scale=grad_scale_value)
     return value_out
 
@@ -124,11 +124,11 @@ def policy_head(data, channels, act_type, channels_policy_head, select_policy_fr
     if select_policy_from_plane:
         policy_out = mx.sym.Convolution(data=policy_out, num_filter=channels_policy_head, kernel=(3, 3), pad=(1, 1),
                                         no_bias=no_bias, name="policy_conv1")
-        policy_out = mx.sym.flatten(data=policy_out, name=train_config['policy_output'])
+        policy_out = mx.sym.flatten(data=policy_out, name=main_config["policy_output"])
         policy_out = mx.sym.SoftmaxOutput(data=policy_out, name='policy', grad_scale=grad_scale_policy)
     else:
         policy_out = mx.sym.Flatten(data=policy_out, name='policy_flatten0')
-        policy_out = mx.sym.FullyConnected(data=policy_out, num_hidden=n_labels, name=train_config['policy_output'])
+        policy_out = mx.sym.FullyConnected(data=policy_out, num_hidden=n_labels, name=main_config["policy_output"])
         policy_out = mx.sym.SoftmaxOutput(data=policy_out, name='policy', grad_scale=grad_scale_policy)
 
     return policy_out
@@ -267,6 +267,7 @@ def sa_se(data, name, use_hard_sigmoid=False):
     Alias function for spatial_attention_module() with average pooling
     """
     return spatial_attention_module(data, name, use_hard_sigmoid, pool_type="avg")
+
 
 def sm_se(data, name, use_hard_sigmoid=False):
     """

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_builder_util.py
@@ -9,7 +9,10 @@ Utility methods for building the Rise NN
 import mxnet
 from mxnet.gluon.nn import HybridSequential, Conv2D, BatchNorm, Dense, AvgPool2D, MaxPool2D
 from mxnet.gluon import HybridBlock
-from mxnet.gluon.contrib.nn import HybridConcurrent
+try:
+    from mxnet.gluon.contrib.nn import HybridConcurrent
+except ModuleNotFoundError:
+    from mxnet.gluon.nn import HybridConcatenate as HybridConcurrent
 from DeepCrazyhouse.src.domain.neural_net.architectures.builder_util import get_act, get_pool
 
 

--- a/DeepCrazyhouse/src/domain/neural_net/onnx/convert_to_onnx.py
+++ b/DeepCrazyhouse/src/domain/neural_net/onnx/convert_to_onnx.py
@@ -97,13 +97,10 @@ def convert_mxnet_model_to_onnx(sym_file, params_file, output_names, input_shape
     Converts the given model specified by symbol and param file to ONNX format.
     For parameters see: parse_args.
     """
-    net = convert_mxnet_model_to_gluon(sym_file, params_file, output_names)
-    net.export("model")
-
     # convert the gluon mxnet model into onnx
     for batch_size in batch_sizes:
         onnx_file = params_file[:-7] + "-bsize-" + str(batch_size) + ".onnx"
-        onnx_model_path = onnx_mxnet.export_model("model-symbol.json", "model-0000.params",
+        onnx_model_path = onnx_mxnet.export_model(sym_file, params_file,
                                                   [(batch_size, input_shape[0], input_shape[1], input_shape[2])],
                                                   np.float32, onnx_file)
         logging.info("Exported model to: %s" % onnx_model_path)
@@ -117,10 +114,6 @@ def convert_mxnet_model_to_onnx(sym_file, params_file, output_names, input_shape
 
             # check if the converted ONNX-protobuf is valid
             checker.check_graph(model_proto.graph)
-
-    # delete temporary export files
-    os.remove("model-0000.params")
-    os.remove("model-symbol.json")
 
 
 def main():

--- a/DeepCrazyhouse/src/domain/util.py
+++ b/DeepCrazyhouse/src/domain/util.py
@@ -124,7 +124,10 @@ def get_numpy_arrays(pgn_dataset):
     start_indices = np.array(pgn_dataset["start_indices"])
     x = np.array(pgn_dataset["x"])
     y_value = np.array(pgn_dataset["y_value"])
-    y_policy = np.array(pgn_dataset["y_policy"])
+    try:
+        y_policy = np.array(pgn_dataset["y_policy_prediction_risev2_27"])
+    except Exception:
+        y_policy = np.array(pgn_dataset["y_policy"])
 
     possible_entries = ["plys_to_end", "y_best_move_q"]
     entries = [None] * 2

--- a/DeepCrazyhouse/src/training/requirements.txt
+++ b/DeepCrazyhouse/src/training/requirements.txt
@@ -12,3 +12,4 @@ onnx==1.3.0
 ipytree
 setproctitle
 rtpt
+dataclasses

--- a/DeepCrazyhouse/src/training/train_cnn.ipynb
+++ b/DeepCrazyhouse/src/training/train_cnn.ipynb
@@ -39,47 +39,30 @@
     "from __future__ import print_function\n",
     "import sys\n",
     "sys.path.insert(0,'../../../')\n",
-    "import os\n",
-    "import re\n",
     "import glob\n",
     "import chess\n",
-    "import random\n",
     "import logging\n",
-    "import datetime\n",
     "import numpy as np\n",
-    "from time import time\n",
-    "from tqdm import tqdm_notebook\n",
-    "from mxnet import nd, autograd\n",
-    "from collections import deque\n",
+    "from mxnet import nd\n",
     "from copy import deepcopy\n",
-    "from multiprocessing import cpu_count\n",
-    "from time import time\n",
     "import mxnet as mx\n",
     "from mxnet import gluon\n",
-    "from mxnet import autograd as ag\n",
     "try:\n",
     "    import mxnet.metric as metric\n",
     "except ModuleNotFoundError:\n",
-    "    import mxnet.gluon.metric as metric\n",
-    "from mxboard import SummaryWriter\n",
-    "import matplotlib.pyplot as plt\n",
+    "    import mxnet.gluon.metric as metrics\n",
+    "\n",
     "from DeepCrazyhouse.src.domain.variants.input_representation import board_to_planes, planes_to_board\n",
     "from DeepCrazyhouse.src.domain.variants.output_representation import policy_to_moves, policy_to_best_move, policy_to_move\n",
     "from DeepCrazyhouse.src.preprocessing.dataset_loader import load_pgn_dataset\n",
     "from DeepCrazyhouse.src.runtime.color_logger import enable_color_logging\n",
     "from DeepCrazyhouse.src.domain.neural_net.architectures.a0_resnet import AlphaZeroResnet\n",
     "from DeepCrazyhouse.src.domain.neural_net.architectures.mxnet_alpha_zero import alpha_zero_symbol\n",
-    "from DeepCrazyhouse.src.domain.neural_net.architectures.rise_mobile_v2 import rise_mobile_v2_symbol, preact_resnet_symbol\n",
+    "from DeepCrazyhouse.src.domain.neural_net.architectures.rise_mobile_v2 import rise_mobile_v2_symbol\n",
     "from DeepCrazyhouse.src.domain.neural_net.architectures.rise_mobile_v3 import rise_mobile_v3_symbol\n",
-    "from DeepCrazyhouse.src.domain.neural_net.architectures.mixture_net import mixture_net_symbol\n",
-    "from DeepCrazyhouse.src.domain.neural_net.architectures.rise import Rise\n",
-    "from DeepCrazyhouse.src.domain.neural_net.architectures.densenet import DenseNet\n",
-    "from DeepCrazyhouse.src.domain.neural_net.architectures.wide_resnet_se import WideResnetSE\n",
-    "from DeepCrazyhouse.src.domain.neural_net.architectures.shuffle_rise import ShuffleRise\n",
-    "from DeepCrazyhouse.src.preprocessing.pgn_record_dataset import PGNRecordDataset\n",
     "from DeepCrazyhouse.configs.main_config import main_config\n",
     "from DeepCrazyhouse.configs.train_config import TrainConfig, TrainObjects\n",
-    "from DeepCrazyhouse.src.training.trainer_agent import TrainerAgent, evaluate_metrics, acc_sign, reset_metrics\n",
+    "from DeepCrazyhouse.src.training.trainer_agent import TrainerAgent, evaluate_metrics, acc_sign\n",
     "from DeepCrazyhouse.src.training.trainer_agent_mxnet import TrainerAgentMXNET, get_context, prepare_policy\n",
     "from DeepCrazyhouse.src.training.lr_schedules.lr_schedules import *\n",
     "from DeepCrazyhouse.src.domain.variants.plane_policy_representation import FLAT_PLANE_IDX\n",
@@ -123,7 +106,7 @@
     "tc.log_metrics_to_tensorboard = True\n",
     "tc.export_grad_histograms = True\n",
     "tc.div_factor = 1  # div factor is a constant which can be used to reduce the batch size and learning rate respectively\n",
-    "# use a value greater 1 if you enconter memory allocation errors\n",
+    "# use a value greater 1 if you encounter memory allocation errors\n",
     "\n",
     "# batch_steps = 1000 means for example that every 1000 batches the validation set gets processed\n",
     "tc.batch_steps = 1000 * tc.div_factor # this defines how often a new checkpoint will be saved and the metrics evaluated\n",
@@ -162,7 +145,7 @@
     "tc.normalize = True # define whether to normalize input data to [0,1]\n",
     "tc.nb_epochs = 7 # define how many epochs the network will be trained\n",
     "tc.select_policy_from_plane = True # Boolean if potential legal moves will be selected from final policy output\n",
-    "tc.use_mxnet_style = True  # Decide between mxnet and gluon style for training\n",
+    "tc.use_mxnet_style = False  # Decide between mxnet and gluon style for training\n",
     "\n",
     "# additional custom validation set files which will be logged to tensorboard\n",
     "to.variant_metrics = None # [\"chess960\", \"koth\", \"three_check\"]\n",
@@ -173,9 +156,9 @@
     "tc.q_value_ratio = 0\n",
     "        \n",
     "# define if policy training target is one-hot encoded a distribution (e.g. mcts samples, knowledge distillation)\n",
-    "tc.sparse_policy_label = False #True\n",
+    "tc.sparse_policy_label = True\n",
     "# define if the policy data is also defined in \"select_policy_from_plane\" representation\n",
-    "tc.is_policy_from_plane_data = True #False\n",
+    "tc.is_policy_from_plane_data = False\n",
     "tc.name_initials = \"JC\""
    ]
   },
@@ -276,10 +259,16 @@
     "s_idcs_val, x_val, yv_val, yp_val, plys_to_end, pgn_datasets_val = load_pgn_dataset(dataset_type='val', part_id=0,\n",
     "                                                                           verbose=True, normalize=tc.normalize)\n",
     "if tc.discount != 1:\n",
-    "    yv_val *= discount**plys_to_end\n",
-    "    \n",
-    "val_dataset = gluon.data.ArrayDataset(nd.array(x_val), nd.array(yv_val), nd.array(prepare_policy(yp_val, tc.select_policy_from_plane, tc.sparse_policy_label, tc.is_policy_from_plane_data)))\n",
-    "val_data = gluon.data.DataLoader(val_dataset, tc.batch_size, shuffle=False, num_workers=tc.cpu_count)"
+    "    yv_val *= tc.discount**plys_to_end\n",
+    "\n",
+    "if tc.use_mxnet_style:\n",
+    "    if tc.select_policy_from_plane:\n",
+    "        val_iter = mx.io.NDArrayIter({'data': x_val}, {'value_label': yv_val, 'policy_label': np.array(FLAT_PLANE_IDX)[yp_val.argmax(axis=1)]}, tc.batch_size)\n",
+    "    else:\n",
+    "        val_iter = mx.io.NDArrayIter({'data': x_val}, {'value_label': yv_val, 'policy_label': yp_val.argmax(axis=1)}, tc.batch_size)\n",
+    "else:\n",
+    "    val_dataset = gluon.data.ArrayDataset(nd.array(x_val), nd.array(yv_val), nd.array(prepare_policy(yp_val, tc.select_policy_from_plane, tc.sparse_policy_label, tc.is_policy_from_plane_data)))\n",
+    "    val_data = gluon.data.DataLoader(val_dataset, tc.batch_size, shuffle=False, num_workers=tc.cpu_count)"
    ]
   },
   {
@@ -321,9 +310,7 @@
    "source": [
     "to.lr_schedule = OneCycleSchedule(start_lr=tc.max_lr/8, max_lr=tc.max_lr, cycle_length=tc.total_it*.3, cooldown_length=tc.total_it*.6, finish_lr=tc.min_lr)\n",
     "to.lr_schedule = LinearWarmUp(to.lr_schedule, start_lr=tc.min_lr, length=tc.total_it/30)\n",
-    "#plot_schedule(to.lr_schedule, iterations=tc.total_it)\n",
-    "#lr_schedule = ConstantSchedule(min_lr)\n",
-    "#plot_schedule(lr_schedule, iterations=total_it, ylim=[-min_lr, max_lr*1.1])"
+    "plot_schedule(to.lr_schedule, iterations=tc.total_it)"
    ]
   },
   {
@@ -340,8 +327,7 @@
    "outputs": [],
    "source": [
     "to.momentum_schedule = MomentumSchedule(to.lr_schedule, tc.min_lr, tc.max_lr, tc.min_momentum, tc.max_momentum)\n",
-    "#momentum_schedule = ConstantSchedule(min_momentum)\n",
-    "#plot_schedule(to.momentum_schedule, iterations=tc.total_it, ylabel='Momentum')"
+    "plot_schedule(to.momentum_schedule, iterations=tc.total_it, ylabel='Momentum')"
    ]
   },
   {
@@ -386,7 +372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# net = gluon.nn.SymbolBlock.imports(symbol_file='weights/%s'%symbol_file, input_names='data', param_file='weights/%s'%params_file, ctx=ctx)"
+    "symbol = None"
    ]
   },
   {
@@ -404,54 +390,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#et = alpha_zero_resnet(n_labels=2272, channels=256, channels_value_head=1, channels_policy_head=81, num_res_blocks=19, value_fc_size=256, bn_mom=0.9, act_type='relu')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#expand_res_blocks=[3,3,3,5,5,5,5,5,7,7,7,7,7]\n",
-    "#expand_res_blocks=[3,3,7,7,7]\n",
-    "#net = Rise(n_labels=yp_val.shape[1], channels=256, channels_value_head=8, channels_policy_head=81, nb_res_blocks_x=0, nb_res_blocks_x_neck=0, expand_res_blocks=expand_res_blocks, value_fc_size=256, bn_mom=0.9, act_type='relu', squeeze_excitation_type=\"cSE\", select_policy_from_plane=select_policy_from_plane, use_rise_stem=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#net = DenseNet(channels_init=64, growth_rate=24, n_layers=7, bottleneck_factor=4, n_labels=yp_val.shape[1], channels_value_head=4, channels_policy_head=8, value_fc_size=256)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# net = WideResnetSE(n_labels=yp_val.shape[1], channels=512, channels_value_head=4, channels_policy_head=8, nb_res_blocks=6, value_fc_size=512, bn_mom=0.9, act_type='relu', use_se=True, use_rise_stem=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#net = ShuffleRise(n_labels=yp_val.shape[1], channels=64, channels_value_head=4, channels_policy_head=81, nb_res_blocks_x=0, nb_shuffle_blocks=19, nb_shuffle_blocks_neck=0, value_fc_size=256, bn_mom=0.9, act_type='lrelu', squeeze_excitation_type=None, select_policy_from_plane=select_policy_from_plane, use_rise_stem=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#net = PyramidResnetSE(n_labels=2272, channels=256,  channels_value_head=1, channels_policy_head=81, num_res_blocks=19, value_fc_size=256,  bn_mom=0.9, act_type='relu')"
+    "#net = alpha_zero_resnet(n_labels=2272, channels=256, channels_value_head=1, channels_policy_head=81, num_res_blocks=19, value_fc_size=256, bn_mom=0.9, act_type='relu')"
    ]
   },
   {
@@ -477,7 +416,7 @@
     "                      n_labels=NB_LABELS, grad_scale_value=tc.val_loss_factor, grad_scale_policy=tc.policy_loss_factor, select_policy_from_plane=tc.select_policy_from_plane,\n",
     "                      use_se=True, dropout_rate=tc.dropout_rate, use_extra_variant_input=use_extra_variant_input)\n",
     "else:\n",
-    "    symbol = mx.sym.load(\"weights/\" + symbol_file)"
+    "    symbol = mx.sym.load(\"weights/\" + tc.symbol_file)"
    ]
   },
   {
@@ -487,16 +426,16 @@
     "kernels = [\n",
     "    [3],  # 0\n",
     "    [3],  # 1\n",
-    "    [3,5],  # 2\n",
-    "    [3,5],  # 3\n",
-    "    [3,5],  # 4\n",
+    "    [3],  # 2\n",
+    "    [3],  # 3\n",
+    "    [3],  # 4\n",
     "    [3],  # 5\n",
     "    [3],  # 6\n",
     "    [3],  # 7\n",
     "    [3],  # 8\n",
-    "    [3,5],  # 9\n",
-    "    [3,5,7,9],  # 10\n",
-    "    [3,5],  # 11\n",
+    "    [5],  # 9\n",
+    "    [5],  # 10\n",
+    "    [5],  # 11\n",
     "    [3],  # 12\n",
     "]\n",
     "se_types = [\n",
@@ -514,7 +453,7 @@
     "    \"sa_se\",  # 11\n",
     "    None, # 12\n",
     "]\n",
-    "symbol = rise_mobile_v3_symbol(channels=256, channels_operating_init=128, channel_expansion=48, act_type='relu',\n",
+    "symbol = rise_mobile_v3_symbol(channels=256, channels_operating_init=512, channel_expansion=0, act_type='relu',\n",
     "                               channels_value_head=8, value_fc_size=256,\n",
     "                               channels_policy_head=NB_POLICY_MAP_CHANNELS,\n",
     "                               grad_scale_value=tc.val_loss_factor, grad_scale_policy=tc.policy_loss_factor, \n",
@@ -523,44 +462,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#symbol =preact_resnet_symbol(channels=256, channels_value_head=4,\n",
-    "#                   channels_policy_head=81, value_fc_size=256, value_kernelsize=7,res_blocks=19,\n",
-    "#                   act_type='relu', n_labels=2272, grad_scale_value=0.01, grad_scale_policy=0.99,\n",
-    "#                   select_policy_from_plane=select_policy_from_plane)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#symbol = mixture_net_symbol()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "symbol = preact_resnet_symbol(channels=256, channels_value_head=8,\n",
-    "                   channels_policy_head=81, value_fc_size=256, res_blocks=19, act_type='relu',\n",
-    "                   n_labels=4992, grad_scale_value=0.01, grad_scale_policy=0.99, select_policy_from_plane=True)\n",
-    "if symbol_file:\n",
-    "    symbol = mx.sym.load(\"weights/\" + symbol_file)\n",
-    "    # probably change 'policy_loss_factor' and 'val_loss_factor'\n",
-    "    #value_out = symbol.get_internals()['value_out_output']\n",
-    "    #policy_out = symbol.get_internals()['policy_out_output']\n",
-    "    #sym = mx.symbol.Group([value_out, policy_out])\n",
-    "    #policy_out = mx.sym.SoftmaxOutput(data=policy_out, name='policy', grad_scale=policy_loss_factor)\n",
-    "    #value_out = mx.sym.LinearRegressionOutput(data=value_out, name='value', grad_scale=val_loss_factor)\n",
-    "\n",
-    "    # group value_out and policy_out together\n",
-    "    #symbol = mx.symbol.Group([value_out, policy_out])"
+    "### Convert MXNet Symbol to Gluon Network"
    ]
   },
   {
@@ -569,7 +474,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if tc.use_mxnet_style:\n",
+    "if not tc.use_mxnet_style and symbol is not None:\n",
     "    inputs = mx.sym.var('data', dtype='float32')\n",
     "    value_out = symbol.get_internals()[main_config['value_output']+'_output']\n",
     "    policy_out = symbol.get_internals()[main_config['policy_output']+'_output']\n",
@@ -590,7 +495,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(net)"
+    "if not tc.use_mxnet_style:\n",
+    "    print(net)"
    ]
   },
   {
@@ -601,7 +507,7 @@
    },
    "outputs": [],
    "source": [
-    "if tc.use_mxnet_style:\n",
+    "if symbol is not None:\n",
     "    display(mx.viz.plot_network(\n",
     "        symbol,\n",
     "        shape={'data':(1, input_shape[0], input_shape[1], input_shape[2])},\n",
@@ -618,15 +524,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "mx.viz.print_summary(\n",
-    "net(mx.sym.var('data'))[1], \n",
-    "shape={'data':(1, input_shape[0], input_shape[1], input_shape[2])},\n",
-    ") "
+    "if tc.use_mxnet_style:\n",
+    "    mx.viz.print_summary(\n",
+    "        symbol,\n",
+    "        shape={'data':(1, input_shape[0], input_shape[1], input_shape[2])},\n",
+    "    )\n",
+    "else:\n",
+    "    mx.viz.print_summary(\n",
+    "    net(mx.sym.var('data'))[1], \n",
+    "    shape={'data':(1, input_shape[0], input_shape[1], input_shape[2])},\n",
+    "    ) "
    ]
   },
   {
@@ -646,13 +556,13 @@
    "outputs": [],
    "source": [
     "# create a trainable module on compute context\n",
-    "if False: #tc.use_mxnet_style:\n",
+    "if tc.use_mxnet_style:\n",
     "    model = mx.mod.Module(symbol=symbol, context=ctx, label_names=['value_label', 'policy_label'])\n",
-    "    model.bind(for_training=True, data_shapes=[('data', (batch_size, input_shape[0], input_shape[1], input_shape[2]))],\n",
+    "    model.bind(for_training=True, data_shapes=[('data', (tc.batch_size, input_shape[0], input_shape[1], input_shape[2]))],\n",
     "             label_shapes=val_iter.provide_label)\n",
     "    model.init_params(mx.initializer.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24))\n",
     "    if tc.params_file:\n",
-    "        model.load_params(\"weights/\" + params_file)    \n",
+    "        model.load_params(\"weights/\" + tc.params_file)    \n",
     "else:    \n",
     "    # Initializing the parameters\n",
     "    for param in net.collect_params('.*gamma|.*moving_mean|.*moving_var'):\n",
@@ -663,7 +573,7 @@
     "        net.params[param].initialize(mx.init.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24), ctx=ctx)\n",
     "\n",
     "    if tc.params_file:\n",
-    "        net.collect_params().load(\"weights/\" + params_file, ctx)\n",
+    "        net.collect_params().load(\"weights/\" + tc.params_file, ctx)\n",
     "    net.hybridize()"
    ]
   },
@@ -698,7 +608,7 @@
     "'policy_acc': metric.Accuracy(axis=1, name='policy_acc', output_names=['policy_output'],\n",
     "                                       label_names=['policy_label'])\n",
     "}\n",
-    "if False: #use_mxnet_style:\n",
+    "if tc.use_mxnet_style:\n",
     "    to.metrics = metrics_mxnet\n",
     "else:\n",
     "    to.metrics = metrics_gluon"
@@ -717,7 +627,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_agent = TrainerAgent(net, val_data, tc, to)"
+    "if tc.use_mxnet_style:\n",
+    "    train_agent = TrainerAgentMXNET(model, symbol, val_iter, tc, to)\n",
+    "else:\n",
+    "    train_agent = TrainerAgent(net, val_data, tc, to)"
    ]
   },
   {
@@ -733,8 +646,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if False: #tc.use_mxnet_style:\n",
-    "    model.score(val_iter, metrics)"
+    "if tc.use_mxnet_style:\n",
+    "    print(model.score(val_iter, to.metrics))"
    ]
   },
   {
@@ -810,8 +723,8 @@
     "print('load current best model:', model_params_path)\n",
     "symbol = mx.sym.load(model_arch_path)\n",
     "inputs = mx.sym.var('data', dtype='float32')\n",
-    "value_out = symbol.get_internals()[train_config['value_output']+'_output']\n",
-    "policy_out = symbol.get_internals()[train_config['policy_output']+'_output']\n",
+    "value_out = symbol.get_internals()[main_config['value_output']+'_output']\n",
+    "policy_out = symbol.get_internals()[main_config['policy_output']+'_output']\n",
     "sym = mx.symbol.Group([value_out, policy_out])\n",
     "net = mx.gluon.SymbolBlock(sym, inputs)\n",
     "net.collect_params().load(model_params_path, ctx)"
@@ -841,7 +754,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "board = planes_to_board(x_val[idx], normalized_input=normalize, mode=mode)\n",
+    "board = planes_to_board(x_val[idx], normalized_input=tc.normalize, mode=mode)\n",
     "\n",
     "print(chess.COLOR_NAMES[board.turn])\n",
     "if board.uci_variant == \"crazyhouse\":\n",
@@ -874,7 +787,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pred = predict_single(net, x_val[0], select_policy_from_plane)\n",
+    "pred = predict_single(net, x_val[0], tc.select_policy_from_plane)\n",
     "pred"
    ]
   },
@@ -884,7 +797,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pred = predict_single(net, x_val[0], select_policy_from_plane)"
+    "pred = predict_single(net, x_val[0], tc.select_policy_from_plane)"
    ]
   },
   {
@@ -931,7 +844,7 @@
     "board.push_uci('f1c4')\n",
     "board.push_uci('b8c6')\n",
     "board.push_uci('d1h5')\n",
-    "x_scholar_atck = board_to_planes(board, normalize=normalize, mode=mode)\n",
+    "x_scholar_atck = board_to_planes(board, normalize=tc.normalize, mode=mode)\n",
     "board"
    ]
   },
@@ -941,7 +854,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pred = predict_single(net, x_scholar_atck, select_policy_from_plane)\n",
+    "pred = predict_single(net, x_scholar_atck, tc.select_policy_from_plane)\n",
     "\n",
     "selected_moves, probs = policy_to_moves(board, pred[1][0])\n",
     "plt.barh(range(opts)[::-1], probs[:opts])\n",
@@ -976,7 +889,7 @@
     "s_idcs_test, x_test, yv_test, yp_test, _, pgn_datasets_test = load_pgn_dataset(dataset_type='test', part_id=0,\n",
     "                                                                               verbose=True, normalize=True)\n",
     "test_dataset = gluon.data.ArrayDataset(nd.array(x_test), nd.array(yv_test), nd.array(yp_test.argmax(axis=1)))\n",
-    "test_data = gluon.data.DataLoader(test_dataset, batch_size=batch_size, shuffle=True, num_workers=CPU_COUNT)"
+    "test_data = gluon.data.DataLoader(test_dataset, batch_size=tc.batch_size, shuffle=True, num_workers=tc.cpu_count)"
    ]
   },
   {
@@ -987,7 +900,7 @@
    "source": [
     "metrics = metrics_gluon\n",
     "evaluate_metrics(metrics, test_data, net, nb_batches=None, sparse_policy_label=True, ctx=ctx,\n",
-    "                 apply_select_policy_from_plane=select_policy_from_plane)"
+    "                 apply_select_policy_from_plane=tc.select_policy_from_plane)"
    ]
   },
   {
@@ -1004,7 +917,7 @@
    "outputs": [],
    "source": [
     "s_idcs_mate, x_mate, yv_mate, yp_mate, _, pgn_dataset_mate = load_pgn_dataset(dataset_type='mate_in_one', part_id=0,\n",
-    "                                                                              verbose=True, normalize=normalize)"
+    "                                                                              verbose=True, normalize=tc.normalize)"
    ]
   },
   {
@@ -1014,7 +927,7 @@
    "outputs": [],
    "source": [
     "mate_dataset = mx.gluon.data.dataset.ArrayDataset(nd.array(x_mate), nd.array(yv_mate), nd.array(yp_mate.argmax(axis=1)))\n",
-    "mate_data = mx.gluon.data.DataLoader(mate_dataset, batch_size=batch_size, num_workers=CPU_COUNT)"
+    "mate_data = mx.gluon.data.DataLoader(mate_dataset, batch_size=tc.batch_size, num_workers=tc.cpu_count)"
    ]
   },
   {
@@ -1032,7 +945,7 @@
    "source": [
     "metrics = metrics_gluon\n",
     "evaluate_metrics(metrics, mate_data, net, sparse_policy_label=True, ctx=ctx,\n",
-    "                 apply_select_policy_from_plane=select_policy_from_plane)"
+    "                 apply_select_policy_from_plane=tc.select_policy_from_plane)"
    ]
   },
   {
@@ -1067,7 +980,7 @@
    "source": [
     "def eval_pos(net, x_mate, yp_mate, verbose=False, select_policy_from_plane=False):\n",
     "    \n",
-    "    board = planes_to_board(x_mate, normalized_input=normalize, mode=mode)\n",
+    "    board = planes_to_board(x_mate, normalized_input=tc.normalize, mode=mode)\n",
     "    if verbose is True:\n",
     "        print(\"{0}'s turn\".format(chess.COLOR_NAMES[board.turn]))\n",
     "        if board.uci_variant == \"crazyhouse\":\n",
@@ -1125,7 +1038,7 @@
     "mate_mv_cnts = []\n",
     "\n",
     "for i in range(nb_pos):\n",
-    "    pred, pred_moves, true_move, board, is_mate, is_mate_5_top, legal_mv_cnt, mate_mv_cnt= eval_pos(net, x_mate[i], yp_mate[i], select_policy_from_plane=select_policy_from_plane)\n",
+    "    pred, pred_moves, true_move, board, is_mate, is_mate_5_top, legal_mv_cnt, mate_mv_cnt= eval_pos(net, x_mate[i], yp_mate[i], select_policy_from_plane=tc.select_policy_from_plane)\n",
     "    mates_found.append(is_mate)\n",
     "    legal_mv_cnts.append(legal_mv_cnt)\n",
     "    mate_mv_cnts.append(mate_mv_cnt)\n",
@@ -1261,7 +1174,7 @@
    "source": [
     "for i in range(17):\n",
     "    print(clean_string(site_mate[i]))\n",
-    "    pred, pred_moves, true_move, board, is_checkmate, is_mate_5_top, legal_move_cnt, mate_move_cnt = eval_pos(net, x_mate[i], yp_mate[i], verbose=True, select_policy_from_plane=select_policy_from_plane)\n",
+    "    pred, pred_moves, true_move, board, is_checkmate, is_mate_5_top, legal_move_cnt, mate_move_cnt = eval_pos(net, x_mate[i], yp_mate[i], verbose=True, select_policy_from_plane=tc.select_policy_from_plane)\n",
     "    pred_move = pred_moves[0]\n",
     "    pred_arrow = chess.svg.Arrow(pred_move.from_square, pred_move.to_square)\n",
     "    SVG(data=chess.svg.board(board=board, arrows=[pred_arrow], size=400))"
@@ -1284,11 +1197,11 @@
    "source": [
     "mate_missed = 0\n",
     "for i in range(1000):\n",
-    "    pred, pred_moves, true_move, board, is_checkmate, is_mate_5_top, legal_move_cnt, mate_move_cnt = eval_pos(net, x_mate[i], yp_mate[i], verbose=False, select_policy_from_plane=select_policy_from_plane)\n",
+    "    pred, pred_moves, true_move, board, is_checkmate, is_mate_5_top, legal_move_cnt, mate_move_cnt = eval_pos(net, x_mate[i], yp_mate[i], verbose=False, select_policy_from_plane=tc.select_policy_from_plane)\n",
     "    if is_mate_5_top is False:\n",
     "        mate_missed += 1\n",
     "        print(clean_string(site_mate[i]))\n",
-    "        pred, pred_moves, true_move, board, is_checkmate, is_mate_5_top, legal_move_cnt, mate_move_cnt = eval_pos(net, x_mate[i], yp_mate[i], verbose=True, select_policy_from_plane=select_policy_from_plane)\n",
+    "        pred, pred_moves, true_move, board, is_checkmate, is_mate_5_top, legal_move_cnt, mate_move_cnt = eval_pos(net, x_mate[i], yp_mate[i], verbose=True, select_policy_from_plane=tc.select_policy_from_plane)\n",
     "        pred_move = pred_moves[0]\n",
     "        pred_arrow = chess.svg.Arrow(pred_move.from_square, pred_move.to_square)\n",
     "        SVG(data=chess.svg.board(board=board, arrows=[pred_arrow], size=400))\n",
@@ -1321,6 +1234,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.6"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
   }
  },
  "nbformat": 4,

--- a/DeepCrazyhouse/src/training/train_cnn.ipynb
+++ b/DeepCrazyhouse/src/training/train_cnn.ipynb
@@ -74,8 +74,9 @@
     "from DeepCrazyhouse.src.domain.neural_net.architectures.shuffle_rise import ShuffleRise\n",
     "from DeepCrazyhouse.src.preprocessing.pgn_record_dataset import PGNRecordDataset\n",
     "from DeepCrazyhouse.configs.main_config import main_config\n",
+    "from DeepCrazyhouse.configs.train_config import TrainConfig, TrainObjects\n",
     "from DeepCrazyhouse.src.training.trainer_agent import TrainerAgent, evaluate_metrics, acc_sign, reset_metrics\n",
-    "from DeepCrazyhouse.src.training.trainer_agent_mxnet import TrainerAgentMXNET\n",
+    "from DeepCrazyhouse.src.training.trainer_agent_mxnet import TrainerAgentMXNET, get_context\n",
     "from DeepCrazyhouse.src.training.lr_schedules.lr_schedules import *\n",
     "from DeepCrazyhouse.src.domain.variants.plane_policy_representation import FLAT_PLANE_IDX\n",
     "from DeepCrazyhouse.src.domain.variants.constants import NB_POLICY_MAP_CHANNELS, NB_LABELS\n",
@@ -97,64 +98,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# set the context on CPU, switch to GPU if there is one available (strongly recommended for training)\n",
-    "ctx = mx.gpu(9)\n",
-    "# set a specific seed value for reproducibility\n",
-    "seed = 7 # 42\n",
-    "\n",
-    "export_weights = True\n",
-    "log_metrics_to_tensorboard = True\n",
-    "export_grad_histograms = True\n",
-    "div_factor = 1  # div factor is a constant which can be used to reduce the batch size and learning rate respectively\n",
-    "# use a value smaller 1 if you enconter memory allocation errors\n",
-    "\n",
-    "# batch_steps = 1000 means for example that every 1000 batches the validation set gets processed\n",
-    "batch_steps = 1000 * div_factor # this defines how often a new checkpoint will be saved and the metrics evaluated\n",
-    "# k_steps_initial defines how many steps have been trained before\n",
-    "# (k_steps_initial != 0 if you continue training from a checkpoint)\n",
-    "k_steps_initial = 0\n",
-    "cur_it = k_steps_initial * batch_steps # iteration counter used for the momentum and learning rate schedule\n",
-    "# these are the weights to continue training with\n",
-    "symbol_file = None # 'model-0.81901-0.713-symbol.json'\n",
-    "params_file = None #'model-0.81901-0.713-0498.params'\n",
-    "\n",
-    "batch_size = int(1024 / div_factor) # 1024 # the batch_size needed to be reduced to 1024 in order to fit in the GPU 1080Ti\n",
-    "#4096 was originally used in the paper -> works slower for current GPU\n",
-    "# 2048 was used in the paper Mastering the game of Go without human knowledge and fits in GPU memory\n",
-    "#typically if you half the batch_size, you should double the lr\n",
-    "\n",
-    "# optimization parameters\n",
-    "optimizer_name = \"nag\"\n",
-    "max_lr = 0.35 / div_factor #0.01 # default lr for adam\n",
-    "min_lr = 0.00001\n",
-    "max_momentum = 0.95\n",
-    "min_momentum = 0.8\n",
-    "# loads a previous checkpoint if the loss increased significanly\n",
-    "use_spike_recovery = True\n",
-    "# stop training as soon as max_spikes has been reached\n",
-    "max_spikes = 20\n",
-    "# define spike threshold when the detection will be triggered\n",
-    "spike_thresh = 1.5\n",
-    "# weight decay\n",
-    "wd = 1e-4\n",
-    "dropout_rate = 0 #0.15\n",
-    "# weight the value loss a lot lower than the policy loss in order to prevent overfitting\n",
-    "val_loss_factor = 0.01\n",
-    "policy_loss_factor = 0.99\n",
-    "discount = 1.0\n",
-    "\n",
-    "normalize = True # define whether to normalize input data to [0,1]\n",
-    "nb_epochs = 7 # define how many epochs the network will be trained\n",
-    "\n",
-    "select_policy_from_plane = True # Boolean if potential legal moves will be selected from final policy output\n",
-    "use_mxnet_style = True # Decide between mxnet and gluon style for training\n",
-    "mode = main_config[\"mode\"]\n",
-    "\n",
-    "# additional custom validation set files which will be logged to tensorboard\n",
-    "variant_metrics = None #[\"chess960\", \"koth\", \"three_check\"]\n",
-    "# if use_extra_variant_input is true the current active variant is passed two each residual block and\n",
-    "# concatenated at the end of the final feature representation\n",
-    "use_extra_variant_input = False"
+    "tc = TrainConfig()\n",
+    "to = TrainObjects()"
    ]
   },
   {
@@ -163,6 +108,77 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# set the context on CPU, switch to GPU if there is one available (strongly recommended for training)\n",
+    "tc.ctx = mx.cpu() #mx.gpu(0)\n",
+    "# set a specific seed value for reproducibility\n",
+    "tc.seed = 7 # 42\n",
+    "\n",
+    "tc.export_weights = True\n",
+    "tc.log_metrics_to_tensorboard = True\n",
+    "tc.export_grad_histograms = True\n",
+    "tc.div_factor = 100  # div factor is a constant which can be used to reduce the batch size and learning rate respectively\n",
+    "# use a value greater 1 if you enconter memory allocation errors\n",
+    "\n",
+    "# batch_steps = 1000 means for example that every 1000 batches the validation set gets processed\n",
+    "tc.batch_steps = 1000 * div_factor # this defines how often a new checkpoint will be saved and the metrics evaluated\n",
+    "# k_steps_initial defines how many steps have been trained before\n",
+    "# (k_steps_initial != 0 if you continue training from a checkpoint)\n",
+    "tc.k_steps_initial = 0\n",
+    "tc.cur_it = k_steps_initial * batch_steps # iteration counter used for the momentum and learning rate schedule\n",
+    "# these are the weights to continue training with\n",
+    "tc.symbol_file = None # 'model-0.81901-0.713-symbol.json'\n",
+    "tc.params_file = None #'model-0.81901-0.713-0498.params'\n",
+    "\n",
+    "tc.batch_size = int(1024 / div_factor) # 1024 # the batch_size needed to be reduced to 1024 in order to fit in the GPU 1080Ti\n",
+    "#4096 was originally used in the paper -> works slower for current GPU\n",
+    "# 2048 was used in the paper Mastering the game of Go without human knowledge and fits in GPU memory\n",
+    "#typically if you half the batch_size, you should double the lr\n",
+    "\n",
+    "# optimization parameters\n",
+    "tc.optimizer_name = \"nag\"\n",
+    "tc.max_lr = 0.35 / div_factor #0.01 # default lr for adam\n",
+    "tc.min_lr = 0.00001\n",
+    "tc.max_momentum = 0.95\n",
+    "tc.min_momentum = 0.8\n",
+    "# loads a previous checkpoint if the loss increased significanly\n",
+    "tc.use_spike_recovery = True\n",
+    "# stop training as soon as max_spikes has been reached\n",
+    "tc.max_spikes = 20\n",
+    "# define spike threshold when the detection will be triggered\n",
+    "tc.spike_thresh = 1.5\n",
+    "# weight decay\n",
+    "tc.wd = 1e-4\n",
+    "tc.dropout_rate = 0 #0.15\n",
+    "# weight the value loss a lot lower than the policy loss in order to prevent overfitting\n",
+    "tc.val_loss_factor = 0.01\n",
+    "tc.policy_loss_factor = 0.99\n",
+    "tc.discount = 1.0\n",
+    "\n",
+    "tc.normalize = True # define whether to normalize input data to [0,1]\n",
+    "tc.nb_epochs = 7 # define how many epochs the network will be trained\n",
+    "tc.select_policy_from_plane = True # Boolean if potential legal moves will be selected from final policy output\n",
+    "tc.use_mxnet_style = True  # Decide between mxnet and gluon style for training\n",
+    "\n",
+    "# additional custom validation set files which will be logged to tensorboard\n",
+    "to.variant_metrics = None # [\"chess960\", \"koth\", \"three_check\"]\n",
+    "# if use_extra_variant_input is true the current active variant is passed two each residual block and\n",
+    "\n",
+    "# define if policy training target is one-hot encoded a distribution (e.g. mcts samples, knowledge distillation)\n",
+    "tc.sparse_policy_label = True\n",
+    "# define if the policy data is also defined in \"select_policy_from_plane\" representation\n",
+    "tc.is_policy_from_plane_data = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mode = main_config[\"mode\"]\n",
+    "ctx = get_context(tc.context, tc.device_id)\n",
+    "# concatenated at the end of the final feature representation\n",
+    "use_extra_variant_input = False\n",
     "# Fixing the random seed\n",
     "mx.random.seed(seed)"
    ]
@@ -196,7 +212,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### load the config file"
+    "### Show the config files"
    ]
   },
   {
@@ -206,6 +222,24 @@
    "outputs": [],
    "source": [
     "print(main_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(tc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(to)"
    ]
   },
   {
@@ -243,7 +277,7 @@
     "                                                                           verbose=True, normalize=normalize)\n",
     "if discount != 1:\n",
     "    yv_val *= discount**plys_to_end\n",
-    "if use_mxnet_style:\n",
+    "if tc.use_mxnet_style:\n",
     "    if select_policy_from_plane:\n",
     "        val_iter = mx.io.NDArrayIter({'data': x_val}, {'value_label': yv_val, 'policy_label': np.array(FLAT_PLANE_IDX)[yp_val.argmax(axis=1)]}, batch_size)\n",
     "    else:\n",
@@ -268,8 +302,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nb_parts = len(glob.glob(main_config['planes_train_dir'] + '**/*'))\n",
-    "nb_parts"
+    "tc.nb_parts = len(glob.glob(main_config['planes_train_dir'] + '**/*'))\n",
+    "tc.nb_parts"
    ]
   },
   {
@@ -278,10 +312,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nb_it_per_epoch = (len(x_val) * nb_parts) // batch_size # calculate how many iterations per epoch exist\n",
+    "nb_it_per_epoch = (len(x_val) * tc.nb_parts) // tc.batch_size # calculate how many iterations per epoch exist\n",
     "# one iteration is defined by passing 1 batch and doing backprop\n",
-    "total_it = int(nb_it_per_epoch * nb_epochs)\n",
-    "total_it"
+    "tc.total_it = int(nb_it_per_epoch * tc.nb_epochs)\n",
+    "tc.total_it"
    ]
   },
   {
@@ -299,9 +333,9 @@
    },
    "outputs": [],
    "source": [
-    "lr_schedule = OneCycleSchedule(start_lr=max_lr/8, max_lr=max_lr, cycle_length=total_it*.3, cooldown_length=total_it*.6, finish_lr=min_lr)\n",
-    "lr_schedule = LinearWarmUp(lr_schedule, start_lr=min_lr, length=total_it/30)\n",
-    "plot_schedule(lr_schedule, iterations=total_it)\n",
+    "to.lr_schedule = OneCycleSchedule(start_lr=tc.max_lr/8, max_lr=tc.max_lr, cycle_length=tc.total_it*.3, cooldown_length=tc.total_it*.6, finish_lr=tc.min_lr)\n",
+    "to.lr_schedule = LinearWarmUp(to.lr_schedule, start_lr=tc.min_lr, length=tc.total_it/30)\n",
+    "plot_schedule(to.lr_schedule, iterations=tc.total_it)\n",
     "#lr_schedule = ConstantSchedule(min_lr)\n",
     "#plot_schedule(lr_schedule, iterations=total_it, ylim=[-min_lr, max_lr*1.1])"
    ]
@@ -319,9 +353,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "momentum_schedule = MomentumSchedule(lr_schedule, min_lr, max_lr, min_momentum, max_momentum)\n",
+    "to.momentum_schedule = MomentumSchedule(to.lr_schedule, tc.min_lr, tc.max_lr, tc.min_momentum, tc.max_momentum)\n",
     "#momentum_schedule = ConstantSchedule(min_momentum)\n",
-    "plot_schedule(momentum_schedule, iterations=total_it, ylabel='Momentum')"
+    "plot_schedule(to.momentum_schedule, iterations=tc.total_it, ylabel='Momentum')"
    ]
   },
   {
@@ -556,7 +590,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if not use_mxnet_style:\n",
+    "if not tc.use_mxnet_style:\n",
     "    print(net)"
    ]
   },
@@ -568,7 +602,7 @@
    },
    "outputs": [],
    "source": [
-    "if use_mxnet_style:\n",
+    "if tc.use_mxnet_style:\n",
     "    display(mx.viz.plot_network(\n",
     "        symbol,\n",
     "        shape={'data':(1, input_shape[0], input_shape[1], input_shape[2])},\n",
@@ -590,7 +624,7 @@
    },
    "outputs": [],
    "source": [
-    "if use_mxnet_style:\n",
+    "if tc.use_mxnet_style:\n",
     "    mx.viz.print_summary(\n",
     "        symbol,\n",
     "        shape={'data':(1, input_shape[0], input_shape[1], input_shape[2])},\n",
@@ -619,7 +653,7 @@
    "outputs": [],
    "source": [
     "# create a trainable module on compute context\n",
-    "if use_mxnet_style:\n",
+    "if tc.use_mxnet_style:\n",
     "    model = mx.mod.Module(symbol=symbol, context=ctx, label_names=['value_label', 'policy_label'])\n",
     "    model.bind(for_training=True, data_shapes=[('data', (batch_size, input_shape[0], input_shape[1], input_shape[2]))],\n",
     "             label_shapes=val_iter.provide_label)\n",
@@ -663,9 +697,9 @@
     "                                       label_names=['policy_label'])\n",
     "}\n",
     "if use_mxnet_style:\n",
-    "    metrics = metrics_mxnet\n",
+    "    to.metrics = metrics_mxnet\n",
     "else:\n",
-    "    metrics = metrics_gluon"
+    "    to.metrics = metrics_gluon"
    ]
   },
   {
@@ -681,19 +715,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if use_mxnet_style:\n",
-    "    train_agent = TrainerAgentMXNET(model, symbol, val_iter, nb_parts, lr_schedule, momentum_schedule, total_it, optimizer_name, wd=wd, batch_steps=batch_steps,\n",
-    "                 k_steps_initial=k_steps_initial, cpu_count=CPU_COUNT-3, batch_size=batch_size, normalize=normalize, export_weights=export_weights,\n",
-    "                 export_grad_histograms=export_grad_histograms, log_metrics_to_tensorboard=log_metrics_to_tensorboard, ctx=ctx, metrics=metrics,\n",
-    "                use_spike_recovery=use_spike_recovery, max_spikes=max_spikes, spike_thresh=spike_thresh, seed=seed,\n",
-    "                val_loss_factor=val_loss_factor, policy_loss_factor=policy_loss_factor, select_policy_from_plane=select_policy_from_plane, discount=discount,\n",
-    "                variant_metrics=variant_metrics)\n",
+    "if tc.use_mxnet_style:\n",
+    "    train_agent = TrainerAgentMXNET(model, symbol, val_iter, tc, to)\n",
     "else:\n",
-    "    train_agent = TrainerAgent(net, val_data, nb_parts, lr_schedule, momentum_schedule, total_it, optimizer_name, wd=wd, batch_steps=batch_steps,\n",
-    "                     k_steps_initial=k_steps_initial, cpu_count=CPU_COUNT-3, batch_size=batch_size, normalize=normalize, export_weights=export_weights,\n",
-    "                     export_grad_histograms=export_grad_histograms, log_metrics_to_tensorboard=log_metrics_to_tensorboard, ctx=ctx, metrics=metrics,\n",
-    "                    use_spike_recovery=use_spike_recovery, max_spikes=max_spikes, spike_thresh=spike_thresh, seed=seed,\n",
-    "                               val_loss_factor=val_loss_factor, policy_loss_factor=policy_loss_factor, select_policy_from_plane=select_policy_from_plane)"
+    "    train_agent = TrainerAgent(net, val_data, tc, to)"
    ]
   },
   {
@@ -709,7 +734,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.score(val_iter, metrics)"
+    "if tc.use_mxnet_style:\n",
+    "    model.score(val_iter, metrics)"
    ]
   },
   {
@@ -745,7 +771,7 @@
    "source": [
     "prefix = \"./weights/model-%.5f-%.3f\" % (policy_loss_final, val_p_acc_final)\n",
     "\n",
-    "if use_mxnet_style:\n",
+    "if tc.use_mxnet_style:\n",
     "    # the export function saves both the architecture and the weights\n",
     "    model.save_checkpoint(prefix, epoch=k_steps_final)\n",
     "else:\n",
@@ -768,7 +794,7 @@
    "outputs": [],
    "source": [
     "# delete the current net object form memory\n",
-    "if not use_mxnet_style:\n",
+    "if not tc.use_mxnet_style:\n",
     "    del net\n",
     "    del model"
    ]
@@ -785,8 +811,8 @@
     "print('load current best model:', model_params_path)\n",
     "symbol = mx.sym.load(model_arch_path)\n",
     "inputs = mx.sym.var('data', dtype='float32')\n",
-    "value_out = symbol.get_internals()['value_out_output'] #value_tanh0_output']\n",
-    "policy_out = symbol.get_internals()['policy_out_output'] #flatten0_output']\n",
+    "value_out = symbol.get_internals()[train_config['value_output']+'_output']\n",
+    "policy_out = symbol.get_internals()[train_config['policy_output']+'_output']\n",
     "sym = mx.symbol.Group([value_out, policy_out])\n",
     "net = mx.gluon.SymbolBlock(sym, inputs)\n",
     "net.collect_params().load(model_params_path, ctx) #, allow_missing=True)"
@@ -1295,7 +1321,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/DeepCrazyhouse/src/training/train_cnn.ipynb
+++ b/DeepCrazyhouse/src/training/train_cnn.ipynb
@@ -57,6 +57,10 @@
     "import mxnet as mx\n",
     "from mxnet import gluon\n",
     "from mxnet import autograd as ag\n",
+    "try:\n",
+    "    import mxnet.metric as metric\n",
+    "except ModuleNotFoundError:\n",
+    "    import mxnet.gluon.metric as metric\n",
     "from mxboard import SummaryWriter\n",
     "import matplotlib.pyplot as plt\n",
     "from DeepCrazyhouse.src.domain.variants.input_representation import board_to_planes, planes_to_board\n",
@@ -76,7 +80,7 @@
     "from DeepCrazyhouse.configs.main_config import main_config\n",
     "from DeepCrazyhouse.configs.train_config import TrainConfig, TrainObjects\n",
     "from DeepCrazyhouse.src.training.trainer_agent import TrainerAgent, evaluate_metrics, acc_sign, reset_metrics\n",
-    "from DeepCrazyhouse.src.training.trainer_agent_mxnet import TrainerAgentMXNET, get_context\n",
+    "from DeepCrazyhouse.src.training.trainer_agent_mxnet import TrainerAgentMXNET, get_context, prepare_policy\n",
     "from DeepCrazyhouse.src.training.lr_schedules.lr_schedules import *\n",
     "from DeepCrazyhouse.src.domain.variants.plane_policy_representation import FLAT_PLANE_IDX\n",
     "from DeepCrazyhouse.src.domain.variants.constants import NB_POLICY_MAP_CHANNELS, NB_LABELS\n",
@@ -109,34 +113,35 @@
    "outputs": [],
    "source": [
     "# set the context on CPU, switch to GPU if there is one available (strongly recommended for training)\n",
-    "tc.ctx = mx.cpu() #mx.gpu(0)\n",
+    "tc.context = \"cpu\"\n",
+    "tc.device_id = 0\n",
+    "\n",
     "# set a specific seed value for reproducibility\n",
     "tc.seed = 7 # 42\n",
     "\n",
     "tc.export_weights = True\n",
     "tc.log_metrics_to_tensorboard = True\n",
     "tc.export_grad_histograms = True\n",
-    "tc.div_factor = 100  # div factor is a constant which can be used to reduce the batch size and learning rate respectively\n",
+    "tc.div_factor = 1000  # div factor is a constant which can be used to reduce the batch size and learning rate respectively\n",
     "# use a value greater 1 if you enconter memory allocation errors\n",
     "\n",
     "# batch_steps = 1000 means for example that every 1000 batches the validation set gets processed\n",
-    "tc.batch_steps = 1000 * div_factor # this defines how often a new checkpoint will be saved and the metrics evaluated\n",
+    "tc.batch_steps = 1000 * tc.div_factor # this defines how often a new checkpoint will be saved and the metrics evaluated\n",
     "# k_steps_initial defines how many steps have been trained before\n",
     "# (k_steps_initial != 0 if you continue training from a checkpoint)\n",
     "tc.k_steps_initial = 0\n",
-    "tc.cur_it = k_steps_initial * batch_steps # iteration counter used for the momentum and learning rate schedule\n",
     "# these are the weights to continue training with\n",
     "tc.symbol_file = None # 'model-0.81901-0.713-symbol.json'\n",
     "tc.params_file = None #'model-0.81901-0.713-0498.params'\n",
     "\n",
-    "tc.batch_size = int(1024 / div_factor) # 1024 # the batch_size needed to be reduced to 1024 in order to fit in the GPU 1080Ti\n",
+    "tc.batch_size = int(1024 / tc.div_factor) # 1024 # the batch_size needed to be reduced to 1024 in order to fit in the GPU 1080Ti\n",
     "#4096 was originally used in the paper -> works slower for current GPU\n",
     "# 2048 was used in the paper Mastering the game of Go without human knowledge and fits in GPU memory\n",
     "#typically if you half the batch_size, you should double the lr\n",
     "\n",
     "# optimization parameters\n",
     "tc.optimizer_name = \"nag\"\n",
-    "tc.max_lr = 0.35 / div_factor #0.01 # default lr for adam\n",
+    "tc.max_lr = 0.35 / tc.div_factor #0.01 # default lr for adam\n",
     "tc.min_lr = 0.00001\n",
     "tc.max_momentum = 0.95\n",
     "tc.min_momentum = 0.8\n",
@@ -163,6 +168,10 @@
     "to.variant_metrics = None # [\"chess960\", \"koth\", \"three_check\"]\n",
     "# if use_extra_variant_input is true the current active variant is passed two each residual block and\n",
     "\n",
+    "# ratio for mixing the value return with the corresponding q-value\n",
+    "# for a ratio of 0 no q-value information will be used\n",
+    "tc.q_value_ratio = 0\n",
+    "        \n",
     "# define if policy training target is one-hot encoded a distribution (e.g. mcts samples, knowledge distillation)\n",
     "tc.sparse_policy_label = True\n",
     "# define if the policy data is also defined in \"select_policy_from_plane\" representation\n",
@@ -179,8 +188,9 @@
     "ctx = get_context(tc.context, tc.device_id)\n",
     "# concatenated at the end of the final feature representation\n",
     "use_extra_variant_input = False\n",
+    "cur_it = tc.k_steps_initial * tc.batch_steps # iteration counter used for the momentum and learning rate schedule\n",
     "# Fixing the random seed\n",
-    "mx.random.seed(seed)"
+    "mx.random.seed(tc.seed)"
    ]
   },
   {
@@ -243,17 +253,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "CPU_COUNT = 6\n",
-    "#if use_mxnet_style:\n",
-    "#    os.environ[\"MXNET_CPU_WORKER_NTHREADS\"] = str(CPU_COUNT) "
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -274,17 +273,12 @@
    "outputs": [],
    "source": [
     "s_idcs_val, x_val, yv_val, yp_val, plys_to_end, pgn_datasets_val = load_pgn_dataset(dataset_type='val', part_id=0,\n",
-    "                                                                           verbose=True, normalize=normalize)\n",
-    "if discount != 1:\n",
+    "                                                                           verbose=True, normalize=tc.normalize)\n",
+    "if tc.discount != 1:\n",
     "    yv_val *= discount**plys_to_end\n",
-    "if tc.use_mxnet_style:\n",
-    "    if select_policy_from_plane:\n",
-    "        val_iter = mx.io.NDArrayIter({'data': x_val}, {'value_label': yv_val, 'policy_label': np.array(FLAT_PLANE_IDX)[yp_val.argmax(axis=1)]}, batch_size)\n",
-    "    else:\n",
-    "        val_iter = mx.io.NDArrayIter({'data': x_val}, {'value_label': yv_val, 'policy_label': yp_val.argmax(axis=1)}, batch_size)\n",
-    "else:\n",
-    "    val_dataset = gluon.data.ArrayDataset(nd.array(x_val), nd.array(yv_val), nd.array(yp_val.argmax(axis=1)))\n",
-    "    val_data = gluon.data.DataLoader(val_dataset, batch_size, shuffle=False, num_workers=CPU_COUNT)"
+    "    \n",
+    "val_dataset = gluon.data.ArrayDataset(nd.array(x_val), nd.array(yv_val), nd.array(prepare_policy(yp_val, tc.select_policy_from_plane, tc.sparse_policy_label, tc.is_policy_from_plane_data)))\n",
+    "val_data = gluon.data.DataLoader(val_dataset, tc.batch_size, shuffle=False, num_workers=tc.cpu_count)"
    ]
   },
   {
@@ -531,8 +525,8 @@
     "symbol = rise_mobile_v3_symbol(channels=256, channels_operating_init=128, channel_expansion=48, act_type='relu',\n",
     "                               channels_value_head=8, value_fc_size=256,\n",
     "                               channels_policy_head=NB_POLICY_MAP_CHANNELS,\n",
-    "                               grad_scale_value=val_loss_factor, grad_scale_policy=policy_loss_factor, \n",
-    "                               dropout_rate=dropout_rate, select_policy_from_plane=True,\n",
+    "                               grad_scale_value=tc.val_loss_factor, grad_scale_policy=tc.policy_loss_factor, \n",
+    "                               dropout_rate=tc.dropout_rate, select_policy_from_plane=True,\n",
     "                               kernels=kernels, se_ratio=4, se_types=se_types)"
    ]
   },
@@ -578,6 +572,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if tc.use_mxnet_style:\n",
+    "    inputs = mx.sym.var('data', dtype='float32')\n",
+    "    value_out = symbol.get_internals()[main_config['value_output']+'_output']\n",
+    "    policy_out = symbol.get_internals()[main_config['policy_output']+'_output']\n",
+    "    sym = mx.symbol.Group([value_out, policy_out])\n",
+    "    net = mx.gluon.SymbolBlock(sym, inputs)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -590,8 +598,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if not tc.use_mxnet_style:\n",
-    "    print(net)"
+    "print(net)"
    ]
   },
   {
@@ -624,16 +631,10 @@
    },
    "outputs": [],
    "source": [
-    "if tc.use_mxnet_style:\n",
-    "    mx.viz.print_summary(\n",
-    "        symbol,\n",
-    "        shape={'data':(1, input_shape[0], input_shape[1], input_shape[2])},\n",
-    "    )\n",
-    "else:\n",
-    "    mx.viz.print_summary(\n",
-    "    net(mx.sym.var('data'))[1], \n",
-    "    shape={'data':(1, input_shape[0], input_shape[1], input_shape[2])},\n",
-    "    ) "
+    "mx.viz.print_summary(\n",
+    "net(mx.sym.var('data'))[1], \n",
+    "shape={'data':(1, input_shape[0], input_shape[1], input_shape[2])},\n",
+    ") "
    ]
   },
   {
@@ -653,15 +654,21 @@
    "outputs": [],
    "source": [
     "# create a trainable module on compute context\n",
-    "if tc.use_mxnet_style:\n",
+    "if False: #tc.use_mxnet_style:\n",
     "    model = mx.mod.Module(symbol=symbol, context=ctx, label_names=['value_label', 'policy_label'])\n",
     "    model.bind(for_training=True, data_shapes=[('data', (batch_size, input_shape[0], input_shape[1], input_shape[2]))],\n",
     "             label_shapes=val_iter.provide_label)\n",
     "    model.init_params(mx.initializer.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24))\n",
-    "    if params_file:\n",
+    "    if tc.params_file:\n",
     "        model.load_params(\"weights/\" + params_file)    \n",
-    "else:\n",
-    "    net.collect_params().initialize(mx.init.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24), ctx=ctx)\n",
+    "else:    \n",
+    "    # Initializing the parameters\n",
+    "    net.collect_params('.*gamma|.*moving_mean|.*moving_var').initialize(mx.initializer.Constant(1))\n",
+    "    net.collect_params('.*beta|.*bias').initialize(mx.initializer.Constant(0))\n",
+    "    net.collect_params('.*weight').initialize(mx.init.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24))\n",
+    "    \n",
+    "    if tc.params_file:\n",
+    "        net.collect_params().load(\"weights/\" + params_file, ctx)\n",
     "    net.hybridize()"
    ]
   },
@@ -679,24 +686,24 @@
    "outputs": [],
    "source": [
     "metrics_mxnet = [\n",
-    "mx.metric.MSE(name='value_loss', output_names=['value_output'], label_names=['value_label']),\n",
-    "mx.metric.CrossEntropy(name='policy_loss', output_names=['policy_output'],\n",
+    "metric.MSE(name='value_loss', output_names=['value_output'], label_names=['value_label']),\n",
+    "metric.CrossEntropy(name='policy_loss', output_names=['policy_output'],\n",
     "                                            label_names=['policy_label']),\n",
-    "mx.metric.create(acc_sign, name='value_acc_sign', output_names=['value_output'],\n",
+    "metric.create(acc_sign, name='value_acc_sign', output_names=['value_output'],\n",
     "                                         label_names=['value_label']),\n",
-    "mx.metric.Accuracy(axis=1, name='policy_acc', output_names=['policy_output'],\n",
+    "metric.Accuracy(axis=1, name='policy_acc', output_names=['policy_output'],\n",
     "                                       label_names=['policy_label'])\n",
     "]\n",
     "metrics_gluon = {\n",
-    "'value_loss': mx.metric.MSE(name='value_loss', output_names=['value_output']),\n",
-    "'policy_loss': mx.metric.CrossEntropy(name='policy_loss', output_names=['policy_output'],\n",
+    "'value_loss': metric.MSE(name='value_loss', output_names=['value_output']),\n",
+    "'policy_loss': metric.CrossEntropy(name='policy_loss', output_names=['policy_output'],\n",
     "                                            label_names=['policy_label']),\n",
-    "'value_acc_sign': mx.metric.create(acc_sign, name='value_acc_sign', output_names=['value_output'],\n",
+    "'value_acc_sign': metric.create(acc_sign, name='value_acc_sign', output_names=['value_output'],\n",
     "                                         label_names=['value_label']),\n",
-    "'policy_acc': mx.metric.Accuracy(axis=1, name='policy_acc', output_names=['policy_output'],\n",
+    "'policy_acc': metric.Accuracy(axis=1, name='policy_acc', output_names=['policy_output'],\n",
     "                                       label_names=['policy_label'])\n",
     "}\n",
-    "if use_mxnet_style:\n",
+    "if False: #use_mxnet_style:\n",
     "    to.metrics = metrics_mxnet\n",
     "else:\n",
     "    to.metrics = metrics_gluon"
@@ -715,10 +722,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if tc.use_mxnet_style:\n",
-    "    train_agent = TrainerAgentMXNET(model, symbol, val_iter, tc, to)\n",
-    "else:\n",
-    "    train_agent = TrainerAgent(net, val_data, tc, to)"
+    "train_agent = TrainerAgent(net, val_data, tc, to)"
    ]
   },
   {
@@ -734,7 +738,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if tc.use_mxnet_style:\n",
+    "if False: #tc.use_mxnet_style:\n",
     "    model.score(val_iter, metrics)"
    ]
   },
@@ -815,7 +819,7 @@
     "policy_out = symbol.get_internals()[train_config['policy_output']+'_output']\n",
     "sym = mx.symbol.Group([value_out, policy_out])\n",
     "net = mx.gluon.SymbolBlock(sym, inputs)\n",
-    "net.collect_params().load(model_params_path, ctx) #, allow_missing=True)"
+    "net.collect_params().load(model_params_path, ctx)"
    ]
   },
   {

--- a/DeepCrazyhouse/src/training/train_cnn.ipynb
+++ b/DeepCrazyhouse/src/training/train_cnn.ipynb
@@ -113,7 +113,7 @@
    "outputs": [],
    "source": [
     "# set the context on CPU, switch to GPU if there is one available (strongly recommended for training)\n",
-    "tc.context = \"cpu\"\n",
+    "tc.context = \"gpu\"\n",
     "tc.device_id = 0\n",
     "\n",
     "# set a specific seed value for reproducibility\n",
@@ -122,7 +122,7 @@
     "tc.export_weights = True\n",
     "tc.log_metrics_to_tensorboard = True\n",
     "tc.export_grad_histograms = True\n",
-    "tc.div_factor = 1000  # div factor is a constant which can be used to reduce the batch size and learning rate respectively\n",
+    "tc.div_factor = 1  # div factor is a constant which can be used to reduce the batch size and learning rate respectively\n",
     "# use a value greater 1 if you enconter memory allocation errors\n",
     "\n",
     "# batch_steps = 1000 means for example that every 1000 batches the validation set gets processed\n",
@@ -173,9 +173,10 @@
     "tc.q_value_ratio = 0\n",
     "        \n",
     "# define if policy training target is one-hot encoded a distribution (e.g. mcts samples, knowledge distillation)\n",
-    "tc.sparse_policy_label = True\n",
+    "tc.sparse_policy_label = False #True\n",
     "# define if the policy data is also defined in \"select_policy_from_plane\" representation\n",
-    "tc.is_policy_from_plane_data = False"
+    "tc.is_policy_from_plane_data = True #False\n",
+    "tc.name_initials = \"JC\""
    ]
   },
   {
@@ -287,15 +288,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x_val.dtype"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "tc.nb_parts = len(glob.glob(main_config['planes_train_dir'] + '**/*'))\n",
     "tc.nb_parts"
    ]
@@ -329,7 +321,7 @@
    "source": [
     "to.lr_schedule = OneCycleSchedule(start_lr=tc.max_lr/8, max_lr=tc.max_lr, cycle_length=tc.total_it*.3, cooldown_length=tc.total_it*.6, finish_lr=tc.min_lr)\n",
     "to.lr_schedule = LinearWarmUp(to.lr_schedule, start_lr=tc.min_lr, length=tc.total_it/30)\n",
-    "plot_schedule(to.lr_schedule, iterations=tc.total_it)\n",
+    "#plot_schedule(to.lr_schedule, iterations=tc.total_it)\n",
     "#lr_schedule = ConstantSchedule(min_lr)\n",
     "#plot_schedule(lr_schedule, iterations=total_it, ylim=[-min_lr, max_lr*1.1])"
    ]
@@ -349,7 +341,7 @@
    "source": [
     "to.momentum_schedule = MomentumSchedule(to.lr_schedule, tc.min_lr, tc.max_lr, tc.min_momentum, tc.max_momentum)\n",
     "#momentum_schedule = ConstantSchedule(min_momentum)\n",
-    "plot_schedule(to.momentum_schedule, iterations=tc.total_it, ylabel='Momentum')"
+    "#plot_schedule(to.momentum_schedule, iterations=tc.total_it, ylabel='Momentum')"
    ]
   },
   {
@@ -473,24 +465,24 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "bc_res_blocks = [3] * 13\n",
-    "if symbol_file is None:\n",
+    "if tc.symbol_file is None:\n",
     "    symbol = rise_mobile_v2_symbol(channels=256, channels_operating_init=128, channel_expansion=64, channels_value_head=8,\n",
     "                      channels_policy_head=NB_POLICY_MAP_CHANNELS, value_fc_size=256, bc_res_blocks=bc_res_blocks, res_blocks=[], act_type='relu',\n",
-    "                      n_labels=NB_LABELS, grad_scale_value=val_loss_factor, grad_scale_policy=policy_loss_factor, select_policy_from_plane=select_policy_from_plane,\n",
-    "                      use_se=True, dropout_rate=dropout_rate, use_extra_variant_input=use_extra_variant_input)\n",
+    "                      n_labels=NB_LABELS, grad_scale_value=tc.val_loss_factor, grad_scale_policy=tc.policy_loss_factor, select_policy_from_plane=tc.select_policy_from_plane,\n",
+    "                      use_se=True, dropout_rate=tc.dropout_rate, use_extra_variant_input=use_extra_variant_input)\n",
     "else:\n",
     "    symbol = mx.sym.load(\"weights/\" + symbol_file)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "kernels = [\n",
     "    [3],  # 0\n",
@@ -663,10 +655,13 @@
     "        model.load_params(\"weights/\" + params_file)    \n",
     "else:    \n",
     "    # Initializing the parameters\n",
-    "    net.collect_params('.*gamma|.*moving_mean|.*moving_var').initialize(mx.initializer.Constant(1))\n",
-    "    net.collect_params('.*beta|.*bias').initialize(mx.initializer.Constant(0))\n",
-    "    net.collect_params('.*weight').initialize(mx.init.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24))\n",
-    "    \n",
+    "    for param in net.collect_params('.*gamma|.*moving_mean|.*moving_var'):\n",
+    "        net.params[param].initialize(mx.initializer.Constant(1), ctx=ctx)\n",
+    "    for param in net.collect_params('.*beta|.*bias'):\n",
+    "        net.params[param].initialize(mx.initializer.Constant(0), ctx=ctx)\n",
+    "    for param in net.collect_params('.*weight'):\n",
+    "        net.params[param].initialize(mx.init.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24), ctx=ctx)\n",
+    "\n",
     "    if tc.params_file:\n",
     "        net.collect_params().load(\"weights/\" + params_file, ctx)\n",
     "    net.hybridize()"
@@ -1325,7 +1320,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/DeepCrazyhouse/src/training/trainer_agent.py
+++ b/DeepCrazyhouse/src/training/trainer_agent.py
@@ -136,7 +136,6 @@ class TrainerAgent:  # Probably needs refactoring
         if self.tc.log_metrics_to_tensorboard:
             self.sum_writer = SummaryWriter(logdir="./logs", flush_secs=5, verbose=False)
         # Define the two loss functions
-        #  sparse_policy_label defines if the policy target is one-hot encoded (sparse=True)
         self._softmax_cross_entropy = gluon.loss.SoftmaxCrossEntropyLoss(sparse_label=self.tc.sparse_policy_label)
         self._l2_loss = gluon.loss.L2Loss()
         if self.tc.optimizer_name != "nag":
@@ -185,7 +184,7 @@ class TrainerAgent:  # Probably needs refactoring
             # old_label = value_label
             with autograd.record():
                 [value_out, policy_out] = self._net(data)
-                if self.tc.select_policy_from_plane:
+                if self.tc.select_policy_from_plane and not self.tc.is_policy_from_plane_data:
                     policy_out = policy_out[:, FLAT_PLANE_IDX]
                 value_loss = self._l2_loss(value_out, value_label)
                 policy_loss = self._softmax_cross_entropy(policy_out, policy_label)
@@ -267,7 +266,6 @@ class TrainerAgent:  # Probably needs refactoring
                     old_label = value_label
                     with autograd.record():
                         [value_out, policy_out] = self._net(data)
-
                         value_loss = self._l2_loss(value_out, value_label)
                         policy_loss = self._softmax_cross_entropy(policy_out, policy_label)
                         # weight the components of the combined loss

--- a/DeepCrazyhouse/src/training/trainer_agent_mxnet.py
+++ b/DeepCrazyhouse/src/training/trainer_agent_mxnet.py
@@ -278,7 +278,6 @@ class TrainerAgentMXNET:  # Probably needs refactoring
 
                 if self.tc.discount != 1:
                     self.yv_train *= self.tc.discount**plys_to_end
-
                 self.yp_train = prepare_policy(self.yp_train, self.tc.select_policy_from_plane,
                                                self.tc.sparse_policy_label, self.tc.is_policy_from_plane_data)
 

--- a/engine/src/nn/neuralnetapi.cpp
+++ b/engine/src/nn/neuralnetapi.cpp
@@ -49,7 +49,8 @@ NeuralNetAPI::NeuralNetAPI(const string& ctx, int deviceID, unsigned int batchSi
     deviceID(deviceID),
     batchSize(batchSize),
     policyOutputLength(StateConstants::NB_LABELS() * batchSize),
-    enableTensorrt(enableTensorrt)
+    enableTensorrt(enableTensorrt),
+    modelName("")
 {
     modelDir = parse_directory(modelDirectory);
     deviceName = ctx + string("_") + to_string(deviceID);

--- a/engine/src/nn/tensorrtapi.cpp
+++ b/engine/src/nn/tensorrtapi.cpp
@@ -47,7 +47,8 @@ TensorrtAPI::TensorrtAPI(int deviceID, unsigned int batchSize, const string &mod
     // select the requested device
     cudaSetDevice(deviceID);
     // in ONNX, the model architecture and parameters are in the same file
-    modelFilePath = modelDir + get_file_ending_with(modelDir, "-bsize-" + to_string(batchSize) + ".onnx");
+    modelName = get_file_ending_with(modelDir, "-bsize-" + to_string(batchSize) + ".onnx");
+    modelFilePath = modelDir + modelName;
     info_string("onnx file:", modelFilePath);
     trtFilePath = generate_trt_file_path(modelDir, batchSize, precision, deviceID);
     gLogger.setReportableSeverity(nvinfer1::ILogger::Severity::kERROR);

--- a/engine/src/rl/rl_training.py
+++ b/engine/src/rl/rl_training.py
@@ -11,30 +11,34 @@ import sys
 import glob
 import logging
 import mxnet as mx
+try:
+    import mxnet.metric as metric
+except ModuleNotFoundError:
+    import mxnet.gluon.metric as metric
+from mxnet import nd
+from mxnet import gluon
 
 sys.path.append("../../../")
+from DeepCrazyhouse.configs.train_config import TrainConfig, TrainObjects
 from DeepCrazyhouse.src.preprocessing.dataset_loader import load_pgn_dataset
 from DeepCrazyhouse.src.training.trainer_agent import acc_sign, cross_entropy, acc_distribution
-from DeepCrazyhouse.src.training.trainer_agent_mxnet import TrainerAgentMXNET, add_non_sparse_cross_entropy,\
-    remove_no_sparse_cross_entropy, prepare_policy
+from DeepCrazyhouse.src.training.trainer_agent_mxnet import prepare_policy
+from DeepCrazyhouse.src.training.trainer_agent import TrainerAgent
 from DeepCrazyhouse.src.training.lr_schedules.lr_schedules import MomentumSchedule, LinearWarmUp,\
     CosineAnnealingSchedule
 from DeepCrazyhouse.src.domain.neural_net.onnx.convert_to_onnx import convert_mxnet_model_to_onnx
 
 
-def update_network(queue, nn_update_idx, k_steps_initial, max_lr, symbol_filename, params_filename, cwd, convert_to_onnx, main_config, train_config):
+def update_network(queue, nn_update_idx, symbol_filename, params_filename, convert_to_onnx, main_config, train_config: TrainConfig):
     """
     Creates a new NN checkpoint in the model contender directory after training using the game files stored in the
      training directory
     :param queue: Queue object used to return items
-    :param k_steps_initial: Initial amount of steps of the NN update
     :param nn_update_idx: Defines how many updates of the nn has already been done. This index should be incremented
     after every update.
-    :param max_lr: Maximum learning rate used for the learning rate schedule
     :param symbol_filename: Architecture definition file
     :param params_filename: Weight file which will be loaded before training
     Updates the neural network with the newly acquired games from the replay memory
-    :param cwd: Current working directory (must end with "/")
     :param convert_to_onnx: Boolean indicating if the network shall be exported to ONNX to allow TensorRT inference
     :param main_config: Dict of the main_config (imported from main_config.py)
     :param train_config: Dict of the train_config (imported from train_config.py)
@@ -42,121 +46,92 @@ def update_network(queue, nn_update_idx, k_steps_initial, max_lr, symbol_filenam
     """
 
     # set the context on CPU, switch to GPU if there is one available (strongly recommended for training)
-    ctx = mx.gpu(train_config["device_id"]) if train_config["context"] == "gpu" else mx.cpu()
+    ctx = mx.gpu(train_config.device_id) if train_config.context == "gpu" else mx.cpu()
     # set a specific seed value for reproducibility
-    nb_parts = len(glob.glob(main_config["planes_train_dir"] + '**/*.zip'))
-    logging.info("number parts: %d" % nb_parts)
+    train_config.nb_parts = len(glob.glob(main_config["planes_train_dir"] + '**/*.zip'))
+    logging.info("number parts: %d" % train_config.nb_parts)
+    train_objects = TrainObjects()
 
-    if nb_parts <= 0:
+    if train_config.nb_parts <= 0:
         raise Exception('No .zip files for training available. Check the path in main_config["planes_train_dir"]:'
                         ' %s' % main_config["planes_train_dir"])
 
     _, x_val, y_val_value, y_val_policy, _, _ = load_pgn_dataset(dataset_type="val",
                                                                  part_id=0,
-                                                                 normalize=train_config["normalize"],
+                                                                 normalize=train_config.normalize,
                                                                  verbose=False,
-                                                                 q_value_ratio=train_config["q_value_ratio"])
-
-    y_val_policy = prepare_policy(y_val_policy, train_config["select_policy_from_plane"],
-                                  train_config["sparse_policy_label"])
+                                                                 q_value_ratio=train_config.q_value_ratio)
+    y_val_policy = prepare_policy(y_val_policy, train_config.select_policy_from_plane,
+                                  train_config.sparse_policy_label, train_config.is_policy_from_plane_data)
+    val_dataset = gluon.data.ArrayDataset(nd.array(x_val), nd.array(y_val_value), nd.array(y_val_policy))
+    val_data = gluon.data.DataLoader(val_dataset, train_config.batch_size, shuffle=False, num_workers=train_config.cpu_count)
 
     symbol = mx.sym.load(symbol_filename)
-    if not train_config["sparse_policy_label"]:
-       symbol = add_non_sparse_cross_entropy(symbol, train_config["val_loss_factor"],
-                                             main_config["value_output"]+"_output",
-                                             main_config["policy_output"]+"_output")
 
     # calculate how many iterations per epoch exist
-    nb_it_per_epoch = (len(x_val) * nb_parts) // train_config["batch_size"]
+    nb_it_per_epoch = (len(x_val) * train_config.nb_parts) // train_config.batch_size
     # one iteration is defined by passing 1 batch and doing backprop
-    total_it = int(nb_it_per_epoch * train_config["nb_epochs"])
+    train_config.total_it = int(nb_it_per_epoch * train_config.nb_epochs)
 
-    lr_schedule = CosineAnnealingSchedule(train_config["min_lr"], max_lr, max(total_it * .7, 1))
-    lr_schedule = LinearWarmUp(lr_schedule, start_lr=train_config["min_lr"], length=max(total_it * .25, 1))
-    momentum_schedule = MomentumSchedule(lr_schedule, train_config["min_lr"], max_lr,
-                                         train_config["min_momentum"], train_config["max_momentum"])
-
-    if train_config["select_policy_from_plane"]:
-        val_iter = mx.io.NDArrayIter({'data': x_val}, {'value_label': y_val_value,
-                                                       'policy_label': y_val_policy}, train_config["batch_size"])
-    else:
-        val_iter = mx.io.NDArrayIter({'data': x_val},
-                                     {'value_label': y_val_value, 'policy_label': y_val_policy},
-                                     train_config["batch_size"])
+    train_objects.lr_schedule = CosineAnnealingSchedule(train_config.min_lr, train_config.max_lr, max(train_config.total_it * .7, 1))
+    train_objects.lr_schedule = LinearWarmUp(train_objects.lr_schedule, start_lr=train_config.min_lr, length=max(train_config.total_it * .25, 1))
+    train_objects.momentum_schedule = MomentumSchedule(train_objects.lr_schedule, train_config.min_lr, train_config.max_lr,
+                                         train_config.min_momentum, train_config.max_momentum)
 
     # calculate how many iterations per epoch exist
-    nb_it_per_epoch = (len(x_val) * nb_parts) // train_config["batch_size"]
+    nb_it_per_epoch = (len(x_val) * train_config.nb_parts) // train_config.batch_size
     # one iteration is defined by passing 1 batch and doing backprop
-    total_it = int(nb_it_per_epoch * train_config["nb_epochs"])
+    train_config.total_it = int(nb_it_per_epoch * train_config.nb_epochs)
 
     input_shape = x_val[0].shape
-    model = mx.mod.Module(symbol=symbol, context=ctx, label_names=['value_label', 'policy_label'])
-    # mx.viz.print_summary(
-    #     symbol,
-    #     shape={'data': (1, input_shape[0], input_shape[1], input_shape[2])},
-    # )
-    model.bind(for_training=True,
-               data_shapes=[('data', (train_config["batch_size"], input_shape[0], input_shape[1], input_shape[2]))],
-               label_shapes=val_iter.provide_label)
-    model.load_params(params_filename)
 
-    metrics = [
-        mx.metric.MSE(name='value_loss', output_names=['value_output'], label_names=['value_label']),
-        mx.metric.create(acc_sign, name='value_acc_sign', output_names=['value_output'],
-                         label_names=['value_label']),
-    ]
+    inputs = mx.sym.var('data', dtype='float32')
+    value_out = symbol.get_internals()[main_config['value_output'] + '_output']
+    policy_out = symbol.get_internals()[main_config['policy_output'] + '_output']
+    sym = mx.symbol.Group([value_out, policy_out])
+    net = mx.gluon.SymbolBlock(sym, inputs)
+    net.collect_params().load(params_filename, ctx)
 
-    if train_config["sparse_policy_label"]:
+    metrics_gluon = {
+        'value_loss': metric.MSE(name='value_loss', output_names=['value_output']),
+
+        'value_acc_sign': metric.create(acc_sign, name='value_acc_sign', output_names=['value_output'],
+                                        label_names=['value_label']),
+    }
+
+    if train_config.sparse_policy_label:
         print("train with sparse labels")
         # the default cross entropy only supports sparse labels
-        metrics.append(mx.metric.Accuracy(axis=1, name='policy_acc', output_names=['policy_output'],
-                       label_names=['policy_label']))
-        metrics.append(mx.metric.CrossEntropy(name='policy_loss', output_names=['policy_output'],
-                                              label_names=['policy_label']))
+        metrics_gluon['policy_loss'] = metric.CrossEntropy(name='policy_loss', output_names=['policy_output'],
+                                           label_names=['policy_label']),
+        metrics_gluon['policy_acc'] = metric.Accuracy(axis=1, name='policy_acc', output_names=['policy_output'],
+                                      label_names=['policy_label'])
     else:
-        metrics.append(mx.metric.create(acc_distribution, name='policy_acc', output_names=['policy_output'],
-                       label_names=['policy_label']))
-        metrics.append(mx.metric.create(cross_entropy, name='policy_loss', output_names=['policy_output'],
-                                        label_names=['policy_label']))
+        metrics_gluon['policy_loss'] = metric.create(cross_entropy, name='policy_loss', output_names=['policy_output'],
+                                        label_names=['policy_label'])
+        metrics_gluon['policy_acc'] = metric.create(acc_distribution, name='policy_acc', output_names=['policy_output'],
+                       label_names=['policy_label'])
 
-    logging.info("Performance pre training")
-    logging.info(model.score(val_iter, metrics))
+    train_objects.metrics = metrics_gluon
 
-    train_agent = TrainerAgentMXNET(model, symbol, val_iter, nb_parts, lr_schedule, momentum_schedule, total_it,
-                                    train_config["optimizer_name"], wd=train_config["wd"],
-                                    batch_steps=train_config["batch_steps"],
-                                    k_steps_initial=k_steps_initial,
-                                    cpu_count=train_config["cpu_count"],
-                                    batch_size=train_config["batch_size"], normalize=train_config["normalize"],
-                                    export_weights=train_config["export_weights"],
-                                    export_grad_histograms=train_config["export_grad_histograms"],
-                                    log_metrics_to_tensorboard=train_config["log_metrics_to_tensorboard"], ctx=ctx,
-                                    metrics=metrics, use_spike_recovery=train_config["use_spike_recovery"],
-                                    max_spikes=train_config["max_spikes"],
-                                    spike_thresh=train_config["spike_thresh"],
-                                    seed=None, val_loss_factor=train_config["val_loss_factor"],
-                                    policy_loss_factor=train_config["policy_loss_factor"],
-                                    select_policy_from_plane=train_config["select_policy_from_plane"],
-                                    discount=train_config["discount"],
-                                    sparse_policy_label=train_config["sparse_policy_label"],
-                                    q_value_ratio=train_config["q_value_ratio"],
-                                    cwd=cwd)
+    train_config.export_weights = False  # don't save intermediate weights
+    train_agent = TrainerAgent(net, val_data, train_config, train_objects)
+
     # iteration counter used for the momentum and learning rate schedule
-    cur_it = train_config["k_steps_initial"] * train_config["batch_steps"]
+    cur_it = train_config.k_steps_initial * train_config.batch_steps
     (k_steps_final, val_value_loss_final, val_policy_loss_final, val_value_acc_sign_final,
      val_policy_acc_final), _ = train_agent.train(cur_it)
 
-    if not train_config["sparse_policy_label"]:
-       symbol = remove_no_sparse_cross_entropy(symbol, train_config["val_loss_factor"],
-                                               main_config["value_output"]+"_output",
-                                               main_config["policy_output"]+"_output")
-    prefix = cwd + "model_contender/model-%.5f-%.5f-%.3f-%.3f" % (val_value_loss_final, val_policy_loss_final,
+    prefix = train_config.cwd + "model_contender/model-%.5f-%.5f-%.3f-%.3f" % (val_value_loss_final, val_policy_loss_final,
                                                                   val_value_acc_sign_final, val_policy_acc_final)
 
     sym_file = prefix + "-symbol.json"
     params_file = prefix + "-" + "%04d.params" % nn_update_idx
-    symbol.save(sym_file)
-    model.save_params(params_file)
+
+    # the export function saves both the architecture and the weights
+    net.export(prefix, epoch=nn_update_idx)
+    print()
+    logging.info("Saved checkpoint to %s-%04d.params", prefix, nn_update_idx)
 
     if convert_to_onnx:
         convert_mxnet_model_to_onnx(sym_file, params_file, ["value_out_output", "policy_out_output"], input_shape,

--- a/engine/src/rl/rl_training.py
+++ b/engine/src/rl/rl_training.py
@@ -63,8 +63,8 @@ def update_network(queue, nn_update_idx, k_steps_initial, max_lr, symbol_filenam
     symbol = mx.sym.load(symbol_filename)
     if not train_config["sparse_policy_label"]:
        symbol = add_non_sparse_cross_entropy(symbol, train_config["val_loss_factor"],
-                                             train_config["value_output"]+"_output",
-                                             train_config["policy_output"]+"_output")
+                                             main_config["value_output"]+"_output",
+                                             main_config["policy_output"]+"_output")
 
     # calculate how many iterations per epoch exist
     nb_it_per_epoch = (len(x_val) * nb_parts) // train_config["batch_size"]
@@ -148,8 +148,8 @@ def update_network(queue, nn_update_idx, k_steps_initial, max_lr, symbol_filenam
 
     if not train_config["sparse_policy_label"]:
        symbol = remove_no_sparse_cross_entropy(symbol, train_config["val_loss_factor"],
-                                               train_config["value_output"]+"_output",
-                                               train_config["policy_output"]+"_output")
+                                               main_config["value_output"]+"_output",
+                                               main_config["policy_output"]+"_output")
     prefix = cwd + "model_contender/model-%.5f-%.5f-%.3f-%.3f" % (val_value_loss_final, val_policy_loss_final,
                                                                   val_value_acc_sign_final, val_policy_acc_final)
 

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <fstream>
 #include "uci.h"
+#include "state.h"
 #include "uci/variants.h"
 #include "util/blazeutil.h"
 #include "util/randomgen.h"

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -340,9 +340,9 @@ void CrazyAra::arena(istringstream &is)
     SearchLimits searchLimits;
     searchLimits.nodes = size_t(Options["Nodes"]);
     SelfPlay selfPlay(rawAgent.get(), mctsAgent.get(), &searchLimits, &playSettings, &rlSettings);
-    netSingle = create_new_net_single(Options["Model_Directory_Contender"]);
-    netBatches = create_new_net_batches(Options["Model_Directory_Contender"]);
-    mctsAgentContender = create_new_mcts_agent(netSingle.get(), netBatches, searchSettings);
+    netSingleContender = create_new_net_single(Options["Model_Directory_Contender"]);
+    netBatchesContender = create_new_net_batches(Options["Model_Directory_Contender"]);
+    mctsAgentContender = create_new_mcts_agent(netSingleContender.get(), netBatchesContender, searchSettings);
     size_t numberOfGames;
     is >> numberOfGames;
     TournamentResult tournamentResult = selfPlay.go_arena(mctsAgentContender.get(), numberOfGames, variant);


### PR DESCRIPTION
This PR makes training in Gluon the new default since the MXNet Symbol-API will become more and more deprecated (e.g. `SoftmaxOutput()` is not available in MXNet 2.0 anymore (https://github.com/apache/incubator-mxnet/issues/19177)).