### PR TITLE
Enable dynamic change of UCI settings after "isready"

### DIFF
--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -315,7 +315,7 @@ void MCTSAgent::run_mcts_search()
         threads[i] = new thread(run_search_thread, searchThreads[i]);
     }
     int curMovetime = timeManager->get_time_for_move(searchLimits, rootState->side_to_move(), rootNode->plies_from_null()/2);
-     threadManager = make_unique<ThreadManager>(rootNode, evalInfo, searchThreads, curMovetime, 250, searchSettings->multiPV, searchSettings->qValueWeight, overallNPS, lastValueEval,
+     threadManager = make_unique<ThreadManager>(rootNode, evalInfo, searchThreads, curMovetime, 250, searchSettings, overallNPS, lastValueEval,
                                                 is_game_sceneario(searchLimits),
                                                 can_prolong_search(rootNode->plies_from_null()/2, timeManager->get_thresh_move()));
     unique_ptr<thread> tManager = make_unique<thread>(run_thread_manager, threadManager.get());

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -52,7 +52,7 @@ using namespace crazyara;
 class MCTSAgent : public Agent
 {
 private:
-    SearchSettings* searchSettings;
+    SearchSettings* searchSettings;  // TODO: add "const" to searchSetting
     vector<SearchThread*> searchThreads;
     unique_ptr<TimeManager> timeManager;
 
@@ -145,13 +145,13 @@ public:
 
     float get_q_value_weight() const;
 
-    /**
+    /** TODO: Remove this method
      * @brief update_q_value_weight Updates the Q-value weights for the search (used for quick search)
      * @param value New value to set
      */
     void update_q_value_weight(float value);
 
-    /**
+    /** TODO: Remove this method
      * @brief update_dirichlet_epsilon Updates the amount of dirichlet noise (used for quick search)
      * @param value New value to set
      */

--- a/engine/src/environments/chess_related/boardstate.h
+++ b/engine/src/environments/chess_related/boardstate.h
@@ -246,7 +246,7 @@ public:
     bool gives_check(Action action) const override;
     void print(ostream& os) const override;
     Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState &result) override;
-    void set_auxiliary_outputs(const float* auxiliaryOutputs);
+    void set_auxiliary_outputs(const float* auxiliaryOutputs) override;
     BoardState* clone() const override;
 };
 

--- a/engine/src/manager/threadmanager.cpp
+++ b/engine/src/manager/threadmanager.cpp
@@ -27,15 +27,14 @@
 #include "../util/blazeutil.h"
 #include <chrono>
 
-ThreadManager::ThreadManager(Node* rootNode, EvalInfo* evalInfo, vector<SearchThread*>& searchThreads, size_t movetimeMS, size_t updateIntervalMS, size_t multiPV, float qValueWeight, float overallNPS, float lastValueEval, bool inGame, bool canProlong):
+ThreadManager::ThreadManager(Node* rootNode, EvalInfo* evalInfo, vector<SearchThread*>& searchThreads, size_t movetimeMS, size_t updateIntervalMS, const SearchSettings* searchSettings, float overallNPS, float lastValueEval, bool inGame, bool canProlong):
     rootNode(rootNode),
     evalInfo(evalInfo),
     searchThreads(searchThreads),
     movetimeMS(movetimeMS),
     remainingMoveTimeMS(movetimeMS),
     updateIntervalMS(updateIntervalMS),
-    multiPV(multiPV),
-    qValueWeight(qValueWeight),
+    searchSettings(searchSettings),
     overallNPS(overallNPS),
     lastValueEval(lastValueEval),
     checkedContinueSearch(0),
