### PR TITLE
Terminal TB nodes

### DIFF
--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -240,7 +240,7 @@ Node* SearchThread::get_new_child_to_evaluate(ChildIdx& childIdx, NodeDescriptio
             }
             return currentNode;
         }
-        if (nextNode->is_terminal()) {
+        if (nextNode->is_terminal() || nextNode->is_tablebase()) {
             description.type = NODE_TERMINAL;
             currentNode->unlock();
             return currentNode;


### PR DESCRIPTION
This PR treats tablebase entry points as terminal nodes

TimeControl "5+0.1"

```python
Score of ClassicAra 0.9.3-Dev - TB - Terminal - 3 Threads vs ClassicAra
0.9.3-Dev -TB - Default - 3 Threads: 50 - 8 - 38 [0.719]
Elo difference: 163.0 +/- 55.9, LOS: 100.0 %, DrawRatio: 39.6 %

96 of 1000 games finished.
```