### PR TITLE
Q-Veto-Delta

### DIFF
--- a/engine/src/agents/config/searchsettings.cpp
+++ b/engine/src/agents/config/searchsettings.cpp
@@ -32,6 +32,7 @@ SearchSettings::SearchSettings():
         dirichletAlpha(0.2f),
         nodePolicyTemperature(1.0f),
         qValueWeight(1.0f),
+        qVetoDelta(0.4f),
         virtualLoss(1.0f),
         verbose(true),
         epsilonChecksCounter(100),

--- a/engine/src/agents/config/searchsettings.h
+++ b/engine/src/agents/config/searchsettings.h
@@ -33,7 +33,7 @@
 
 struct SearchSettings
 {
-    unsigned int multiPV;
+    uint16_t multiPV;
     size_t threads;
     unsigned int batchSize;
     float dirichletEpsilon;
@@ -41,6 +41,8 @@ struct SearchSettings
     // policy temperature which can be applied on the every nodes' policy
     float nodePolicyTemperature;
     float qValueWeight;
+    // describes how much better the highest Q-Value has to be to replace the candidate move with the highest visit count
+    float qVetoDelta;
     uint_fast32_t virtualLoss;
     bool verbose;
     uint_fast8_t epsilonChecksCounter;

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -299,7 +299,7 @@ void MCTSAgent::evaluate_board_state()
         run_mcts_search();
         update_stats();
     }
-    update_eval_info(*evalInfo, rootNode, tbHits, maxDepth, searchSettings->multiPV, searchSettings->qValueWeight);
+    update_eval_info(*evalInfo, rootNode, tbHits, maxDepth, searchSettings);
     lastValueEval = evalInfo->bestMoveQ[0];
     update_nps_measurement(evalInfo->calculate_nps());
     tGCThread.join();

--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -109,12 +109,12 @@ int value_to_centipawn(float value)
     return int(-(sgn(value) * std::log(1.0f - std::abs(value)) / std::log(1.2f)) * 100.0f);
 }
 
-void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vector<size_t>& indices)
+void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vector<size_t>& indices, const SearchSettings* searchSettings)
 {
     vector<Action> pv;
     size_t childIdx;
     if (idx == 0) {
-        childIdx = get_best_action_index(rootNode, false, evalInfo.qValueWeight);
+        childIdx = get_best_action_index(rootNode, false, searchSettings->qValueWeight, searchSettings->qVetoDelta);
     }
     else {
         childIdx = indices[idx];
@@ -124,7 +124,7 @@ void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vect
     const Node* nextNode = rootNode->get_child_node(childIdx);
     // make sure the nextNode has been expanded (e.g. when inference of the NN is too slow on the given hardware to evaluate the next node in time)
     if (nextNode != nullptr) {
-        nextNode->get_principal_variation(pv, evalInfo.qValueWeight);
+        nextNode->get_principal_variation(pv, searchSettings->qValueWeight, searchSettings->qVetoDelta);
         evalInfo.pv[idx] = pv;
 
         // scores
@@ -165,9 +165,8 @@ void sort_eval_lists(EvalInfo& evalInfo, vector<size_t>& indices)
     apply_permutation_in_place(indices, p);
 }
 
-void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t selDepth, size_t multiPV, float qValueWeight)
+void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t selDepth, const SearchSettings* searchSettings)
 {
-    evalInfo.qValueWeight = qValueWeight;
     const size_t targetLength = rootNode->get_number_child_nodes();
     evalInfo.childNumberVisits = rootNode->get_child_number_visits();
     evalInfo.qValues = rootNode->get_q_values();
@@ -177,7 +176,7 @@ void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t 
     }
     else {
         size_t bestMoveIdx;
-        rootNode->get_mcts_policy(evalInfo.policyProbSmall, bestMoveIdx, evalInfo.qValueWeight);
+        rootNode->get_mcts_policy(evalInfo.policyProbSmall, bestMoveIdx, searchSettings->qValueWeight, searchSettings->qVetoDelta);
     }
     // ensure the policy has the correct length even if some child nodes have not been visited
     if (evalInfo.policyProbSmall.size() != targetLength) {
@@ -189,13 +188,13 @@ void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t 
     evalInfo.legalMoves = rootNode->get_legal_actions();
 
     vector<size_t> indices;
-    size_t maxIdx = min(multiPV, rootNode->get_no_visit_idx());
+    size_t maxIdx = min(searchSettings->multiPV, rootNode->get_no_visit_idx());
 
     if (maxIdx > 1) {
         sort_eval_lists(evalInfo, indices);
     }
 
-    evalInfo.init_vectors_for_multi_pv(multiPV);
+    evalInfo.init_vectors_for_multi_pv(searchSettings->multiPV);
 
     if (targetLength == 1 && rootNode->is_blank_root_node()) {
         // single move with no tree reuse
@@ -206,7 +205,7 @@ void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t 
     }
     else {
         for (size_t idx = 0; idx < maxIdx; ++idx) {
-            set_eval_for_single_pv(evalInfo, rootNode, idx, indices);
+            set_eval_for_single_pv(evalInfo, rootNode, idx, indices, searchSettings);
         }
     }
 

--- a/engine/src/evalinfo.h
+++ b/engine/src/evalinfo.h
@@ -57,7 +57,6 @@ struct EvalInfo
     Action bestMove;
     std::vector<int> movesToMate;
     size_t tbHits;
-    float qValueWeight;
 
     size_t calculate_elapsed_time_ms() const;
     size_t calculate_nps(size_t elapsedTimeMS) const;
@@ -81,10 +80,9 @@ int value_to_centipawn(float value);
  * @param evalInfo Evaluation infomration struct
  * @param rootNode Root node of the search tree
  * @param selDepth Selective depth, in this case the maximum reached depth
- * @param multiPV Number of pv lines (default=1)
- * @param qValueWeight Decides if Q-values shall be used to compute the MCTS policy (e.g. qValueWeight=0, visitsOnly)
+ * @param searchSettings searchSettings struct
  */
-void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t selDepth, size_t multiPV, float qValueWeight);
+void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t selDepth, const SearchSettings* searchSettings);
 
 /**
  * @brief set_eval_for_single_pv Sets the eval struct pv line and score for a single pv
@@ -93,7 +91,7 @@ void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t 
  * @param idx index of the pv line
  * @param indices sorted indices of each child node
  */
