### PR TITLE
Default implementation for check_result(), unit tests and terminal checks

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 if (MODE_OPEN_SPIEL)
     project(OpenSpielAra CXX)
     add_definitions(-DMODE_OPEN_SPIEL)
+    add_definitions(-DACTION_64_BIT)
 endif()
 
 if (BUILD_TESTS)

--- a/engine/src/environments/chess_related/board.cpp
+++ b/engine/src/environments/chess_related/board.cpp
@@ -343,22 +343,6 @@ bool leads_to_terminal(const Board &pos, Move m, StateListPtr& states)
     return posCheckTerminal.is_terminal();
 }
 
-Result get_result(const Board& pos, bool inCheck)
-{
-    if (pos.is_terminal()) {
-        if (!inCheck || pos.is_50_move_rule_draw() || pos.can_claim_3fold_repetition() || pos.draw_by_insufficient_material()) {
-            return DRAWN;
-        }
-        if (pos.side_to_move() == BLACK) {
-            return WHITE_WIN;
-        }
-        else {
-            return BLACK_WIN;
-        }
-    }
-    return NO_RESULT;
-}
-
 Tablebases::WDLScore probe_wdl(Board& pos, Tablebases::ProbeState* result)
 {
     return Tablebases::probe_wdl(pos, result);

--- a/engine/src/environments/chess_related/board.h
+++ b/engine/src/environments/chess_related/board.h
@@ -165,15 +165,6 @@ std::string pgn_move(Move m, bool chess960, const Board& pos, const std::vector<
 bool leads_to_terminal(const Board& pos, Move m, StateListPtr& states);
 
 /**
- * @brief get_result Returns the current game result. In case a normal position is given NO_RESULT is returned.
- * @param pos Board position
- * @param inCheck Determines if a king in the current position is in check (needed to differ between checkmate and stalemate).
- * It can be computed by `gives_check(<last-move-before-current-position>)`.
- * @return value in [DRAWN, WHITE_WIN, BLACK_WIN, NO_RESULT]
- */
-Result get_result(const Board& pos, bool inCheck);
-
-/**
  * @brief probe_wdl Wrapper for probe_wdl(Position& pos, Tablebases::ProbeState* result)
  * @param pos Board position
  * @param result If result == FAIL then probe was unsuccessful

--- a/engine/src/environments/chess_related/boardstate.cpp
+++ b/engine/src/environments/chess_related/boardstate.cpp
@@ -27,7 +27,7 @@
 #include "boardstate.h"
 #include "inputrepresentation.h"
 #include "syzygy/tbprobe.h"
-
+#include "uci/variants.h"
 
 action_idx_map OutputRepresentation::MV_LOOKUP = {};
 action_idx_map OutputRepresentation::MV_LOOKUP_MIRRORED = {};
@@ -153,6 +153,46 @@ TerminalType BoardState::is_terminal(size_t numberLegalMoves, bool inCheck, floa
         }
     }
 #endif
+#ifdef HORDE
+    if (board.is_horde()) {
+        if (board.is_horde_loss()) {
+            return TERMINAL_LOSS;
+        }
+    }
+#endif
+#ifdef KOTH
+    if (board.is_koth()) {
+        if (board.is_koth_win()) {
+            return TERMINAL_WIN;
+        }
+        if (board.is_koth_loss()) {
+            return TERMINAL_LOSS;
+        }
+    }
+#endif
+#ifdef THREECHECK
+    if (board.is_three_check()) {
+        if (board.is_three_check_win()) {
+            return TERMINAL_WIN;
+        }
+        if (board.is_three_check_loss()) {
+            return TERMINAL_LOSS;
+        }
+    }
+#endif
+#ifdef RACE
+   if (board.is_race()) {
+       if (board.is_race_win()) {
+           return TERMINAL_WIN;
+       }
+       if (board.is_race_draw()) {
+           return TERMINAL_DRAW;
+       }
+       if (board.is_race_loss()) {
+           return TERMINAL_LOSS;
+       }
+   }
+#endif
     if (numberLegalMoves == 0) {
 #ifdef ANTI
         if (board.is_anti()) {
@@ -174,11 +214,6 @@ TerminalType BoardState::is_terminal(size_t numberLegalMoves, bool inCheck, floa
 
     // normal game position
     return TERMINAL_NONE;
-}
-
-Result BoardState::check_result(bool inCheck) const
-{
-    return get_result(board, inCheck);
 }
 
 bool BoardState::gives_check(Action action) const
@@ -207,6 +242,12 @@ void BoardState::set_auxiliary_outputs(const float *auxiliaryOutputs)
 BoardState* BoardState::clone() const
 {
     return new BoardState(*this);
+}
+
+void BoardState::init(int variant, bool is960)
+{
+    states = StateListPtr(new std::deque<StateInfo>(1));
+    board.set(StartFENs[variant], is960, Variant(variant), &states->back(), nullptr);
 }
 
 #endif

--- a/engine/src/environments/chess_related/boardstate.h
+++ b/engine/src/environments/chess_related/boardstate.h
@@ -242,12 +242,12 @@ public:
     Action uci_to_action(string& uciStr) const override;
     string action_to_san(Action action, const vector<Action>& legalActions, bool leadsToWin=false, bool bookMove=false) const override;
     TerminalType is_terminal(size_t numberLegalMoves, bool inCheck, float& customTerminalValue) const override;
-    Result check_result(bool inCheck) const override;
     bool gives_check(Action action) const override;
     void print(ostream& os) const override;
     Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState &result) override;
     void set_auxiliary_outputs(const float* auxiliaryOutputs) override;
     BoardState* clone() const override;
+    void init(int variant, bool isChess960) override;
 };
 
 #endif // BOARTSTATE_H

--- a/engine/src/environments/open_spiel/openspielstate.cpp
+++ b/engine/src/environments/open_spiel/openspielstate.cpp
@@ -93,7 +93,10 @@ unsigned int OpenSpielState::number_repetitions() const
 
 int OpenSpielState::side_to_move() const
 {
-    return spielState->CurrentPlayer();
+    // spielState->CurrentPlayer()) may return negative values for terminal values.
+    // This implementation assumes a two player game with ordered turns.
+    // MoveNumber() assumes to be the number of plies and not chess moves.
+    return spielState->MoveNumber() % 2;
 }
 
 Key OpenSpielState::hash_key() const
@@ -137,36 +140,6 @@ TerminalType OpenSpielState::is_terminal(size_t numberLegalMoves, bool inCheck, 
     return TERMINAL_NONE;
 }
 
-Result OpenSpielState::check_result(bool inCheck) const
-{
-    float dummy;
-    const TerminalType terminalType = is_terminal(0, 0, dummy);
-
-    switch(terminalType) {
-    case TERMINAL_WIN:
-        // spielState->CurrentPlayer()) my return negative values
-        // this implementation assumes a two player game with ordered turns
-        switch (spielState->MoveNumber() % 2) {
-        case 0:
-            return WHITE_WIN;
-        default:
-            return BLACK_WIN;
-        }
-    case TERMINAL_LOSS:
-        switch (spielState->MoveNumber() % 2) {
-        case 0:
-            return BLACK_WIN;
-        default:
-            return WHITE_WIN;
-        }
-    case TERMINAL_NONE:
-        return NO_RESULT;
-    default:
-        return DRAWN;
-    }
-    return NO_RESULT;
-}
-
 bool OpenSpielState::gives_check(Action action) const
 {
     // gives_check() is unavailable
@@ -191,4 +164,8 @@ void OpenSpielState::set_auxiliary_outputs(const float* auxiliaryOutputs)
 OpenSpielState* OpenSpielState::clone() const
 {
     return new OpenSpielState(*this);
+}
+
+void init(int variant, bool isChess960) {
+    spielState = spielGame->NewInitialState();
 }

--- a/engine/src/environments/open_spiel/openspielstate.h
+++ b/engine/src/environments/open_spiel/openspielstate.h
@@ -112,12 +112,12 @@ public:
     Action uci_to_action(std::string &uciStr) const;
     std::string action_to_san(Action action, const std::vector<Action> &legalActions, bool leadsToWin, bool bookMove) const;
     TerminalType is_terminal(size_t numberLegalMoves, bool inCheck, float &customTerminalValue) const;
-    Result check_result(bool inCheck) const;
     bool gives_check(Action action) const;
     void print(std::ostream &os) const;
     Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState &result);
     void set_auxiliary_outputs(const float* auxiliaryOutputs);
     OpenSpielState *clone() const;
+    void init(int variant, bool isChess960);
 };
 
 #endif // OPENSPIELSTATE_H

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -332,6 +332,7 @@ TournamentResult SelfPlay::go_arena(MCTSAgent *mctsContender, size_t numberOfGam
 
 unique_ptr<StateObj> init_state(Variant variant, bool is960, GamePGN& gamePGN)
 {
+    // TODO: Use state->init() here
     unique_ptr<StateObj> state= make_unique<StateObj>();
 #ifdef SUPPORT960
     if (is960) {

--- a/engine/src/state.cpp
+++ b/engine/src/state.cpp
@@ -37,6 +37,30 @@ TerminalType invert_terminal_type(TerminalType terminalType) {
     return terminalType;
 }
 
+Result State::check_result(bool inCheck) const
+{
+    float customTerminalValue;
+    TerminalType terminalType = this->is_terminal(legal_actions().size(), inCheck, customTerminalValue);
+    switch(terminalType) {
+    case TERMINAL_NONE:
+        return NO_RESULT;
+    case TERMINAL_DRAW:
+        return DRAWN;
+    case TERMINAL_WIN:
+        return side_to_move() == FIRST_PLAYER_IDX ? WHITE_WIN : BLACK_WIN;
+    case TERMINAL_LOSS:
+        return side_to_move() == FIRST_PLAYER_IDX ? BLACK_WIN : WHITE_WIN;
+    case TERMINAL_CUSTOM:
+        if (customTerminalValue > 0.0) {
+            return side_to_move() == FIRST_PLAYER_IDX ? WHITE_WIN : BLACK_WIN;
+        }
+        if (customTerminalValue < 0.0) {
+            return side_to_move() == FIRST_PLAYER_IDX ? BLACK_WIN : WHITE_WIN;
+        }
+        return DRAWN;
+    }
+}
+
 TerminalType State::random_rollout(float& customValueTerminal)
 {
     int sideToMove = this->steps_from_null() % 2;

--- a/engine/src/state.h
+++ b/engine/src/state.h
@@ -35,7 +35,11 @@
 #include <memory>
 
 typedef uint64_t Key;
+#ifdef ACTION_64_BIT
 typedef int64_t Action;
+#else
+typedef int32_t Action;
+#endif
 typedef uint16_t MoveIdx;
 typedef unsigned int uint;
 typedef int SideToMove;
@@ -65,7 +69,7 @@ enum Result {
     WHITE_WIN,
     BLACK_WIN,
     NO_RESULT,
-};
+};  // TODO: Check if introduction of CUSTOM_RESULT is required.
 
 /**
  * @brief is_win Return true if the given result is a win, else false
@@ -226,6 +230,14 @@ public:
     }
 
     /**
+     * @brief check_result Returns the current game result. In case a normal position is given NO_RESULT is returned.
+     * @param inCheck Determines if a king in the current position is in check (needed to differ between checkmate and stalemate).
+     * It can be computed by `gives_check(<last-move-before-current-position>)`.
+     * @return value in [DRAWN, WHITE_WIN, BLACK_WIN, NO_RESULT]
+     */
+    Result check_result(bool inCheck) const;
+
+    /**
      * @brief random_rollout Does a random rollout until it reaches a terminal node.
      * This functions modifies the current state and returns the terminal type.
      * @return Terminal type
@@ -351,14 +363,6 @@ public:
     virtual TerminalType is_terminal(size_t numberLegalMoves, bool inCheck, float& customTerminalValue) const = 0;
 
     /**
-     * @brief check_result Returns the current game result. In case a normal position is given NO_RESULT is returned.
-     * @param inCheck Determines if a king in the current position is in check (needed to differ between checkmate and stalemate).
-     * It can be computed by `gives_check(<last-move-before-current-position>)`.
-     * @return value in [DRAWN, WHITE_WIN, BLACK_WIN, NO_RESULT]
-     */
-    virtual Result check_result(bool inCheck) const = 0;
-
-    /**
      * @brief gives_check Checks if the current action is a checking move
      * @param action Action
      * @return bool
@@ -405,6 +409,14 @@ public:
      * @return deep copy
      */
     virtual State* clone() const = 0;
+
+    /**
+     * @brief init Initializes the current state to the starting position.
+     * If there a multiple possible starting positions either choose a random or a fixed one.
+     * @param isChess960 If true 960 mode will be active
+     * @param variant Variant which the position corresponds to
+     */
+    virtual void init(int variant, bool isChess960) = 0;
 };
 
 #endif // GAMESTATE_H

--- a/engine/tests/tests.cpp
+++ b/engine/tests/tests.cpp
@@ -285,10 +285,10 @@ GameInfo apply_random_moves(StateObj& state, uint movesToApply) {
         REQUIRE(state.steps_from_null() == gameInfo.nbAppliedMoves);
         vector<Action> actions = state.legal_actions();
         const Action randomAction = actions[random() % actions.size()];
+        gameInfo.givesCheck = state.gives_check(randomAction);
         state.do_action(actions[random() % actions.size()]);
         ++gameInfo.nbAppliedMoves;
         float dummy;
-        gameInfo.givesCheck = state.gives_check(randomAction);
         if (state.is_terminal(actions.size(), gameInfo.givesCheck, dummy) != TERMINAL_NONE)  {
             gameInfo.reachedTerminal = true;
             return gameInfo;

--- a/engine/tests/tests.h
+++ b/engine/tests/tests.h
@@ -32,6 +32,7 @@
 #ifdef BUILD_TESTS
 #include <vector>
 #include <string>
+#include "stateobj.h"
 #include "environments/chess_related/board.h"
 
 using namespace std;
@@ -68,6 +69,29 @@ void apply_moves_to_board(const vector<string>& uciMoves, Board& pos, StateListP
  * @return boolean
  */
 bool are_all_entries_true(const vector<string>& uciMoves, bool (*foo)(Square, Square));
+
+/**
+ * @brief The GameInfo struct is a return type for apply_random_moves() which provides information about the game.
+ */
+struct GameInfo {
+    uint nbAppliedMoves;
+    bool reachedTerminal;
+    bool givesCheck;
+    GameInfo() :
+        nbAppliedMoves(0),
+        reachedTerminal(false),
+        givesCheck(false) {};
+};
+
+/**
+ * @brief apply_random_moves Applies random legal moves to the state object and returns a GameInfo struct.
+ * If a terminal state is reached the loop stops and GameInfo.givesCheck == true is returned.
+ * @param state Starting position
+ * @param movesToApply Number of moves to apply.
+ * @return GameInfo struct
+ */
+GameInfo apply_random_moves(StateObj& state, uint movesToApply);
+
 
 #endif
 


### PR DESCRIPTION
This PR adds the following functionality:

* provided check_result() implementation in State.h
   * check_result() implementation is not more required in custom environments

+ added unit tests for `State` class
   * State: steps_from_null()
   * State: Reach terminal state
   * State: check_result()
   * State: clone()
+ added `ACTION_64_BIT` for environments which require action of 64 bits
+ added virtual `State.init()` which used for unit tests atm, but may later be used in the RL-loop
+ added missing terminal checks for `HORDE`, `RACE`, `KOTH` and `THREECHECK`
