### PR TITLE
Time-out readyok thread

### DIFF
--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -72,6 +72,7 @@ const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al."
 #else
 #define VALUE_TO_CENTI_PARAM 1.2f
 #endif
+#define TIME_OUT_IS_READY_MS 13000
 
 #ifndef MODE_POMMERMAN
 #define TERMINAL_NODE_CACHE 8192

--- a/engine/src/uci/crazyara.h
+++ b/engine/src/uci/crazyara.h
@@ -38,6 +38,7 @@
 #include "agents/config/playsettings.h"
 #include "node.h"
 #include "uci.h"
+#include "timeoutreadythread.h"
 #ifdef USE_RL
 #include "rl/selfplay.h"
 #include "agents/config/rlsettings.h"

--- a/engine/src/uci/timeoutreadythread.cpp
+++ b/engine/src/uci/timeoutreadythread.cpp
@@ -1,0 +1,42 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: timeoutreadythread.cpp
+ * Created on 05.05.2021
+ * @author: queensgambit
+ */
+
+#include "timeoutreadythread.h"
+
+void TimeOutReadyThread::print_is_ready()
+{
+    isRunning = true;
+    size_t remainingMoveTimeMS = timeOutMS;
+    remainingMoveTimeMS = timeOutMS;
+    if (wait_for(chrono::milliseconds(timeOutMS))){
+        if (isRunning) {
+            cout << "readyok" << endl;
+        }
+    }
+}
+
+void run_timeout_thread(TimeOutReadyThread* t) {
+    t->print_is_ready();
+}

--- a/engine/src/uci/timeoutreadythread.h
+++ b/engine/src/uci/timeoutreadythread.h
@@ -1,0 +1,61 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: timeoutreadythread.h
+ * Created on 05.05.2021
+ * @author: queensgambit
+ *
+ * Thread which prints out "readyok" after a given amount of ms unless killed.
+ * This is to avoid running into time outs of e.g. cutechess on Multi-GPU systems when deserializing complex NN architectures.
+ */
+
+#ifndef TIMEOUTREADYTHREAD_H
+#define TIMEOUTREADYTHREAD_H
+
+#include <iostream>
+#include "util/killablethread.h"
+
+using namespace std;
+
+/**
+ * @brief The TimeOutReadyThread class prints out "readyok" after a given amout of "timeOutMS" unless it is killed before.
+ */
+class TimeOutReadyThread : public KillableThread
+{
+
+private:
+    size_t timeOutMS;
+    size_t updateIntervalMS = 250;
+    bool isRunning;
+public:
+    TimeOutReadyThread(size_t timeOutMS) : timeOutMS(timeOutMS) {}
+
+    void print_is_ready();
+};
+
+
+/**
+ * @brief run_timeout_thread Runner function to start the time out thread
+ * @param t TimeOutReady thread object
+ */
+void run_timeout_thread(TimeOutReadyThread* t);
+
+
+#endif // TIMEOUTREADYTHREAD_H

--- a/engine/src/util/killablethread.h
+++ b/engine/src/util/killablethread.h
@@ -67,6 +67,12 @@ public:
         cv.notify_all();
         isRunning = false;
     }
+    /**
+     * @brief stop Stops the current thre without triggering the conditional variable
+     */
+    void stop() {
+        isRunning = false;
+    }
 
     KillableThread() = default;
     KillableThread(KillableThread&&)=delete;


### PR DESCRIPTION
* added TimeOutReadyThread
 * Thread which prints out "readyok" after a given amount of ms unless
killed.
 * This is to avoid running into time outs of e.g. cutechess on Multi-
GPU systems when deserializing complex NN architectures.