-void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vector<size_t>& indices);
+void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vector<size_t>& indices, const SearchSettings* searchSettings);
 
 /**
  * @brief operator << Returns all MultiPV as a string sperated by endl

--- a/engine/src/manager/threadmanager.cpp
+++ b/engine/src/manager/threadmanager.cpp
@@ -47,7 +47,7 @@ ThreadManager::ThreadManager(Node* rootNode, EvalInfo* evalInfo, vector<SearchTh
 void ThreadManager::print_info()
 {
     evalInfo->end = chrono::steady_clock::now();
-    update_eval_info(*evalInfo, rootNode, get_tb_hits(searchThreads), get_max_depth(searchThreads), searchSettings->multiPV, searchSettings->qValueWeight);
+    update_eval_info(*evalInfo, rootNode, get_tb_hits(searchThreads), get_max_depth(searchThreads), searchSettings);
     info_msg(*evalInfo);
 }
 

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -278,7 +278,7 @@ public:
     float get_action_value() const;
     SearchSettings* get_search_settings() const;
 
-    size_t get_no_visit_idx() const;
+    uint16_t get_no_visit_idx() const;
 
     bool is_fully_expanded() const;
 
@@ -333,16 +333,18 @@ public:
      * @param mctsPolicy Output of the final mcts policy after search
      * @param bestMoveIdx Index for the best move
      * @param qValueWeight Decides if Q-values are taken into account
+     * @param qVetoDelta Describes how much better the highest Q-Value has to be to replace the candidate move with the highest visit count
      */
-     void get_mcts_policy(DynamicVector<float>& mctsPolicy, size_t& bestMoveIdx, float qValueWeight) const;
+     void get_mcts_policy(DynamicVector<float>& mctsPolicy, size_t& bestMoveIdx, float qValueWeight, float qVetoDelta) const;
 
     /**
      * @brief get_principal_variation Traverses the tree using the get_mcts_policy() function until a leaf or terminal node is found.
      * The moves a are pushed into the pv vector.
      * @param pv Vector in which moves will be pushed.
      * @param qValueWeight Decides if Q-values are taken into account
+     * @param qVetoDelta Describes how much better the highest Q-Value has to be to replace the candidate move with the highest visit count
      */
