### PR TITLE
Optional auxiliary outputs for NN prediction

### DIFF
--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -185,9 +185,9 @@ void MCTSAgent::create_new_root_node(StateObj* state)
     rootNode->enable_has_nn_results();
 #else
     state->get_state_planes(true, inputPlanes);
-    net->predict(inputPlanes, valueOutputs, probOutputs);
+    net->predict(inputPlanes, valueOutputs, probOutputs, auxiliaryOutputs);
     size_t tbHits = 0;
-    fill_nn_results(0, net->is_policy_map(), valueOutputs, probOutputs, rootNode, tbHits, state->side_to_move(), searchSettings);
+    fill_nn_results(0, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, rootNode, tbHits, state->side_to_move(), searchSettings);
 #endif
     rootNode->prepare_node_for_visits();
 }

--- a/engine/src/agents/rawnetagent.cpp
+++ b/engine/src/agents/rawnetagent.cpp
@@ -54,7 +54,7 @@ void RawNetAgent::evaluate_board_state()
         return;
     }
     state->get_state_planes(true, inputPlanes);
-    net->predict(inputPlanes, valueOutputs, probOutputs);
+    net->predict(inputPlanes, valueOutputs, probOutputs, auxiliaryOutputs);
 
     evalInfo->policyProbSmall.resize(evalInfo->legalMoves.size());
     get_probs_of_move_list(0, probOutputs, evalInfo->legalMoves, state->side_to_move(),

--- a/engine/src/environments/chess_related/boardstate.cpp
+++ b/engine/src/environments/chess_related/boardstate.cpp
@@ -199,7 +199,7 @@ Tablebase::WDLScore BoardState::check_for_tablebase_wdl(Tablebase::ProbeState &r
     return wdlScore;
 }
 
-void BoardState::set_auxiliary_outputs(const float *auxiliaryOutputs) const
+void BoardState::set_auxiliary_outputs(const float *auxiliaryOutputs)
 {
     // do nothing
 }

--- a/engine/src/environments/chess_related/boardstate.cpp
+++ b/engine/src/environments/chess_related/boardstate.cpp
@@ -199,6 +199,11 @@ Tablebase::WDLScore BoardState::check_for_tablebase_wdl(Tablebase::ProbeState &r
     return wdlScore;
 }
 
+void BoardState::set_auxiliary_outputs(const float *auxiliaryOutputs) const
+{
+    // do nothing
+}
+
 BoardState* BoardState::clone() const
 {
     return new BoardState(*this);

--- a/engine/src/environments/chess_related/boardstate.h
+++ b/engine/src/environments/chess_related/boardstate.h
@@ -61,6 +61,9 @@ public:
     static uint NB_LABELS_POLICY_MAP() {
         return NB_CHANNELS_POLICY_MAP() * BOARD_HEIGHT() * BOARD_WIDTH();
     }
+    static uint NB_AUXILIARY_OUTPUTS() {
+        return 0U;
+    }
     static uint NB_PLAYERS() {
         return 2;
     }
@@ -243,6 +246,7 @@ public:
     bool gives_check(Action action) const override;
     void print(ostream& os) const override;
     Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState &result) override;
+    void set_auxiliary_outputs(const float* auxiliaryOutputs) const;
     BoardState* clone() const override;
 };
 

--- a/engine/src/environments/chess_related/boardstate.h
+++ b/engine/src/environments/chess_related/boardstate.h
@@ -246,7 +246,7 @@ public:
     bool gives_check(Action action) const override;
     void print(ostream& os) const override;
     Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState &result) override;
-    void set_auxiliary_outputs(const float* auxiliaryOutputs) const;
+    void set_auxiliary_outputs(const float* auxiliaryOutputs);
     BoardState* clone() const override;
 };
 

--- a/engine/src/environments/open_spiel/openspielstate.cpp
+++ b/engine/src/environments/open_spiel/openspielstate.cpp
@@ -183,6 +183,11 @@ Tablebase::WDLScore OpenSpielState::check_for_tablebase_wdl(Tablebase::ProbeStat
     return Tablebase::WDLScoreNone;
 }
 
