### PR TITLE
mctsPolicy<double>

### DIFF
--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -193,8 +193,8 @@ void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t 
     // ensure the policy has the correct length even if some child nodes have not been visited
     if (evalInfo.policyProbSmall.size() != targetLength) {
         const size_t startIdx = evalInfo.policyProbSmall.size();
-        fill_missing_values<float>(evalInfo.policyProbSmall, startIdx, targetLength, 0.0f);
-        fill_missing_values<float>(evalInfo.childNumberVisits, startIdx, targetLength, 0.0f);
+        fill_missing_values<double>(evalInfo.policyProbSmall, startIdx, targetLength, 0.0);
+        fill_missing_values<double>(evalInfo.childNumberVisits, startIdx, targetLength, 0.0);
         fill_missing_values<float>(evalInfo.qValues, startIdx, targetLength, LOSS_VALUE);
     }
     evalInfo.legalMoves = rootNode->get_legal_actions();

--- a/engine/src/evalinfo.h
+++ b/engine/src/evalinfo.h
@@ -44,8 +44,8 @@ struct EvalInfo
     chrono::steady_clock::time_point end;
     std::vector<float> bestMoveQ;
     std::vector<Action> legalMoves;
-    DynamicVector<float> policyProbSmall;
-    DynamicVector<float> childNumberVisits;
+    DynamicVector<double> policyProbSmall;
+    DynamicVector<double> childNumberVisits;
     DynamicVector<float> qValues;
     std::vector<int> centipawns;
     size_t depth;

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -335,7 +335,7 @@ public:
      * @param qValueWeight Decides if Q-values are taken into account
      * @param qVetoDelta Describes how much better the highest Q-Value has to be to replace the candidate move with the highest visit count
      */
-     void get_mcts_policy(DynamicVector<float>& mctsPolicy, size_t& bestMoveIdx, float qValueWeight, float qVetoDelta) const;
+     void get_mcts_policy(DynamicVector<double>& mctsPolicy, size_t& bestMoveIdx, float qValueWeight, float qVetoDelta) const;
 
     /**
      * @brief get_principal_variation Traverses the tree using the get_mcts_policy() function until a leaf or terminal node is found.
@@ -629,20 +629,14 @@ private:
      * remaining moves to 0. Afterwards the policy is renormalized.
      * @param mctsPolicy MCTS policy which will be set
      */
-    void mcts_policy_based_on_wins(DynamicVector<float>& mctsPolicy) const;
+    void mcts_policy_based_on_wins(DynamicVector<double>& mctsPolicy) const;
 
     /**
      * @brief prune_losses_in_mcts_policy Sets all known losing moves in a given policy to 0 in case
      * the node is not known to be losing.
      * @param mctsPolicy MCTS policy which will be set
      */
-    void prune_losses_in_mcts_policy(DynamicVector<float>& mctsPolicy) const;
-
-    /**
-     * @brief mcts_policy_based_on_q_n Creates the MCTS policy based on visits and Q-values
-     * @param mctsPolicy MCTS policy which will be set
-     */
-    void mcts_policy_based_on_q_n(DynamicVector<float>& mctsPolicy, float qValueWeight) const;
+    void prune_losses_in_mcts_policy(DynamicVector<double>& mctsPolicy) const;
 
 //    /**
 //     * @brief mark_enhaned_moves Fills the isCheck and isCapture vector according to the legal moves

--- a/engine/src/stateobj.cpp
+++ b/engine/src/stateobj.cpp
@@ -27,7 +27,7 @@
 #include "constants.h"
 
 
-void get_probs_of_move_list(const size_t batchIdx, const float* policyProb, const std::vector<Action>& legalMoves, SideToMove sideToMove, bool normalize, DynamicVector<float> &policyProbSmall, bool selectPolicyFromPlane)
+void get_probs_of_move_list(const size_t batchIdx, const float* policyProb, const std::vector<Action>& legalMoves, SideToMove sideToMove, bool normalize, DynamicVector<double> &policyProbSmall, bool selectPolicyFromPlane)
 {
     size_t vectorIdx;
     for (size_t mvIdx = 0; mvIdx < legalMoves.size(); ++mvIdx) {

--- a/engine/src/stateobj.h
+++ b/engine/src/stateobj.h
@@ -70,7 +70,7 @@ using blaze::DynamicVector;
  * @return policyProbSmall - A hybrid blaze vector which stores the probabilities for the given move list
  */
 void get_probs_of_move_list(const size_t batchIdx, const float* policyProb, const std::vector<Action>& legalMoves, SideToMove sideToMove,
-                            bool normalize, DynamicVector<float> &policyProbSmall, bool selectPolicyFromPlane);
+                            bool normalize, DynamicVector<double> &policyProbSmall, bool selectPolicyFromPlane);
 
 /**
  * @brief get_policy_data_batch Returns the pointer of the batch for the policy predictions


### PR DESCRIPTION
Changed variable type of MCTS-Policy to double.

This is to avoid artifacts for more than 16 million visits (#39)

Deleted unused function `mcts_policy_based_on_q_n()`.

---

TC: 10s + 0.1s
```python
Score of ClassicAra 0.9.1 - TB- 3-4-5-wdl vs ClassicAra 0.9.1 - TB- 3-4-5-wdl - prev: 8 - 6 - 26 [0.525]
Elo difference: 17.4 +/- 64.3, LOS: 70.4 %, DrawRatio: 65.0 %

40 of 1000 games finished.
```