### PR TITLE
Dynamic NN Reloading

### DIFF
--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -53,7 +53,7 @@ const string engineName = "MultiAra";
 const string engineName = "ClassicAra";
 #endif
 
-const string engineVersion = "0.9.0";
+const string engineVersion = "0.9.1-Dev";
 const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al.";
 
 #define LOSS_VALUE -1

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -500,8 +500,19 @@ vector<unique_ptr<NeuralNetAPI>> CrazyAra::create_new_net_batches(const string& 
 
 void CrazyAra::set_uci_option(istringstream &is, StateObj& state)
 {
+    // these three UCI-Options may trigger a network reload, keep an eye on them
+    const string prevModelDir = Options["Model_Directory"];
+    const int prevThreads = Options["Threads"];
+    const string prevUciVariant = Options["UCI_Variant"];
+
     OptionsUCI::setoption(is, variant, state);
     changedUCIoption = true;
+    if (networkLoaded) {
+        if (string(Options["Model_Directory"]) != prevModelDir || int(Options["Threads"]) != prevThreads || string(Options["UCI_Variant"]) != prevUciVariant) {
+            networkLoaded = false;
+            is_ready();
+        }
+    }
 }
 
 unique_ptr<MCTSAgent> CrazyAra::create_new_mcts_agent(NeuralNetAPI* netSingle, vector<unique_ptr<NeuralNetAPI>>& netBatches, SearchSettings* searchSettings)

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -205,9 +205,18 @@ void OptionsUCI::setoption(istringstream &is, Variant& variant, StateObj& state)
         value += (value.empty() ? "" : " ") + token;
 
     if (Options.find(name) != Options.end()) {
-        Options[name] = value;
-        cout << "info string Updated option " << name << " to " << value << endl;
+        const string givenName = name;
         std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+#ifdef MODE_LICHESS
+        if (name == "model_directory") {
+            if (value.find((string)Options["UCI_Variant"]) == std::string::npos) {
+                cout << "info string The Model_Directory must have the active UCI_Variant '" << (string)Options["UCI_Variant"] << "' in its filepath" << endl;
+                return;
+            }
+        }
+#endif
+        Options[name] = value;
+        cout << "info string Updated option " << givenName << " to " << value << endl;
         if (name == "uci_variant") {
 #ifdef XIANGQI
             // Workaround. Fairy-Stockfish does not use an enum for variants

--- a/engine/src/uci/variants.h
+++ b/engine/src/uci/variants.h
@@ -31,8 +31,8 @@
 #include "types.h"
 using namespace std;
 
-// list of all current available variants for CrazyAra
-static vector<string> availableVariants = {
+// list of all current available variants for MultiAra
+const static vector<string> availableVariants = {
     "3check",
     "atomic",
     "chess",


### PR DESCRIPTION
This PR enables dynamic reload of the neural network if the value for `Model_Directory`, `Threads` or `UCI_Variant` was changed.

* added check for _MultiAra_ that the `Model_Directory` must have the `UCI_Variant` in its file path
    * otherwise ther could be a problem of conflicting UCI_Variant and Model_Directory values