+void OpenSpielState::set_auxiliary_outputs(const float* auxiliaryOutputs) const
+{
+    // do nothing
+}
+
 OpenSpielState* OpenSpielState::clone() const
 {
     return new OpenSpielState(*this);

--- a/engine/src/environments/open_spiel/openspielstate.cpp
+++ b/engine/src/environments/open_spiel/openspielstate.cpp
@@ -183,7 +183,7 @@ Tablebase::WDLScore OpenSpielState::check_for_tablebase_wdl(Tablebase::ProbeStat
     return Tablebase::WDLScoreNone;
 }
 
-void OpenSpielState::set_auxiliary_outputs(const float* auxiliaryOutputs) const
+void OpenSpielState::set_auxiliary_outputs(const float* auxiliaryOutputs)
 {
     // do nothing
 }

--- a/engine/src/environments/open_spiel/openspielstate.h
+++ b/engine/src/environments/open_spiel/openspielstate.h
@@ -66,6 +66,9 @@ public:
     static uint NB_LABELS_POLICY_MAP() {
         return 5184U;  // TODO
     }
+    static uint NB_AUXILIARY_OUTPUTS() {
+        return 0U;
+    }
     static int NB_PLAYERS() {
         return  open_spiel::chess::NumPlayers();
     }
@@ -113,6 +116,7 @@ public:
     bool gives_check(Action action) const;
     void print(std::ostream &os) const;
     Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState &result);
+    void set_auxiliary_outputs(const float* auxiliaryOutputs) const;
     OpenSpielState *clone() const;
 };
 

--- a/engine/src/environments/open_spiel/openspielstate.h
+++ b/engine/src/environments/open_spiel/openspielstate.h
@@ -116,7 +116,7 @@ public:
     bool gives_check(Action action) const;
     void print(std::ostream &os) const;
     Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState &result);
-    void set_auxiliary_outputs(const float* auxiliaryOutputs) const;
+    void set_auxiliary_outputs(const float* auxiliaryOutputs);
     OpenSpielState *clone() const;
 };
 

--- a/engine/src/nn/mxnetapi.cpp
+++ b/engine/src/nn/mxnetapi.cpp
@@ -187,7 +187,7 @@ NDArray MXNetAPI::predict(float* inputPlanes, float& value)
     return probOutputs;
 }
 
