### PR TITLE
Simplified state interface

### DIFF
--- a/engine/src/environments/chess_related/boardstate.cpp
+++ b/engine/src/environments/chess_related/boardstate.cpp
@@ -63,7 +63,6 @@ vector<Action> BoardState::legal_actions() const
 void BoardState::set(const string &fenStr, bool isChess960, int variant)
 {
     states = StateListPtr(new std::deque<StateInfo>(1));
-    variant = UCI::variant_from_name(Options["UCI_Variant"]);
     board.set(fenStr, isChess960, Variant(variant), &states->back(), nullptr);
 }
 
@@ -133,7 +132,7 @@ string BoardState::action_to_san(Action action, const vector<Action>& legalActio
     return pgn_move(Move(action), this->is_chess960(), board, legalActions, leadsToWin, bookMove);
 }
 
-TerminalType BoardState::is_terminal(size_t numberLegalMoves, bool inCheck, float& customTerminalValue) const
+TerminalType BoardState::is_terminal(size_t numberLegalMoves, float& customTerminalValue) const
 {
 #ifdef ATOMIC
     if (board.is_atomic()) {
@@ -203,7 +202,7 @@ TerminalType BoardState::is_terminal(size_t numberLegalMoves, bool inCheck, floa
         }
 #endif
         // test if we have a check-mate
-        if (inCheck) {
+        if (board.checkers()) {
             return TERMINAL_LOSS;
         }
         // we reached a stalmate

--- a/engine/src/environments/chess_related/boardstate.h
+++ b/engine/src/environments/chess_related/boardstate.h
@@ -241,7 +241,7 @@ public:
     void flip() override;
     Action uci_to_action(string& uciStr) const override;
     string action_to_san(Action action, const vector<Action>& legalActions, bool leadsToWin=false, bool bookMove=false) const override;
-    TerminalType is_terminal(size_t numberLegalMoves, bool inCheck, float& customTerminalValue) const override;
+    TerminalType is_terminal(size_t numberLegalMoves, float& customTerminalValue) const override;
     bool gives_check(Action action) const override;
     void print(ostream& os) const override;
     Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState &result) override;

--- a/engine/src/environments/fairy_state/fairystate.cpp
+++ b/engine/src/environments/fairy_state/fairystate.cpp
@@ -82,18 +82,14 @@ Action FairyState::uci_to_action(string &uciStr) const {
     return Action(UCI::to_move(board, uciStr));
 }
 
-TerminalType FairyState::is_terminal(size_t numberLegalMoves, bool inCheck, float &customTerminalValue) const {
+TerminalType FairyState::is_terminal(size_t numberLegalMoves, float &customTerminalValue) const {
     if (numberLegalMoves == 0) {
-        if (inCheck) {
+        if (board.checkers()) {
             return TERMINAL_LOSS;
         }
         return TERMINAL_DRAW;
     }
     return TERMINAL_NONE;
-}
-
-Result FairyState::check_result(bool inCheck) const {
-    return get_result(board, inCheck);
 }
 
 bool FairyState::gives_check(Action action) const {

--- a/engine/src/environments/fairy_state/fairystate.h
+++ b/engine/src/environments/fairy_state/fairystate.h
@@ -131,8 +131,7 @@ public:
     Key hash_key() const override;
     void flip() override;
     Action uci_to_action(std::string& uciStr) const override;
-    TerminalType is_terminal(size_t numberLegalMoves, bool inCheck, float& customTerminalValue) const override;
-    Result check_result(bool inCheck) const;
+    TerminalType is_terminal(size_t numberLegalMoves, float& customTerminalValue) const override;
     bool gives_check(Action action) const override;
     void print(std::ostream& os) const override;
     FairyState* clone() const override;

--- a/engine/src/environments/open_spiel/openspielstate.cpp
+++ b/engine/src/environments/open_spiel/openspielstate.cpp
@@ -121,7 +121,7 @@ std::string OpenSpielState::action_to_san(Action action, const std::vector<Actio
     return spielState->ActionToString(spielState->CurrentPlayer(), action);
 }
 
-TerminalType OpenSpielState::is_terminal(size_t numberLegalMoves, bool inCheck, float &customTerminalValue) const
+TerminalType OpenSpielState::is_terminal(size_t numberLegalMoves, float &customTerminalValue) const
 {
     if (spielState->IsTerminal()) {
         const double currentReturn = spielState->Returns()[spielState->MoveNumber() % 2];

--- a/engine/src/environments/open_spiel/openspielstate.h
+++ b/engine/src/environments/open_spiel/openspielstate.h
@@ -111,7 +111,7 @@ public:
     void flip();
     Action uci_to_action(std::string &uciStr) const;
     std::string action_to_san(Action action, const std::vector<Action> &legalActions, bool leadsToWin, bool bookMove) const;
-    TerminalType is_terminal(size_t numberLegalMoves, bool inCheck, float &customTerminalValue) const;
+    TerminalType is_terminal(size_t numberLegalMoves, float &customTerminalValue) const;
     bool gives_check(Action action) const;
     void print(std::ostream &os) const;
     Tablebase::WDLScore check_for_tablebase_wdl(Tablebase::ProbeState &result);

--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -754,7 +754,7 @@ void Node::mark_as_terminal()
 void Node::check_for_terminal(StateObj* pos, bool inCheck)
 {
     float customValue;
-    TerminalType terminalType = pos->is_terminal(get_number_child_nodes(), inCheck, customValue);
+    TerminalType terminalType = pos->is_terminal(get_number_child_nodes(), customValue);
 
     if (terminalType != TERMINAL_NONE) {
         mark_as_terminal();

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -39,10 +39,7 @@
 
 void play_move_and_update(const EvalInfo& evalInfo, StateObj* state, GamePGN& gamePGN, Result& gameResult)
 {
-    bool givesCheck = state->gives_check(evalInfo.bestMove);
-    std::unique_ptr<StateObj> stateClone = std::unique_ptr<StateObj>(state->clone());
-    stateClone->do_action(evalInfo.bestMove);
-    gameResult = stateClone->check_result(givesCheck);
+    gameResult = state->check_result();
     gamePGN.gameMoves.push_back(state->action_to_san(evalInfo.bestMove, evalInfo.legalMoves, is_win(gameResult), false));
     state->do_action(evalInfo.bestMove);
 }

--- a/engine/src/state.cpp
+++ b/engine/src/state.cpp
@@ -37,10 +37,10 @@ TerminalType invert_terminal_type(TerminalType terminalType) {
     return terminalType;
 }
 
-Result State::check_result(bool inCheck) const
+Result State::check_result() const
 {
     float customTerminalValue;
-    TerminalType terminalType = this->is_terminal(legal_actions().size(), inCheck, customTerminalValue);
+    TerminalType terminalType = this->is_terminal(legal_actions().size(), customTerminalValue);
     switch(terminalType) {
     case TERMINAL_NONE:
         return NO_RESULT;
@@ -67,7 +67,7 @@ TerminalType State::random_rollout(float& customValueTerminal)
     while(true) {
         const std::vector<Action> actions = this->legal_actions();
         const size_t numberActions = actions.size();
-        TerminalType terminalType = this->is_terminal(numberActions, false, customValueTerminal);
+        TerminalType terminalType = this->is_terminal(numberActions, customValueTerminal);
         if (terminalType != TERMINAL_NONE) {
             if (this->steps_from_null() % 2 == sideToMove) {
                 return terminalType;

--- a/engine/src/state.h
+++ b/engine/src/state.h
@@ -224,9 +224,8 @@ public:
     bool leads_to_terminal(Action a)
     {
         std::unique_ptr<State> posCheckTerminal = std::unique_ptr<State>(this->clone());
-        bool givesCheck = posCheckTerminal->gives_check(a);
         posCheckTerminal->do_action(a);
-        return posCheckTerminal->check_result(givesCheck) != NO_RESULT;
+        return posCheckTerminal->check_result() != NO_RESULT;
     }
 
     /**
@@ -235,7 +234,7 @@ public:
      * It can be computed by `gives_check(<last-move-before-current-position>)`.
      * @return value in [DRAWN, WHITE_WIN, BLACK_WIN, NO_RESULT]
      */
-    Result check_result(bool inCheck) const;
+    Result check_result() const;
 
     /**
      * @brief random_rollout Does a random rollout until it reaches a terminal node.
@@ -360,7 +359,7 @@ public:
      * otherwise the value will later be overwritten. In the default case, this parameter can be ignored.
      * @return TerminalType
      */
-    virtual TerminalType is_terminal(size_t numberLegalMoves, bool inCheck, float& customTerminalValue) const = 0;
+    virtual TerminalType is_terminal(size_t numberLegalMoves, float& customTerminalValue) const = 0;
 
     /**
      * @brief gives_check Checks if the current action is a checking move

--- a/engine/src/uci/customlogger.cpp
+++ b/engine/src/uci/customlogger.cpp
@@ -46,7 +46,7 @@ void CustomLogger::start(const std::string& filePath, ios_base::openmode writeMo
       logger.file.open(filePath, writeMode);
 
       if (!logger.file.is_open()) {
-          cerr << "Unable to open debug log file " << filePath << endl;
+          cerr << "Unable to open debug log file " << filePath.c_str() << endl;
           exit(EXIT_FAILURE);
       }
       cin.rdbuf(&logger.in);


### PR DESCRIPTION
* replaced `inCheck` parameter for `is_terminal()` by `position.checkers()`
* removed `variant = UCI::variant_from_name(Options["UCI_Variant"]);` in `BoardState.set()`
* removed `check_result()` in `FairyState`

