### PR TITLE
RL Readme change

### DIFF
--- a/engine/src/rl/README.md
+++ b/engine/src/rl/README.md
@@ -76,7 +76,7 @@ cd /root/CrazyAra/engine/src/rl
 You need to specify at least one gpu to also update the current neural network weights.
 The gpu trainer will stop generating games and update the network as soon as enough training samples have been acquired.
 
-<img class="emoji" title=":warning:" alt=":warning:" src="https://camo.githubusercontent.com/163bb588effffc0b9d07dac9331ace26e508806732e5f0a66bad309c3a2a5784/68747470733a2f2f6769746875622e6769746875626173736574732e636f6d2f696d616765732f69636f6e732f656d6f6a692f756e69636f64652f323661302e706e67" height="20" width="20" align="absmiddle" data-canonical-src="https://github.githubassets.com/images/icons/emoji/unicode/26a0.png">
+<img class="emoji" title=":warning:" alt=":warning:" height="20" width="20" align="absmiddle" src="https://github.githubassets.com/images/icons/emoji/unicode/26a0.png">
 There can only be one trainer and it must be started before starting any generators to ensure correct indexing.
 
 ```shell script

--- a/engine/src/rl/README.md
+++ b/engine/src/rl/README.md
@@ -63,6 +63,8 @@ Alternatively, if a model file is already available on the host machine, you can
 After all premilirary action have been done, you can finally start selfplay from a given checkpoint file, which is stored in the directory `/data/RL/model/`.
 If you want to start learning from zero knowledge, you may use a set of weights which have initialized randomly.
 
+If the program cannot find a model inside `/data/RL/model/` it will look at `/data/RL/model/<variant>/`, where `<variant>` is the selected chess variant.
+
 The python script [**rl_loop.py**](https://github.com/QueensGambit/CrazyAra/blob/master/engine/src/rl/rl_loop.py) is the main script for managing the reinforcement learning loop.
 It can be started in two different modes: a generator mode, and a generator+training mode.
 
@@ -70,18 +72,21 @@ It can be started in two different modes: a generator mode, and a generator+trai
 cd /root/CrazyAra/engine/src/rl
 ```
 
-
-##### Generator
-```shell script
-python rl_loop.py --device-id 0&
-```
-
 ##### Trainer
 You need to specify at least one gpu to also update the current neural network weights.
 The gpu trainer will stop generating games and update the network as soon as enough training samples have been acquired.
 
+<img class="emoji" title=":warning:" alt=":warning:" src="https://camo.githubusercontent.com/163bb588effffc0b9d07dac9331ace26e508806732e5f0a66bad309c3a2a5784/68747470733a2f2f6769746875622e6769746875626173736574732e636f6d2f696d616765732f69636f6e732f656d6f6a692f756e69636f64652f323661302e706e67" height="20" width="20" align="absmiddle" data-canonical-src="https://github.githubassets.com/images/icons/emoji/unicode/26a0.png">
+There can only be one trainer and it must be started before starting any generators to ensure correct indexing.
+
 ```shell script
-python rl_loop.py --device-id 1 --trainer&
+python rl_loop.py --device-id 0 --trainer &
+```
+
+##### Generator
+The other gpu's can be used to generate games.
+```shell script
+python rl_loop.py --device-id 1 &
 ```
 
 #### Configuration

--- a/engine/src/rl/README.md
+++ b/engine/src/rl/README.md
@@ -76,8 +76,7 @@ cd /root/CrazyAra/engine/src/rl
 You need to specify at least one gpu to also update the current neural network weights.
 The gpu trainer will stop generating games and update the network as soon as enough training samples have been acquired.
 
-<img class="emoji" title=":warning:" alt=":warning:" height="20" width="20" align="absmiddle" src="https://github.githubassets.com/images/icons/emoji/unicode/26a0.png">
-There can only be one trainer and it must be started before starting any generators to ensure correct indexing.
+:warning: There can only be one trainer and it must be started before starting any generators to ensure correct indexing.
 
 ```shell script
 python rl_loop.py --device-id 0 --trainer &


### PR DESCRIPTION
Simple change to the reinforcement learning `README.md`
* Added a note that the `trainer` gpu has to be started first
* Added a note that there can be at most 1 trainer gpu
* Described from which folders the `rl_loop.py` will load the model 