-void MXNetAPI::predict(float *inputPlanes, float* valueOutput, float* probOutputs)
+void MXNetAPI::predict(float *inputPlanes, float* valueOutput, float* probOutputs, float* auxiliaryOutputs)
 {
     executor->arg_dict()["data"].SyncCopyFromCPU(inputPlanes, StateConstants::NB_VALUES_TOTAL() * batchSize);
 
@@ -196,6 +196,9 @@ void MXNetAPI::predict(float *inputPlanes, float* valueOutput, float* probOutput
 
     executor->outputs[0].SyncCopyToCPU(valueOutput, batchSize);
     executor->outputs[1].SyncCopyToCPU(probOutputs, policyOutputLength);
+    if (StateConstants::NB_AUXILIARY_OUTPUTS() != 0) {
+        executor->outputs[2].SyncCopyToCPU(auxiliaryOutputs, StateConstants::NB_AUXILIARY_OUTPUTS()*batchSize);
+    }
 }
 
 #endif

--- a/engine/src/nn/mxnetapi.h
+++ b/engine/src/nn/mxnetapi.h
@@ -55,7 +55,7 @@ public:
     MXNetAPI(const string& ctx, int deviceID, unsigned int miniBatchSize, const string& modelDirectory, bool tensorRT);
     ~MXNetAPI();
 
-    void predict(float* inputPlanes, float* valueOutput, float* probOutputs);
+    void predict(float* inputPlanes, float* valueOutput, float* probOutputs, float* auxiliaryOutputs) override;
 
 protected:
     void load_model();

--- a/engine/src/nn/neuralnetapi.h
+++ b/engine/src/nn/neuralnetapi.h
@@ -130,8 +130,9 @@ public:
      * @param inputPlanes Pointer to the input planes of a single board position
      * @param value Value prediction for the board by the neural network
      * @param probOutputs Policy array of the raw network output (including illegal moves). It's assumend that the memory has already been allocated.
+     * @param auxiliaryOutputs Array of optional auxiliary outputs
      */
-    virtual void predict(float* inputPlanes, float* valueOutput, float* probOutputs) = 0;
+    virtual void predict(float* inputPlanes, float* valueOutput, float* probOutputs, float* auxiliaryOutputs) = 0;
 
     unsigned int get_policy_output_length() const;
 

--- a/engine/src/nn/neuralnetapiuser.cpp
+++ b/engine/src/nn/neuralnetapiuser.cpp
@@ -39,6 +39,9 @@ NeuralNetAPIUser::NeuralNetAPIUser(NeuralNetAPI *net):
     CHECK(cudaMallocHost((void**) &inputPlanes, net->get_batch_size() * StateConstants::NB_VALUES_TOTAL() * sizeof(float)));
     CHECK(cudaMallocHost((void**) &valueOutputs, net->get_batch_size() * sizeof(float)));
     CHECK(cudaMallocHost((void**) &probOutputs, net->get_policy_output_length() * sizeof(float)));
+    if (StateConstants::NB_AUXILIARY_OUTPUTS()) {
+        CHECK(cudaMallocHost((void**) &auxiliaryOutputs, net->get_batch_size() * StateConstants::NB_AUXILIARY_OUTPUTS() * sizeof(float)));
+    }
 #else
     inputPlanes = new float[net->get_batch_size() * StateConstants::NB_VALUES_TOTAL()];
     valueOutputs = new float[net->get_batch_size()];
@@ -52,9 +55,15 @@ NeuralNetAPIUser::~NeuralNetAPIUser()
     CHECK(cudaFreeHost(inputPlanes));
     CHECK(cudaFreeHost(valueOutputs));
     CHECK(cudaFreeHost(probOutputs));
+    if (StateConstants::NB_AUXILIARY_OUTPUTS()) {
+        CHECK(cudaFreeHost(auxiliaryOutputs));
+    }
 #else
     delete [] inputPlanes;
     delete [] valueOutputs;
     delete [] probOutputs;
+    if (StateConstants::NB_AUXILIARY_OUTPUTS()) {
+        delete [] auxiliaryOutputs;
+    }
 #endif
 }

--- a/engine/src/nn/neuralnetapiuser.h
+++ b/engine/src/nn/neuralnetapiuser.h
@@ -45,6 +45,7 @@ protected:
     // sufficient memory according to the batch-size will be allocated in the constructor
     float* valueOutputs;
     float* probOutputs;
+    float* auxiliaryOutputs;
 
 public:
     NeuralNetAPIUser(NeuralNetAPI* net);

--- a/engine/src/nn/tensorrtapi.h
+++ b/engine/src/nn/tensorrtapi.h
@@ -65,16 +65,18 @@ private:
     int idxInput;
     int idxValueOutput;
     int idxPolicyOutput;
+    int idxAuxiliaryOutput;
 
-    // device memory, for input, value output and policy output
-    void* deviceMemory[3];
-    size_t memorySizes[3];
+    // device memory, for input, value output and policy output, auxiliary outputs
+    void* deviceMemory[4];
+    size_t memorySizes[4];
 
     // input and output dimension of the network
     Precision precision;
     nvinfer1::Dims inputDims;
     nvinfer1::Dims valueOutputDims;
     nvinfer1::Dims policyOutputDims;
+    nvinfer1::Dims auxiliaryOutputDims;
 
     // tensorRT runtime engine
     string trtFilePath;
@@ -94,7 +96,13 @@ public:
     TensorrtAPI(int deviceID, unsigned int batchSize, const string& modelDirectory, const string& strPrecision);
     ~TensorrtAPI();
 
-    void predict(float* inputPlanes, float* valueOutput, float* probOutputs) override;
+    void predict(float* inputPlanes, float* valueOutput, float* probOutputs, float* auxiliaryOutputs) override;
+
+    /**
+     * @brief check_auxiliary_output Checks consistency of auxiliary output
+     * @return True if ok, else false
+     */
+    bool check_auxiliary_output();
 
 private:
     void load_model() override;