@@ -48,7 +47,7 @@ ThreadManager::ThreadManager(Node* rootNode, EvalInfo* evalInfo, vector<SearchTh
 void ThreadManager::print_info()
 {
     evalInfo->end = chrono::steady_clock::now();
-    update_eval_info(*evalInfo, rootNode, get_tb_hits(searchThreads), get_max_depth(searchThreads), multiPV, qValueWeight);
+    update_eval_info(*evalInfo, rootNode, get_tb_hits(searchThreads), get_max_depth(searchThreads), searchSettings->multiPV, searchSettings->qValueWeight);
     info_msg(*evalInfo);
 }
 

--- a/engine/src/manager/threadmanager.h
+++ b/engine/src/manager/threadmanager.h
@@ -50,8 +50,7 @@ private:
     size_t movetimeMS;
     size_t remainingMoveTimeMS;
     size_t updateIntervalMS;
-    size_t multiPV;
-    float qValueWeight;
+    const SearchSettings* searchSettings;
     float overallNPS;
     float lastValueEval;
 
@@ -77,7 +76,7 @@ private:
     void print_info();
 
 public:
-    ThreadManager(Node* rootNode, EvalInfo* evalInfo, vector<SearchThread*>& searchThreads, size_t movetimeMS, size_t updateIntervalMS, size_t multiPV, float qValueWeight, float overallNPS, float lastValueEval, bool inGame, bool canProlong);
+    ThreadManager(Node* rootNode, EvalInfo* evalInfo, vector<SearchThread*>& searchThreads, size_t movetimeMS, size_t updateIntervalMS, const SearchSettings* searchSettings, float overallNPS, float lastValueEval, bool inGame, bool canProlong);
 
     /**
     * @brief stop_search_based_on_limits Checks for the search limit condition and possible early break-ups

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -40,7 +40,7 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(NeuralNetAPI *netBatch, SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
+SearchThread::SearchThread(NeuralNetAPI *netBatch, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
     NeuralNetAPIUser(netBatch),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->batchSize)),

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -81,7 +81,7 @@ private:
     bool isRunning;
 
     MapWithMutex* mapWithMutex;
-    SearchSettings* searchSettings;
+    const SearchSettings* searchSettings;
     SearchLimits* searchLimits;
     size_t tbHits;
     size_t depthSum;
@@ -94,7 +94,7 @@ public:
      * @param searchSettings Given settings for this search run
      * @param MapWithMutex Handle to the hash table
      */
-    SearchThread(NeuralNetAPI* netBatch, SearchSettings* searchSettings, MapWithMutex* mapWithMutex);
+    SearchThread(NeuralNetAPI* netBatch, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.

--- a/engine/src/uci/crazyara.h
+++ b/engine/src/uci/crazyara.h
@@ -89,6 +89,7 @@ private:
     bool networkLoaded;
     bool ongoingSearch;
     bool is960;
+    bool changedUCIoption = false;
 
 public:
     CrazyAra();
@@ -218,7 +219,7 @@ private:
      * @param searchSettings Search settings object
      * @return Pointer to the new MCTSAgent object
      */
-    unique_ptr<MCTSAgent> create_new_mcts_agent(NeuralNetAPI* netSingle, vector<unique_ptr<NeuralNetAPI>>& netBatches, SearchSettings& searchSettings);
+    unique_ptr<MCTSAgent> create_new_mcts_agent(NeuralNetAPI* netSingle, vector<unique_ptr<NeuralNetAPI>>& netBatches, SearchSettings* searchSettings);
 
     /**
      * @brief create_new_net_single Factory to create and load a new model from a given directory
@@ -233,6 +234,12 @@ private:
      * @return Vector of pointers to the newly createded objects. For every thread a sepreate net.
      */
     vector<unique_ptr<NeuralNetAPI>> create_new_net_batches(const string& modelDirectory);
+
+    /**
+     * @brief set_uci_option Updates an UCI option using the given input stream and set changedUCIoption to true.
+     * @param is Input stream
+     */
+    void set_uci_option(istringstream &is);
 };
 
 /**


### PR DESCRIPTION
This PR allows changing UCI option values after the `isready` command has been given.

:warning: Current limitation: Loading a a different dynamically model by changing `Model_Directory` after `isready` is currently not possible.