-     void get_principal_variation(vector<Action>& pv, bool qValueWeight) const;
+     void get_principal_variation(vector<Action>& pv, float qValueWeight, float qVetoDelta) const;
 
     /**
      * @brief mark_nodes_as_fully_expanded Sets the noVisitIdx to be the number of child nodes.
@@ -662,9 +664,10 @@ private:
  * @param curNode Current node
  * @param fast If true, then the argmax(childNumberVisits) is returned for unsolved nodes
  * @param qValueWeight Decides if qValues are taken into account
+ * @param qVetoDelta Describes how much better the highest Q-Value has to be to replace the candidate move with the highest visit count
  * @return Index for best move and child node
  */
- size_t get_best_action_index(const Node* curNode, bool fast, bool qValueWeight);
+ size_t get_best_action_index(const Node* curNode, bool fast, float qValueWeight, float qVetoDelto);
 
 void add_item_to_delete(Node* node, unordered_map<Key, Node*>& hashTable, GCThread<Node>& gcThread);
 

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -136,7 +136,7 @@ void random_playout(NodeDescription& description, Node* currentNode, ChildIdx& c
         childIdx = uint16_t(-1);
     }
     else {
-        childIdx = min(currentNode->get_no_visit_idx(), currentNode->get_number_child_nodes()-1);
+        childIdx = min(size_t(currentNode->get_no_visit_idx()), currentNode->get_number_child_nodes()-1);
         currentNode->increment_no_visit_idx();
         return;
     }
@@ -147,7 +147,7 @@ Node* SearchThread::get_starting_node(Node* currentNode, NodeDescription& descri
     size_t depth = get_random_depth();
     for (uint curDepth = 0; curDepth < depth; ++curDepth) {
         currentNode->lock();
-        childIdx = get_best_action_index(currentNode, true, 0);
+        childIdx = get_best_action_index(currentNode, true, 0, 0);
         Node* nextNode = currentNode->get_child_node(childIdx);
         if (nextNode == nullptr || !nextNode->is_playout_node() || nextNode->get_visits() < searchSettings->epsilonGreedyCounter || nextNode->get_node_type() != UNSOLVED) {
             currentNode->unlock();

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -486,6 +486,7 @@ void CrazyAra::init_search_settings()
 //    searchSettings.uMin = Options["Centi_U_Min"] / 100.0f;                      currently disabled
 //    searchSettings.uBase = Options["U_Base"];                                   currently disabled
     searchSettings.qValueWeight = Options["Centi_Q_Value_Weight"] / 100.0f;
+    searchSettings.qVetoDelta = Options["Centi_Q_Veto_Delta"] / 100.0f;
     searchSettings.epsilonChecksCounter = round((1.0f / Options["Centi_Epsilon_Checks"]) * 100.0f);
     searchSettings.epsilonGreedyCounter = round((1.0f / Options["Centi_Epsilon_Greedy"]) * 100.0f);
 //    searchSettings.enhanceCaptures = Options["Enhance_Captures"];               //currently disabled

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -65,6 +65,7 @@ void OptionsUCI::init(OptionsMap &o)
 //    o["U_Base"]                        << Option(1965, 0, 99999);      currently disabled
     o["Centi_Node_Temperature"]        << Option(170, 1, 99999);
     o["Centi_Q_Value_Weight"]          << Option(100, 0, 99999);
+    o["Centi_Q_Veto_Delta"]            << Option(40, 0, 99999);
 #ifdef USE_RL
     o["Centi_Quantile_Clipping"]       << Option(0, 0, 100);
 #else
@@ -94,7 +95,6 @@ void OptionsUCI::init(OptionsMap &o)
     o["Fixed_Movetime"]                << Option(0, 0, 99999999);
     o["Last_Device_ID"]                << Option(0, 0, 99999);
     o["Log_File"]                      << Option("", on_logger);
-    o["Max_Search_Depth"]              << Option(99, 1, 99999);
     o["MCTS_Solver"]                   << Option(true);
 #ifdef MODE_CRAZYHOUSE
     o["Model_Directory"]               << Option("model/crazyhouse");


### PR DESCRIPTION
* added UCI-Option Centi_Q_Veto_Delta (closes #85)
   *   Describes how much better the highest Q-Value has to be to replace the candidate move with the highest visit count, default value: 40

* removed unused option Max_Search_Depth

TC: 10s + 0.1s
```python
Score of ClassicAra 0.9.1 - Q-Veto-Delta - 0.4 vs ClassicAra 0.9.0: 17 -
7 - 44 [0.574]
Elo difference: 51.5 +/- 48.9, LOS: 97.9 %, DrawRatio: 64.7 %

68 of 1000 games finished.
```