--- a/engine/src/nn/torchapi.h
+++ b/engine/src/nn/torchapi.h
@@ -46,7 +46,7 @@ public:
     TorchAPI(const string& ctx, int deviceID, unsigned int miniBatchSize, const string& modelDirectory);
 
     // NeuralNetAPI interface
-    void predict(float *inputPlanes, float *valueOutput, float *probOutputs) override;
+    void predict(float *inputPlanes, float *valueOutput, float *probOutputs, float *auxiliaryOutputs) override;
 
 protected:
     void load_model() override;

--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -87,6 +87,11 @@ StateObj* Node::get_state() const
 {
     return state.get();
 }
+
+void Node::set_auxiliary_outputs(const float* auxiliaryOutputs)
+{
+    state->set_auxiliary_outputs(auxiliaryOutputs);
+}
 #endif
 
 Node::Node(StateObj* state, bool inCheck, const SearchSettings* searchSettings):

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -465,6 +465,12 @@ public:
 
 #ifdef MCTS_STORE_STATES
     StateObj* get_state() const;
+
+    /**
+     * @brief set_auxiliary_outputs Sets the auxiliary outputs of the neural network to the state object
+     * @param auxiliaryOutputs Auxiliary outputs of the neural network for the corresponding state
+     */
+    void set_auxiliary_outputs(const float* auxiliaryOutputs);
 #endif
 
     uint32_t get_number_of_nodes() const;

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -200,7 +200,7 @@ private:
 
 void run_search_thread(SearchThread *t);
 
-void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutputs, const float* probOutputs, Node *node, size_t& tbHits, SideToMove sideToMove, const SearchSettings* searchSettings);
+void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, SideToMove sideToMove, const SearchSettings* searchSettings);
 void node_post_process_policy(Node *node, float temperature, bool isPolicyMap, const SearchSettings* searchSettings);
 void node_assign_value(Node *node, const float* valueOutputs, size_t& tbHits, size_t batchIdx);
 

--- a/engine/src/state.h
+++ b/engine/src/state.h
@@ -384,7 +384,7 @@ public:
      * Implement this method if you set StateConstantsInterface::NB_AUXILIARY_OUTPUTS() != 0.
      * @param auxiliaryOutputs Pointer to the auxiliary outputs
      */
-    virtual void set_auxiliary_outputs(const float* auxiliaryOutputs) const = 0;
+    virtual void set_auxiliary_outputs(const float* auxiliaryOutputs) = 0;
 
     /**
      * @brief operator << Operator overload for <<

--- a/engine/src/state.h
+++ b/engine/src/state.h
@@ -103,37 +103,105 @@ template<typename T>
 class StateConstantsInterface
 {
 public:
+    /**
+     * @brief BOARD_WIDTH
+     * @return board width
+     */
     static uint BOARD_WIDTH() {
         return T::BOARD_WIDTH();
     }
+
+    /**
+     * @brief BOARD_HEIGHT Board height of the input representation
+     * @return board height
+     */
     static uint BOARD_HEIGHT() {
         return T::BOARD_HEIGHT();
     }
+
+    /**
+     * @brief NB_CHANNELS_TOTAL Number of channel of the input representation to the neural network
+     * @return number of channels
+     */
     static uint NB_CHANNELS_TOTAL() {
         return T::NB_CHANNELS_TOTAL();
     }
+
+    /**
+     * @brief NB_SQUARES Number of board squares
+     * @return board_width * board_height
+     */
     static uint NB_SQUARES() {
         return BOARD_WIDTH() * BOARD_HEIGHT();
     }
+
+    /**
+     * @brief NB_VALUES_TOTAL Total number of values of the neural network input representation
+     * @return Length of the flattened input representation vector
+     */
     static uint NB_VALUES_TOTAL() {
         return NB_CHANNELS_TOTAL() * NB_SQUARES();
     }
+
+    /**
+     * @brief NB_LABELS Number of policy labels (e.g. UCI-labels) in classical representation
+     * @return Number of policy labels
+     */
     static uint NB_LABELS() {
         return T::NB_LABELS();
     }
+
+    /**
+     * @brief NB_LABELS_POLICY_MAP Number of policy map labels in policy map representation.
+     * @return Number of policy map labels
+     */
     static uint NB_LABELS_POLICY_MAP() {
         return T::NB_LABELS_POLICY_MAP();
     }
