### PR TITLE
UCI Option "Timeout_MS"

### DIFF
--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -53,7 +53,7 @@ const string engineName = "MultiAra";
 const string engineName = "ClassicAra";
 #endif
 
-const string engineVersion = "0.9.2";
+const string engineVersion = "0.9.2.post0";
 const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al.";
 
 #define LOSS_VALUE -1
@@ -72,7 +72,6 @@ const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al."
 #else
 #define VALUE_TO_CENTI_PARAM 1.2f
 #endif
-#define TIME_OUT_IS_READY_MS 13000
 
 #ifndef MODE_POMMERMAN
 #define TERMINAL_NODE_CACHE 8192

--- a/engine/src/nn/mxnetapi.h
+++ b/engine/src/nn/mxnetapi.h
@@ -58,11 +58,11 @@ public:
     void predict(float* inputPlanes, float* valueOutput, float* probOutputs, float* auxiliaryOutputs) override;
 
 protected:
-    void load_model();
-    void load_parameters();
-    void bind_executor();
+    void load_model() override;
+    void load_parameters() override;
+    void bind_executor() override;
 
-    void init_nn_design();
+    void init_nn_design() override;
 
     /**
      * @brief SplitParamMap Splits loaded param map into arg parm and aux param with target context

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -433,7 +433,8 @@ void CrazyAra::init()
 bool CrazyAra::is_ready()
 {
     if (!networkLoaded) {
-        TimeOutReadyThread timeoutThread(TIME_OUT_IS_READY_MS);
+        const size_t timeoutMS = Options["Timeout_MS"];
+        TimeOutReadyThread timeoutThread(timeoutMS);
         thread tTimeoutThread = thread(run_timeout_thread, &timeoutThread);
         init_search_settings();
         init_play_settings();

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -152,6 +152,7 @@ void OptionsUCI::init(OptionsMap &o)
     o["SyzygyPath"]                    << Option("<empty>", on_tb_path);
 #endif
     o["Threads"]                       << Option(2, 1, 512);
+    o["Timeout_MS"]                    << Option(13000, 1, 99999999);
 #ifdef MODE_CRAZYHOUSE
       // we repeat "crazyhouse" in the list because of problem in XBoard/Winboard #23
     o["UCI_Variant"]                   << Option("crazyhouse", {"crazyhouse", "crazyhouse"});


### PR DESCRIPTION
* replaced constant TIME_OUT_IS_READY_MS by
UCI option "Timeout_MS"

* default value is 13000
after this time "readyok" will be replied to avoid running in a time-out

* update to engine version 0.9.2.post0

