### PR TITLE
Bugfix: first_and_second_max()

### DIFF
--- a/engine/src/util/blazeutil.h
+++ b/engine/src/util/blazeutil.h
@@ -137,7 +137,7 @@ vector<size_t> argsort(const DynamicVector<T>& v)
 /**
  * @brief first_and_second_max Finds the first and second max entry with their corresponding index
  * @param v Vector
- * @param endIdx End index of the vector
+ * @param endIdx End index of the vector (endIdx-1 will be the last index in the loop)
  * @param firstMax Return value for max element
  * @param secondMax Return value for 2nd max element
  * @param firstArg Index for max element
@@ -147,17 +147,17 @@ template <typename T>
 void first_and_second_max(const DynamicVector<T>& v, size_t endIdx, T& firstMax, T& secondMax, size_t& firstArg, size_t& secondArg)
 {
     firstMax = v[0];
-    secondMax = v[1];
+    secondMax = v[0];
     firstArg = 0;
     secondArg = 0;
     for (size_t idx = 1; idx < endIdx; ++idx) {
         if (v[idx] > firstMax) {
+            // save previous best result as 2nd best
+            secondMax = firstMax;
+            secondArg = firstArg;
+            // update first best result
             firstMax = v[idx];
             firstArg = idx;
-        }
-        else if (v[idx] > secondMax) {
-            secondMax = v[idx];
-            secondArg = idx;
         }
     }
 }

--- a/engine/tests/tests.cpp
+++ b/engine/tests/tests.cpp
@@ -38,6 +38,7 @@
 #include "stateobj.h"
 #include "environments/chess_related/inputrepresentation.h"
 #include "legacyconstants.h"
+#include "util/blazeutil.h"
 using namespace Catch::literals;
 using namespace std;
 using namespace OptionsUCI;
@@ -254,5 +255,26 @@ TEST_CASE("Board representation constants"){
     REQUIRE(StateConstants::NB_CHANNELS_VARIANTS() == legacy_constants::NB_CHANNELS_VARIANTS);
     REQUIRE(StateConstants::MAX_FULL_MOVE_COUNTER() == legacy_constants::MAX_FULL_MOVE_COUNTER);
 }
+
+
+// ==========================================================================================================
+// ||                                      Blaze-Util Tests                                                ||
+// ==========================================================================================================
+
+TEST_CASE("Blaze: first_and_second_max()"){
+    DynamicVector<float> list = {3, 42, 1, 3, 99, 8, 7};
+    float firstMax;
+    float secondMax;
+    size_t firstArg;
+    size_t secondArg;
+    first_and_second_max(list, list.size(), firstMax, secondMax, firstArg, secondArg);
+
+    REQUIRE(firstMax == 99);
+    REQUIRE(secondMax == 42);
+    REQUIRE(firstArg == 4);
+    REQUIRE(secondArg == 1);
+}
+
+
 
 #endif


### PR DESCRIPTION
This PR fixes **first_and_second_max()** in blazeutil.h and adds a corresponding unit-test.
This fix affects the functionality for `Centi_Q_Value_Weight` > 0. 