+
+    /**
+     * @brief NB_AUXILIARY_OUTPUTS Number of auxiliary outputs of the neural network (default: 0).
+     * The auxiliary outputs are assumed to be a flattened vector.
+     * @return Number of auxiliary outputs
+     */
+    static uint NB_AUXILIARY_OUTPUTS() {
+        return T::NB_AUXILIARY_OUTPUTS();
+    }
+
+    /**
+     * @brief NB_PLAYERS Number of players in the environment
+     * @return Number of players
+     */
     static uint NB_PLAYERS() {
         return T::NB_PLAYERS();
     }
+
+    /**
+     * @brief action_to_uci Returns a string representation of a given move
+     * @param action Action object
+     * @param is960 Boolean indicating if the 960 format is used
+     * @return String
+     */
     static std::string action_to_uci(Action action, bool is960) {
         return T::action_to_uci(action, is960);
     }
+
+    /**
+     * @brief action_to_index Function that is used to map an Action to the corresponding neural network policy index.
+     * @param action Given action
+     * @param p Policy type, either "normal" or "classic". Normal is the active policy output (e.g. classic, or policy map), "classic" corresponds to the classic policy-output.
+     * @param m Mirror type, either "notMirrored" or "mirrored". Can be used to give a different implementation when the input representatation is flipped.
+     * @return Neural network policy index
+     */
     template<PolicyType p, MirrorType m>
     static MoveIdx action_to_index(Action action) {
         return T::action_to_index<p, m>(action);
     }
+
+    /**
+     * @brief init Init function which is called after a neural network has been loaded and can be used to initalize static variables.
+     * @param isPolicyMap Boolean indicating if the neural network uses a policy map representation
+     */
     static void init(bool isPolicyMap) {
         return T::init(isPolicyMap);
     }
@@ -310,6 +378,13 @@ public:
      * @return WDLScore
      */
     virtual Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState& result) = 0;
+
+    /**
+     * @brief set_auxiliary_outputs Sets the auxliary outputs for the state. (By default: pass)
+     * Implement this method if you set StateConstantsInterface::NB_AUXILIARY_OUTPUTS() != 0.
+     * @param auxiliaryOutputs Pointer to the auxiliary outputs
+     */
+    virtual void set_auxiliary_outputs(const float* auxiliaryOutputs) const = 0;
 
     /**
      * @brief operator << Operator overload for <<

--- a/engine/src/stateobj.cpp
+++ b/engine/src/stateobj.cpp
@@ -62,3 +62,8 @@ const float* get_policy_data_batch(const size_t batchIdx, const float* probOutpu
     }
     return probOutputs + batchIdx*StateConstants::NB_LABELS();
 }
+
+const float* get_auxiliary_data_batch(const size_t batchIdx, const float* auxiliaryOutputs)
+{
+    return auxiliaryOutputs + batchIdx*StateConstants::NB_AUXILIARY_OUTPUTS();
+}

--- a/engine/src/stateobj.h
+++ b/engine/src/stateobj.h
@@ -81,4 +81,12 @@ void get_probs_of_move_list(const size_t batchIdx, const float* policyProb, cons
  */
 const float*  get_policy_data_batch(const size_t batchIdx, const float* policyProb, bool isPolicyMap);
 
+/**
+ * @brief get_auxiliary_data_batch Returns the pointer of the batch for the auxliary predictions
+ * @param batchIdx Batch index for the current predicion
+ * @param auxiliaryOutputs All auxiliary predictions of the batch
+ * @return Starting pointer for predictions of the current batch
+ */
+const float*  get_auxiliary_data_batch(const size_t batchIdx, const float* auxiliaryOutputs);
+
 #endif // STATEOBJ_H


### PR DESCRIPTION
This PR allows defining an optional auxiliary output for the neural network prediction.
It is only enabled for `MCTS_STORE_STATES` for now and `NB_AUXILIARY_OUTPUTS() != 0`.
The auxiliary outputs can be stored in the states in the method `set_auxiliary_outputs(const float* auxiliaryOutputs)`.