### PR TITLE
CPU - INT8: Switch between float32 & int8

### DIFF
--- a/engine/src/nn/mxnetapi.h
+++ b/engine/src/nn/mxnetapi.h
@@ -52,7 +52,7 @@ private:
     Context globalCtx = Context::cpu();
 
 public:
-    MXNetAPI(const string& ctx, int deviceID, unsigned int miniBatchSize, const string& modelDirectory, bool tensorRT);
+    MXNetAPI(const string& ctx, int deviceID, unsigned int miniBatchSize, const string& modelDirectory,  const string& strPrecision, bool tensorRT);
     ~MXNetAPI();
 
     void predict(float* inputPlanes, float* valueOutput, float* probOutputs, float* auxiliaryOutputs) override;
@@ -93,6 +93,13 @@ protected:
      * @return Policy NDArray
      */
     NDArray predict(float* inputPlanes, float& value);
+
+private:
+    /**
+     * @brief fill_model_paths Fills the variables modelFilePath, parameterFilePath and modelName
+     * @param strPrecision Neural network precision
+     */
+    void fill_model_paths(const string& strPrecision);
 };
 
 /**

--- a/engine/src/nn/neuralnetapi.cpp
+++ b/engine/src/nn/neuralnetapi.cpp
@@ -28,15 +28,24 @@
 #include "../stateobj.h"
 
 
-string get_file_ending_with(const string& dir, const string& suffix) {
-    const vector<string>& files = get_directory_files(dir);
-    for (const string& file : files) {
-        if (has_suffix(file, suffix)) {
-            return file;
+string get_string_ending_with(const vector<string>& stringVector, const string& suffix) {
+    for (const string& curString : stringVector) {
+        if (has_suffix(curString, suffix)) {
+            return curString;
         }
     }
-    throw invalid_argument( "The given directory at " + dir + " doesn't contain a file ending with " + suffix);
     return "";
+}
+
+vector<string> get_items_by_elment(const vector<string> &stringVector, const string &targetString, bool shouldContain)
+{
+    vector<string> returnVector;
+    for (const string& curString : stringVector) {
+        if ((curString.find(targetString) == std::string::npos) == !shouldContain) {
+            returnVector.emplace_back(curString);
+        }
+    }
+    return returnVector;
 }
 
 

--- a/engine/src/nn/neuralnetapi.h
+++ b/engine/src/nn/neuralnetapi.h
@@ -65,12 +65,22 @@ bool has_suffix(const std::string &str, const std::string &suffix)
 }  // namespace
 
 /**
- * @brief get_file_ending_with Returns the first file of a directory ending with the given suffix
- * @param dir Directory where to look for the file
+ * @brief get_string_ending_with Returns the first string of a list of strings ending with the given suffix
+ * @param stringVector Vector of strings
  * @param suffix Suffix which must be at the end of the file
  * @return The filename of found file excluding the directory and "" and invalid_argument if no file was found
  */
-string get_file_ending_with(const string& dir, const string& suffix);
+string get_string_ending_with(const vector<string>& stringVector, const string& suffix);
+
+/**
+ * @brief get_items_with_elment Returns a vector of all elements of stringVector which contain element
+ * @param stringVector Vector of strings
+ * @param targetString String which searched for in all string vector items
+ * @param shouldContain Boolean indicating if you want to get a vector where each item contains the targetString or
+ * a vector where each item does not contain the targetString
+ * @return new vector
+ */
+vector<string> get_items_by_elment(const vector<string>& stringVector, const string& targetString, bool shouldContain);
 
 
 template <typename T>

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -428,7 +428,7 @@ string CrazyAra::engine_info()
 unique_ptr<NeuralNetAPI> CrazyAra::create_new_net_single(const string& modelDirectory)
 {
 #ifdef MXNET
-    return make_unique<MXNetAPI>(Options["Context"], int(Options["First_Device_ID"]), 1, modelDirectory, false);
+    return make_unique<MXNetAPI>(Options["Context"], int(Options["First_Device_ID"]), 1, modelDirectory, Options["Precision"], false);
 #elif defined TENSORRT
     return make_unique<TensorrtAPI>(int(Options["First_Device_ID"]), 1, modelDirectory, Options["Precision"]);
 #endif
@@ -448,7 +448,7 @@ vector<unique_ptr<NeuralNetAPI>> CrazyAra::create_new_net_batches(const string& 
     for (int deviceId = int(Options["First_Device_ID"]); deviceId <= int(Options["Last_Device_ID"]); ++deviceId) {
         for (size_t i = 0; i < size_t(Options["Threads"]); ++i) {
     #ifdef MXNET
-            netBatches.push_back(make_unique<MXNetAPI>(Options["Context"], deviceId, searchSettings.batchSize, modelDirectory, useTensorRT));
+            netBatches.push_back(make_unique<MXNetAPI>(Options["Context"], deviceId, searchSettings.batchSize, modelDirectory, Options["Precision"], useTensorRT));
     #elif defined TENSORRT
             netBatches.push_back(make_unique<TensorrtAPI>(deviceId, searchSettings.batchSize, modelDirectory, Options["Precision"]));
     #endif

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -104,6 +104,8 @@ void OptionsUCI::init(OptionsMap &o)
 #endif
 #ifdef TENSORRT
     o["Precision"]                     << Option("float16", {"float32", "float16", "int8"});
+#else
+    o["Precision"]                     << Option("int8", {"float32", "int8"});
 #endif
 #ifdef USE_RL
     o["Reuse_Tree"]                    << Option(false);


### PR DESCRIPTION
This PR enables an automatic parsing of the given model file names based on the UCI option "Precision".

This change only affects the MXNetAPI (CPU / IntelMKL) back-end.

Current precision default is set to int8 for CPU.

A set of int8 model weights is expected to contain the string "int8" to be loaded.

If none of these files have been found, a fallback to float32 weights is performed.
