### PR TITLE
Chess960 support

### DIFF
--- a/DeepCrazyhouse/configs/rl_config.py
+++ b/DeepCrazyhouse/configs/rl_config.py
@@ -59,6 +59,7 @@ class UCIConfig:
     Simulations: int = 3200
     SyzygyPath: str = f''
     Temperature_Moves: int = 15  # CZ: 500
+    Timeout_MS: int = 0
 
 
 @dataclass

--- a/DeepCrazyhouse/configs/train_config_template.py
+++ b/DeepCrazyhouse/configs/train_config_template.py
@@ -100,7 +100,9 @@ class TrainConfig:
     # total of training iterations
     total_it: int = None
 
-    use_mxnet_style: bool = True  # Decide between mxnet and gluon style for training
+    # Decide between mxnet and gluon style for training
+    # Reinforcement Learning only works with gluon (== False) atm
+    use_mxnet_style: bool = True
 
     # loads a previous checkpoint if the loss increased significantly
     use_spike_recovery: bool = True

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -42,6 +42,7 @@ if (MODE_LICHESS)
     add_definitions(-DATOMIC)
     add_definitions(-DHORDE)
     add_definitions(-DRACE)
+    add_definitions(-DSUPPORT960)
     add_definitions(-DMCTS_TB_SUPPORT)
 endif()
 

--- a/engine/src/environments/chess_related/boardstate.cpp
+++ b/engine/src/environments/chess_related/boardstate.cpp
@@ -28,6 +28,8 @@
 #include "inputrepresentation.h"
 #include "syzygy/tbprobe.h"
 #include "uci/variants.h"
+#include "chess960position.h"
+#include "../util/communication.h"
 
 action_idx_map OutputRepresentation::MV_LOOKUP = {};
 action_idx_map OutputRepresentation::MV_LOOKUP_MIRRORED = {};
@@ -259,7 +261,14 @@ BoardState* BoardState::clone() const
 void BoardState::init(int variant, bool is960)
 {
     states = StateListPtr(new std::deque<StateInfo>(1));
-    board.set(StartFENs[variant], is960, Variant(variant), &states->back(), nullptr);
+    string start_fen = StartFENs[variant];
+    if(is960 && variant == CHESS_VARIANT) {
+        start_fen = chess960fen();
+    } else if (is960) {
+        info_string("960 has not yet been implemented for" + variants[variant]);
+        info_string("Using standard starting position instead.");
+    }
+    board.set(start_fen, is960, Variant(variant), &states->back(), nullptr);
 }
 
 #endif

--- a/engine/src/environments/chess_related/boardstate.cpp
+++ b/engine/src/environments/chess_related/boardstate.cpp
@@ -134,6 +134,11 @@ string BoardState::action_to_san(Action action, const vector<Action>& legalActio
     return pgn_move(Move(action), this->is_chess960(), board, legalActions, leadsToWin, bookMove);
 }
 
+string BoardState::action_to_uci(Action action) const
+{
+    return UCI::move(Move(action), this->is_chess960());
+}
+
 TerminalType BoardState::is_terminal(size_t numberLegalMoves, float& customTerminalValue) const
 {
 #ifdef ATOMIC

--- a/engine/src/environments/chess_related/boardstate.cpp
+++ b/engine/src/environments/chess_related/boardstate.cpp
@@ -136,11 +136,6 @@ string BoardState::action_to_san(Action action, const vector<Action>& legalActio
     return pgn_move(Move(action), this->is_chess960(), board, legalActions, leadsToWin, bookMove);
 }
 
-string BoardState::action_to_uci(Action action) const
-{
-    return UCI::move(Move(action), this->is_chess960());
-}
-
 TerminalType BoardState::is_terminal(size_t numberLegalMoves, float& customTerminalValue) const
 {
 #ifdef ATOMIC

--- a/engine/src/environments/chess_related/boardstate.h
+++ b/engine/src/environments/chess_related/boardstate.h
@@ -248,12 +248,6 @@ public:
     void set_auxiliary_outputs(const float* auxiliaryOutputs) override;
     BoardState* clone() const override;
     void init(int variant, bool isChess960) override;
-
-    /**
-     * @brief action_to_uci Convert an action to uci notation
-     * @return string of the action in uci notation
-     */
-    string action_to_uci(Action action) const;
 };
 
 #endif // BOARTSTATE_H

--- a/engine/src/environments/chess_related/boardstate.h
+++ b/engine/src/environments/chess_related/boardstate.h
@@ -248,6 +248,12 @@ public:
     void set_auxiliary_outputs(const float* auxiliaryOutputs) override;
     BoardState* clone() const override;
     void init(int variant, bool isChess960) override;
+
+    /**
+     * @brief action_to_uci Convert an action to uci notation
+     * @return string of the action in uci notation
+     */
+    string action_to_uci(Action action) const;
 };
 
 #endif // BOARTSTATE_H

--- a/engine/src/environments/chess_related/chess960position.h
+++ b/engine/src/environments/chess_related/chess960position.h
@@ -1,0 +1,88 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: chess960position.h
+ * Created on 25.04.2020
+ * @author: queensgambit
+ *
+ * http://rosettacode.org/wiki/Generate_Chess960_starting_position
+ */
+
+#ifndef CHESS960POSITION_H
+#define CHESS960POSITION_H
+
+class Chess960Position
+{
+public:
+    Chess960Position();
+};
+
+#include <iostream>
+#include <string>
+#include <time.h>
+#include <cstring>
+using namespace std;
+
+namespace
+{
+    void placeRandomly(char* p, char c)
+    {
+        int loc = rand() % 8;
+        if (!p[loc])
+            p[loc] = c;
+        else
+            placeRandomly(p, c);    // try again
+    }
+    int placeFirst(char* p, char c, int loc = 0)
+    {
+        while (p[loc]) ++loc;
+        p[loc] = c;
+        return loc;
+    }
+
+    string startPos()
+    {
+        char p[8]; memset( p, 0, 8 );
+
+        // bishops on opposite color
+        p[2 * (rand() % 4)] = 'B';
+        p[2 * (rand() % 4) + 1] = 'B';
+
+        // queen knight knight, anywhere
+        for (char c : "QNN")
+            placeRandomly(p, c);
+
+        // rook king rook, in that order
+        placeFirst(p, 'R', placeFirst(p, 'K', placeFirst(p, 'R')));
+
+        return string(p, 8);
+    }
+
+    string chess960fen()
+    {
+        string firstRank = startPos();
+        string lastRank = string(firstRank);
+        std::transform(firstRank.begin(), firstRank.end(), firstRank.begin(), ::tolower);
+        const string fen = firstRank + "/pppppppp/8/8/8/8/PPPPPPPP/" + lastRank +  " w KQkq - 0 1";
+        return fen;
+    }
+}   // leave local
+
+#endif // CHESS960POSITION_H

--- a/engine/src/rl/binaryio.py
+++ b/engine/src/rl/binaryio.py
@@ -48,6 +48,7 @@ class BinaryIO:
         folder with the compressed games, as well as 'games.pgn' and 'gameIdx.txt'.
         :return:
         """
+        logging.info(f'Generating games ...')
         # if 0, binary plays Selfplay_Number_Chunks * Selfplay_Chunk_Size games
         self.proc.stdin.write(b"selfplay 0\n")
         self.proc.stdin.flush()
@@ -85,6 +86,7 @@ class BinaryIO:
         Tells the binary to load the network and waits until it's finished.
         :return:
         """
+        logging.info(f'Loading network & creating backend files ...', )
         self.proc.stdin.write(b"isready\n")
         self.proc.stdin.flush()
         self.read_output(b"readyok\n", check_error=True)

--- a/engine/src/rl/binaryio.py
+++ b/engine/src/rl/binaryio.py
@@ -126,7 +126,7 @@ class BinaryIO:
                 return True
 
     def set_uci_options(self, uci_variant: str, context: str, device_id: str, precision: str,
-                        model_dir: str, is_arena: bool = False):
+                        model_dir: str, model_contender_dir: str, is_arena: bool = False):
         """
         Sets UCI options of the binary.
         :param uci_variant: The UCI variant that shall be trained.
@@ -134,10 +134,12 @@ class BinaryIO:
         :param device_id: The id of the device we are using.
         :param precision: The precision of calculations.
         :param model_dir: The path to the model.
+        :param model_contender_dir: Directory where the model contender dir will be saved.
         :param is_arena: Applies setting for the arena comparison
         :return:
         """
         self._set_uci_param(f'Model_Directory', model_dir)
+        self._set_uci_param(f'Model_Contender_Directory', model_contender_dir)
         self._set_uci_param(f'UCI_Variant', uci_variant)
         self._set_uci_param(f'Context', context)
         self._set_uci_param(f'First_Device_ID', device_id)

--- a/engine/src/rl/fileio.py
+++ b/engine/src/rl/fileio.py
@@ -95,6 +95,8 @@ class FileIO:
         self.val_dir_archive = binary_dir + "export/archive/val/" + variant_suffix
         self.model_contender_dir = binary_dir + "model_contender/" + variant_suffix
         self.model_dir_archive = binary_dir + "export/archive/model/" + variant_suffix
+        self.logs_dir_archive = binary_dir + "export/logs/" + variant_suffix
+        self.logs_dir = binary_dir + "logs"
 
         self._create_directories()
 
@@ -109,7 +111,7 @@ class FileIO:
         Creates directories in the binary folder which will be used during RL
         :return:
         """
-        create_dir(self.binary_dir+"logs")
+        create_dir(self.logs_dir)
         create_dir(self.weight_dir)
         create_dir(self.export_dir_gen_data)
         create_dir(self.train_dir)
@@ -118,6 +120,7 @@ class FileIO:
         create_dir(self.val_dir_archive)
         create_dir(self.model_contender_dir)
         create_dir(self.model_dir_archive)
+        create_dir(self.logs_dir_archive)
 
     def _include_data_from_replay_memory(self, nb_files: int, fraction_for_selection: float):
         """
@@ -250,6 +253,14 @@ class FileIO:
                       "gameIdx_" + device_name + ".txt"]
         for file_name in file_names:
             os.rename(self.binary_dir + file_name, export_dir + file_name)
+
+    def move_training_logs(self, nn_update_index):
+        """
+        Rename logs with variant and update index and move it from /logs to /export/logs/
+        """
+        time_stamp = datetime.datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d-%H-%M-%S")
+        dir_name = f'logs-{self.uci_variant}-update{nn_update_index}-{time_stamp}'
+        os.rename(self.logs_dir, os.path.join(self.logs_dir_archive, dir_name))
 
     def prepare_data_for_training(self, rm_nb_files, rm_fraction_for_selection):
         """

--- a/engine/src/rl/fileio.py
+++ b/engine/src/rl/fileio.py
@@ -256,11 +256,12 @@ class FileIO:
 
     def move_training_logs(self, nn_update_index):
         """
-        Rename logs with variant and update index and move it from /logs to /export/logs/
+        Rename logs and move it from /logs to /export/logs/
         """
         time_stamp = datetime.datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d-%H-%M-%S")
         dir_name = f'logs-{self.uci_variant}-update{nn_update_index}-{time_stamp}'
         os.rename(self.logs_dir, os.path.join(self.logs_dir_archive, dir_name))
+        create_dir(self.logs_dir)
 
     def prepare_data_for_training(self, rm_nb_files, rm_fraction_for_selection):
         """

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -12,6 +12,7 @@ import sys
 import logging
 import argparse
 from rtpt import RTPT
+from multiprocessing import Process, Queue
 
 assert os.getcwd().endswith(f'engine/src/rl'), f'Please change working directory'
 sys.path.append("../../../")

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -82,7 +82,8 @@ class RLLoop:
         self.model_name = self.file_io.get_current_model_weight_file()
         self.binary_io = BinaryIO(binary_path=self.file_io.binary_dir+self.current_binary_name)
         self.binary_io.set_uci_options(self.rl_config.uci_variant, self.args.context, self.args.device_id,
-                                       self.rl_config.precision, self.file_io.model_dir, is_arena)
+                                       self.rl_config.precision, self.file_io.model_dir,
+                                       self.file_io.model_contender_dir, is_arena)
         self.binary_io.load_network()
 
     def check_for_new_model(self):

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -12,7 +12,6 @@ import sys
 import logging
 import argparse
 from rtpt import RTPT
-from multiprocessing import Process, Queue
 
 assert os.getcwd().endswith(f'engine/src/rl'), f'Please change working directory'
 sys.path.append("../../../")

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -136,18 +136,18 @@ class RLLoop:
             if self.tc.max_lr > self.tc.min_lr:
                 self.tc.max_lr = max(self.tc.max_lr - self.lr_reduction, self.tc.min_lr * 10)
 
+            self.file_io.move_training_logs(self.nn_update_index)
+
             self.nn_update_index += 1
 
-            logging.info(f'Start arena tournament ({self.nb_arena_games} rounds)')
             self.initialize()
+            logging.info(f'Start arena tournament ({self.nb_arena_games} rounds)')
             did_contender_win = self.binary_io.compare_new_weights(self.nb_arena_games)
             if did_contender_win is True:
                 logging.info("REPLACING current generator with contender")
                 self.file_io.replace_current_model_with_contender()
             else:
                 logging.info("KEEPING current generator")
-
-            self.file_io.move_training_logs(self.nn_update_index)
 
             self.binary_io.stop_process()
             self.rtpt.step()  # BUG: process changes it's name 1 iteration too late, fix?

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -147,6 +147,8 @@ class RLLoop:
             else:
                 logging.info("KEEPING current generator")
 
+            self.file_io.move_training_logs(self.nn_update_index)
+
             self.binary_io.stop_process()
             self.rtpt.step()  # BUG: process changes it's name 1 iteration too late, fix?
             self.current_binary_name = change_binary_name(self.file_io.binary_dir, self.current_binary_name,

--- a/engine/src/rl/rl_utils.py
+++ b/engine/src/rl/rl_utils.py
@@ -15,7 +15,7 @@ import ntpath
 import logging
 
 
-def change_binary_name(binary_dir: str, current_binary_name: str, process_name: str, current_epoch: int):
+def change_binary_name(binary_dir: str, current_binary_name: str, process_name: str, nn_update_idx: int):
     """
     Change the name of the binary to the process' name (which includes initials,
     binary name and remaining time) & additionally add the current epoch.
@@ -23,7 +23,7 @@ def change_binary_name(binary_dir: str, current_binary_name: str, process_name: 
     :return: the new binary name
     """
     idx = process_name.find(f'#')
-    new_binary_name = f'{process_name[:idx]}_up={current_epoch}{process_name[idx:]}'
+    new_binary_name = f'{process_name[:idx]}_UP={nn_update_idx}{process_name[idx:]}'
 
     if not os.path.exists(binary_dir + new_binary_name):
         os.rename(binary_dir + current_binary_name, binary_dir + new_binary_name)
@@ -67,13 +67,13 @@ def enable_logging(logging_lvl=logging.DEBUG, log_filename=None):
         root.addHandler(fh)
 
 
-def extract_nn_update_from_binary_name(current_binary_name: str) -> int:
+def extract_nn_update_idx_from_binary_name(current_binary_name: str) -> int:
     """
     Extract the epoch from our custom build binary name.
     :param current_binary_name: The current name of the binary
     :return: The epoch. If we could not find a match or an error occurred, return 0.
     """
-    match = re.search(f'_up=[0-9]+#', current_binary_name)
+    match = re.search(f'_UP=[0-9]+#', current_binary_name)
     if match:
         try:
             return int(match.group(0)[4:-1])

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -91,26 +91,13 @@ SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, SearchLimits* se
     filenamePGNArena = string("arena_games_")+ mctsAgent->get_device_name() + string(".pgn");
     fileNameGameIdx = string("gameIdx_") + mctsAgent->get_device_name() + string(".txt");
 
-    // TODO: Faster and shorter. Boost.
-    ifstream f(filenamePGNSelfplay.c_str());
-    bool exist1 = f.good();
-    f.close();
-    if (exist1) {
-        const int delete1 = std::remove(filenamePGNSelfplay.c_str());
-        if (delete1 != 0) {
-            throw std::runtime_error("Could not delete " + filenamePGNSelfplay + " although it exists.");
-        }
-    }
-
-    ifstream f2(fileNameGameIdx.c_str());
-    bool exist2 = f2.good();
-    f2.close();
-    if (exist2) {
-        const int delete2 = std::remove(fileNameGameIdx.c_str());
-        if (delete2 != 0) {
-            throw std::runtime_error("Could not delete " + fileNameGameIdx + " although it exists.");
-        }
-    }
+    // delete content of files
+    ofstream pgnFile;
+    pgnFile.open(filenamePGNSelfplay, std::ios_base::trunc);
+    pgnFile.close();
+    ofstream idxFile;
+    idxFile.open(fileNameGameIdx, std::ios_base::trunc);
+    idxFile.close();
 
     backupNodes = searchLimits->nodes;
     backupQValueWeight = mctsAgent->get_q_value_weight();

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -62,23 +62,17 @@ SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, SearchLimits* se
     rawAgent(rawAgent), mctsAgent(mctsAgent), searchLimits(searchLimits), playSettings(playSettings),
     rlSettings(rlSettings), gameIdx(0), gamesPerMin(0), samplesPerMin(0), options(options)
 {
-    const bool is960 = false;
-#ifdef MODE_CRAZYHOUSE
-    gamePGN.variant = "crazyhouse";
-#elif defined MODE_CHESS
+    is960 = options["UCI_Chess960"];
+    string suffix960 = "";
     if (is960) {
-        gamePGN.variant = "chess960";
+        suffix960 = "960";
     }
-    else {
+    if (not is960 && string(options["UCI_Variant"]) == "chess") {
+        // TODO: do we want standard instead of chess ?
         gamePGN.variant = "standard";
-    }
-#elif defined MODE_LICHESS
-    if (is960) {
-        gamePGN.variant = "chess960";
     } else {
-        gamePGN.variant = string(options["UCI_Variant"]);
+        gamePGN.variant = string(options["UCI_Variant"]) + suffix960;
     }
-#endif
 
     time_t     now = time(0);
     struct tm  tstruct;
@@ -90,7 +84,7 @@ SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, SearchLimits* se
     gamePGN.event = "SelfPlay";
     gamePGN.site = "Darmstadt, GER";
     gamePGN.round = "?";
-    gamePGN.is960 = false;
+    gamePGN.is960 = is960;
     this->exporter = new TrainDataExporter(string("data_") + mctsAgent->get_device_name() + string(".zarr"),
                                            rlSettings->numberChunks, rlSettings->chunkSize);
     filenamePGNSelfplay = string("games_") + mctsAgent->get_device_name() + string(".pgn");
@@ -161,7 +155,7 @@ void SelfPlay::generate_game(Variant variant, bool verbose)
     ply = clip_ply(ply, playSettings->maxInitPly);
 
     srand(unsigned(int(time(nullptr))));
-    unique_ptr<StateObj> state = init_starting_state_from_raw_policy(*rawAgent, ply, gamePGN, variant, rlSettings->rawPolicyProbabilityTemperature);
+    unique_ptr<StateObj> state = init_starting_state_from_raw_policy(*rawAgent, ply, gamePGN, variant, is960, rlSettings->rawPolicyProbabilityTemperature);
     EvalInfo evalInfo;
     Result gameResult;
     exporter->new_game();
@@ -217,7 +211,8 @@ Result SelfPlay::generate_arena_game(MCTSAgent* whitePlayer, MCTSAgent* blackPla
 {
     gamePGN.white = whitePlayer->get_name();
     gamePGN.black = blackPlayer->get_name();
-    unique_ptr<StateObj> state = init_state(variant, true, gamePGN);
+    unique_ptr<StateObj> state= make_unique<StateObj>();
+    state->init(variant, is960);
     EvalInfo evalInfo;
 
     MCTSAgent* activePlayer;
@@ -353,31 +348,11 @@ TournamentResult SelfPlay::go_arena(MCTSAgent *mctsContender, size_t numberOfGam
     return tournamentResult;
 }
 
-unique_ptr<StateObj> init_state(Variant variant, bool is960, GamePGN& gamePGN)
+unique_ptr<StateObj> init_starting_state_from_raw_policy(RawNetAgent &rawAgent, size_t plys, GamePGN &gamePGN, Variant variant, bool is960, float rawPolicyProbTemp)
 {
-    // TODO: Use state->init() here
     unique_ptr<StateObj> state= make_unique<StateObj>();
-#ifdef SUPPORT960
-    if (is960) {
-        string firstRank = startPos();
-        string lastRank = string(firstRank);
-        std::transform(firstRank.begin(), firstRank.end(), firstRank.begin(), ::tolower);
-        const string fen = firstRank + "/pppppppp/8/8/8/8/PPPPPPPP/" + lastRank +  " w KQkq - 0 1";
-        gamePGN.fen = fen;
-        position->set(fen, true, variant);
-    }
-    else {
-        position->set(StartFENs[variant], false, variant);
-    }
-#else
-    state->set(StartFENs[variant], false, variant);
-#endif
-    return state;
-}
-
-unique_ptr<StateObj> init_starting_state_from_raw_policy(RawNetAgent &rawAgent, size_t plys, GamePGN &gamePGN, Variant variant, float rawPolicyProbTemp)
-{
-    unique_ptr<StateObj> state = init_state(variant, false, gamePGN);
+    state->init(variant, is960);
+    gamePGN.fen = state->fen();
 
     for (size_t ply = 0; ply < plys; ++ply) {
         EvalInfo eval;
@@ -398,9 +373,11 @@ unique_ptr<StateObj> init_starting_state_from_raw_policy(RawNetAgent &rawAgent, 
     return state;
 }
 
-unique_ptr<StateObj> init_starting_state_from_fixed_move(GamePGN &gamePGN, Variant variant, const vector<Action>& actions)
+unique_ptr<StateObj> init_starting_state_from_fixed_move(GamePGN &gamePGN, Variant variant, bool is960, const vector<Action>& actions)
 {
-    unique_ptr<StateObj> state = init_state(variant, false, gamePGN);
+    unique_ptr<StateObj> state= make_unique<StateObj>();
+    state->init(variant, is960);
+    gamePGN.fen = state->fen();
     for (Action action : actions) {
         gamePGN.gameMoves.push_back(state->action_to_san(action, {}, false, true));
         state->do_action(action);

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -91,6 +91,27 @@ SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, SearchLimits* se
     filenamePGNArena = string("arena_games_")+ mctsAgent->get_device_name() + string(".pgn");
     fileNameGameIdx = string("gameIdx_") + mctsAgent->get_device_name() + string(".txt");
 
+    // TODO: Faster and shorter. Boost.
+    ifstream f(filenamePGNSelfplay.c_str());
+    bool exist1 = f.good();
+    f.close();
+    if (exist1) {
+        const int delete1 = std::remove(filenamePGNSelfplay.c_str());
+        if (delete1 != 0) {
+            throw std::runtime_error("Could not delete " + filenamePGNSelfplay + " although it exists.");
+        }
+    }
+
+    ifstream f2(fileNameGameIdx.c_str());
+    bool exist2 = f2.good();
+    f2.close();
+    if (exist2) {
+        const int delete2 = std::remove(fileNameGameIdx.c_str());
+        if (delete2 != 0) {
+            throw std::runtime_error("Could not delete " + fileNameGameIdx + " although it exists.");
+        }
+    }
+
     backupNodes = searchLimits->nodes;
     backupQValueWeight = mctsAgent->get_q_value_weight();
     backupDirichletEpsilon = mctsAgent->get_dirichlet_noise();

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -68,6 +68,7 @@ private:
     size_t backupNodes;
     float backupDirichletEpsilon;
     float backupQValueWeight;
+    bool is960;
 
 public:
     /**
@@ -192,33 +193,27 @@ private:
 void clean_up(GamePGN& gamePGN, MCTSAgent* mctsAgent);
 
 /**
- * @brief init_board Initialies a new board with the starting position of the variant
- * @param variant Variant to be played
- * @param is960 If it is a 960 variant
- * @param gamePGN Struct which stores the pgn information
- * @return New state object
- */
-unique_ptr<StateObj> init_state(Variant variant, bool is960, GamePGN& gamePGN);
-
-/**
  * @brief init_games_from_raw_policy Inits a new starting position by sampling from the raw policy with temperature 1.
  * The iteration stops either when the number of plys is reached or when the next move would lead to a terminal state.
  * @param rawAgent Handle to the raw agent
  * @param plys Number of plys to generate
  * @param gamePGN Game pgn struct where the moves will be stored
+ * @param variant Game variant
+ * @param is960 If we are in a 960 game or not
  * @param rawPolicyProbTemp Probability for which a temperature scaling > 1.0f is applied
  * @return New state object
  */
-unique_ptr<StateObj> init_starting_state_from_raw_policy(RawNetAgent& rawAgent, size_t plys, GamePGN& gamePGN, Variant variant, float rawPolicyProbTemp);
+unique_ptr<StateObj> init_starting_state_from_raw_policy(RawNetAgent& rawAgent, size_t plys, GamePGN& gamePGN, Variant variant, bool is960, float rawPolicyProbTemp);
 
 /**
  * @brief init_starting_state_from_fixed_move Initializes a starting position using a vector of actions
  * @param gamePGN Game pgn struct where the moves will be stored
  * @param variant Game variant
+ * @param is960 If we are in a 960 game or not
  * @param actions Vector of actions
  * @return New state object
  */
-unique_ptr<StateObj> init_starting_state_from_fixed_move(GamePGN& gamePGN, Variant variant, const vector<Action>& actions);
+unique_ptr<StateObj> init_starting_state_from_fixed_move(GamePGN& gamePGN, Variant variant, bool is960, const vector<Action>& actions);
 
 /**
  * @brief apply_raw_policy_temp Applies a temperature scaling to the policyProbSmall of the eval struct.

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -225,35 +225,24 @@ void OptionsUCI::setoption(istringstream &is, Variant& variant, StateObj& state)
             // Workaround. Fairy-Stockfish does not use an enum for variants
             cout << "info string variant " << "Xiangqi" << " startpos " << "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR w - - 0 1" << endl;
 #else
-            if (value == "standard") {
-                Options["UCI_Variant"] << Option("chess");
-            }
-#ifdef MODE_LICHESS
-            if (value == "antichess" || value == "losers") {
-                Options["UCI_Variant"] << Option("giveaway");
-            }
-#endif // MODE_LICHESS
-            string suffix_960 = "";
+            bool is960 = false;
+            string uci_variant = check_uci_variant_input(value, &is960);
+            Options["UCI_Variant"] << Option(uci_variant.c_str());
+            info_string("Updated option " + givenName + " to " + uci_variant);
 #ifdef SUPPORT960
-            if (value == "fischerandom" || value == "chess960"
-                || ((value == "chess") && Options["UCI_Chess960"])) {
-                Options["UCI_Variant"] << Option("chess");
-                Options["UCI_Chess960"] << Option(true);
-                cout << "info string Updated option " << givenName << " to chess" << endl;
-                cout << "info string Updated option uci_chess960 to true" << endl;
-                suffix_960 = "960";
-            } else {
-                Options["UCI_Chess960"] << Option(false); // We only want 960 for chess at the moment
+            if (Options["UCI_Chess960"] != is960) {
+                Options["UCI_Chess960"] << Option(is960);
+                info_string("Updated option UCI_Chess960 to " + (string) Options["UCI_Chess960"]);
             }
 #endif // SUPPORT960
-            if(suffix_960 == "") {
-                cout << "info string Updated option " << givenName << " to " << value << endl;
-            }
-            Options["Model_Directory"] << Option(((string) "model/" + string(Options["UCI_Variant"]) + suffix_960).c_str());
-            Options["Model_Directory_Contender"] << Option(((string) "model_contender/" + string(Options["UCI_Variant"]) + suffix_960).c_str());
-            variant = UCI::variant_from_name(value);
-            state.init(variant, Options["UCI_Chess960"]);
+            variant = UCI::variant_from_name(uci_variant);
+            state.init(variant, is960);
 
+            cout << is960 << endl;
+
+            string suffix_960 = (is960) ? "960" : "";
+            Options["Model_Directory"] << Option(("model/" + (string)Options["UCI_Variant"] + suffix_960).c_str());
+            Options["Model_Directory_Contender"] << Option(("model_contender/" + (string)Options["UCI_Variant"] + suffix_960).c_str());
             info_string("info string variant " + (string)Options["UCI_Variant"] + suffix_960 + " startpos " + state.fen());
 #endif
         }
@@ -261,6 +250,27 @@ void OptionsUCI::setoption(istringstream &is, Variant& variant, StateObj& state)
     else {
         cout << "info string Given option " << name << " does not exist " << endl;
     }
+}
+
+string OptionsUCI::check_uci_variant_input(const string &value, bool *is960) {
+    // default value of is960 == false
+#ifdef SUPPORT960
+    // we only want 960 for chess atm
+    if (value == "fischerandom" || value == "chess960"
+        || (((value == "chess") || (value == "standard")) && Options["UCI_Chess960"])) {
+        *is960 = true;
+        return "chess";
+    }
+#endif // SUPPORT960
+    if (value == "standard") {
+       return "chess";
+    }
+#ifdef MODE_LICHESS
+    if (value == "antichess" || value == "losers") {
+        return "giveaway";
+    }
+    return value;
+#endif // MODE_LICHESS
 }
 
 void OptionsUCI::init_new_search(SearchLimits& searchLimits, OptionsMap &options)

--- a/engine/src/uci/optionsuci.h
+++ b/engine/src/uci/optionsuci.h
@@ -53,6 +53,16 @@ namespace OptionsUCI {
      */
     void setoption(istringstream& is, Variant& variant, StateObj& state);
 
+
+    /**
+     * @brief check_uci_variant_input Gets a uci variant and translates it if necessary.
+     * This way we can support multiple names for the same variants.
+     * @param value UCI Variant name
+     * @param is960 Bool pointer, which shall be false when passed
+     * @return string The uci variant string that we use internally to represent the variant.
+     */
+    string check_uci_variant_input(const string &value, bool *is960);
+
     /**
      * @brief init_new_search Initializes the struct according to the given OptionsMap for a new search
      * @param searchLimit search limits struct to be changed

--- a/engine/src/uci/variants.h
+++ b/engine/src/uci/variants.h
@@ -33,14 +33,25 @@ using namespace std;
 
 // list of all current available variants for MultiAra
 const static vector<string> availableVariants = {
-    "3check",
-    "atomic",
+#if defined(MODE_CHESS) && defined(MODE_LICHESS)
     "chess",
+    "standard",
+#endif
+#if defined(MODE_CRAZYHOUSE) && defined(MODE_LICHESS)
     "crazyhouse",
-    "giveaway",  // antichess
-    "horde",
+#endif
+#ifdef MODE_LICHESS
     "kingofthehill",
-    "racingkings"
+    "atomic",
+    "giveaway",
+    "horde",
+    "racingkings",
+    "3check",
+    "fischerandom"
+    "chess960",
+    "antichess", // giveaway
+    "losers" // giveaway
+#endif
 };
 
 // FEN strings of the initial positions

--- a/engine/src/uci/variants.h
+++ b/engine/src/uci/variants.h
@@ -36,7 +36,11 @@ const static vector<string> availableVariants = {
 #if defined(MODE_CHESS) && defined(MODE_LICHESS)
     "chess",
     "standard",
-#endif
+#if defined(SUPPORT960)
+    "fischerandom",
+    "chess960",
+#endif // SUPPORT960
+#endif // MODE_CHESS && MODE_LICHESS
 #if defined(MODE_CRAZYHOUSE) && defined(MODE_LICHESS)
     "crazyhouse",
 #endif
@@ -47,10 +51,8 @@ const static vector<string> availableVariants = {
     "horde",
     "racingkings",
     "3check",
-    "fischerandom"
-    "chess960",
     "antichess", // giveaway
-    "losers" // giveaway
+    "losers", // giveaway
 #endif
 };
 

--- a/engine/tests/tests.cpp
+++ b/engine/tests/tests.cpp
@@ -39,7 +39,6 @@
 #include "environments/chess_related/inputrepresentation.h"
 #include "legacyconstants.h"
 #include "util/blazeutil.h"
-#include "uci/optionsuci.h"
 using namespace Catch::literals;
 using namespace std;
 using namespace OptionsUCI;
@@ -87,6 +86,33 @@ bool are_all_entries_true(const vector<string>& uciMoves, bool (*foo)(Square, Sq
     return true;
 }
 
+
+bool is_uci_move_legal(const BoardState& pos, const string& move) {
+    for (Action action : pos.legal_actions()) {
+        if (pos.action_to_uci(action) == move) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool legal_actions_equal_ucimoves(BoardState& pos, vector<string>& uciMoves) {
+    vector<string> compareMoves;
+    for (Action action : pos.legal_actions()) {
+        compareMoves.push_back(pos.action_to_uci(action));
+    }
+    return std::is_permutation(uciMoves.begin(), uciMoves.end(), compareMoves.begin());
+}
+
+bool are_uci_moves_legal_bool(BoardState& pos, vector<string> uciMoves, bool equals) {
+    for (string move : uciMoves) {
+        if (is_uci_move_legal(pos, move) != equals) {
+            return false;
+        }
+    }
+    return true;
+}
+
 Variant get_default_variant()
 {
 #ifndef MODE_CRAZYHOUSE
@@ -99,11 +125,6 @@ Variant get_default_variant()
 TEST_CASE("En-passent moves") {
     vector<string> en_passent_moves = create_en_passent_moves();
     REQUIRE(are_all_entries_true(en_passent_moves, is_en_passent_candidate) == true);
-}
-
-TEST_CASE("Chess960 castling moves") {
-    vector<string> castlingMoves = create_castling_moves(true);
-    REQUIRE(are_all_entries_true(castlingMoves, is_960_castling_candidate_move) == true);
 }
 
 #ifdef MODE_LICHESS
@@ -135,13 +156,6 @@ TEST_CASE("Anti-Chess StartFEN"){
     REQUIRE(int(max_num) == 1);
     REQUIRE(int(sum) == 224);
     REQUIRE(int(key) == 417296);
-}
-
-TEST_CASE("Variant_Kingofthehill"){
-    init();
-    BoardState pos;
-    pos.set("5k2/1p5p/8/p7/2P1Kp2/5N1P/Pr3PP1/3RR3 b - - 1 29", false, KOTH_VARIANT); // bottom right
-    REQUIRE(pos.check_result(false) == WHITE_WIN);
 }
 #endif
 
@@ -219,6 +233,8 @@ TEST_CASE("Draw_by_insufficient_material"){
     REQUIRE(pos.draw_by_insufficient_material() == false);
 #endif
 }
+
+
 
 #ifdef MODE_CHESS
 TEST_CASE("Chess_Input_Planes"){
@@ -621,5 +637,517 @@ TEST_CASE("Xiangqi_Input_Planes") {
     REQUIRE(StateConstantsFairy::NB_VALUES_TOTAL() == 28*90);
 }
 #endif // MODE_XIANGQI
+
+#ifdef MODE_LICHESS
+TEST_CASE("King of the hill"){
+    init();
+    BoardState pos;
+
+    // Check for win in the center
+    // black wins
+    pos.set("8/7p/8/1b1pk3/4p3/5n2/1K3P2/8 w - - 4 43", false, KOTH_VARIANT); // top right
+    REQUIRE(pos.check_result() == BLACK_WIN);
+    pos.set("8/8/2p2p2/3k3p/4p2P/r6P/8/5K2 w - - 0 47", false, KOTH_VARIANT); // top left
+    REQUIRE(pos.check_result() == BLACK_WIN);
+    pos.set("rnbq1bnr/pppp1ppp/8/8/P2kp3/1RN4N/1PPPPPPP/2BQKB1R w K - 0 1", false, KOTH_VARIANT); // bottom left
+    REQUIRE(pos.check_result() == BLACK_WIN);
+    pos.set("rnbq1bnr/ppp1pppp/3p4/8/P3k3/1RN4N/1PPPPPPP/2BQKB1R w K - 0 1", false, KOTH_VARIANT); // bottom right
+    REQUIRE(pos.check_result() == BLACK_WIN);
+    // white wins
+    pos.set("5k2/1p5p/8/p7/2P1Kp2/5N1P/Pr3PP1/3RR3 b - - 1 29", false, KOTH_VARIANT); // bottom right
+    REQUIRE(pos.check_result() == WHITE_WIN);
+    pos.set("6k1/5p2/bP3B2/3N4/3K4/5P1p/P7/8 b - - 2 37", false, KOTH_VARIANT); // bottom left
+    REQUIRE(pos.check_result() == WHITE_WIN);
+    pos.set("rnbqkb1r/1pppppp1/p7/3K1n1p/8/5N2/PPPP1PPP/RNBQ1B1R w kq - 0 1", false, KOTH_VARIANT); // top left
+    REQUIRE(pos.check_result() == WHITE_WIN);
+    pos.set("rnb1kb1r/1ppqppp1/p6n/3PK2p/8/8/PPPP1PPP/RNBQ1BNR w kq - 0 1", false, KOTH_VARIANT); // top right
+    REQUIRE(pos.check_result() == WHITE_WIN);
+}
+
+TEST_CASE("Variants_Horde"){
+    init();
+    BoardState pos;
+
+    // The Pieces win by capturing all the pawns
+    pos.set("8/8/1p4k1/8/4q3/8/8/8 w - - 0 76", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == BLACK_WIN);
+    pos.set("6r1/8/4k3/5q2/p7/8/8/8 w - - 0 65", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == BLACK_WIN);
+    pos.set("8/4k3/8/4q3/8/8/8/8 w - - 0 63", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == BLACK_WIN);
+
+    // Pawns win by checkmating the king
+    pos.set("rnbqkbnr/1ppp1P1p/3PP3/2P5/PP5P/P1PPPPPP/PPpPPPPP/PPPPPPPP b kq - 0 10", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // ... even with multiple promoted pieces
+    pos.set("8/8/R7/6P1/8/PP1P4/k1P5/Q3QPP1 b - - 3 69", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // Stalmate due to missing of legal moves
+    pos.set("6k1/6P1/7q/8/8/8/8/8 w - - 0 1", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == DRAW);
+    pos.set("1k6/3R4/2Q5/8/2P5/3P4/8/8 b - - 0 1", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == DRAW);
+
+    // Stalmate due to 50 move rule
+    pos.set("6k1/3R4/8/8/8/8/8/8 b - - 99 85", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == NO_RESULT);
+    pos.set("6k1/3R4/8/8/8/8/8/8 b - - 100 85", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == DRAW);
+
+    // Pawns on the first rank can move 2 squares (and 1 square)
+
+    pos.set("3k4/8/8/8/8/8/8/PPPPPPPP w - - 0 1", false, HORDE_VARIANT);
+    vector<Action> legalActions = pos.legal_actions();
+    vector<string> legalActionsSan;
+    for (Action action : legalActions) {
+        legalActionsSan.push_back(pos.action_to_san(action, legalActions));
+    }
+    vector<string> match = {"a3", "b3", "c3", "d3", "e3", "f3", "g3", "h3", "a2", "b2", "c2", "d2", "e2", "f2", "g2", "h2"};
+    std::sort(match.begin(), match.end());
+    std::sort(legalActionsSan.begin(), legalActionsSan.end());
+    REQUIRE(legalActionsSan == match);
+
+    // Pawns of the first rank that moved 2 squares cannot be captured en passant
+
+    pos.set("6k1/8/8/8/8/1p1p4/8/2P5 w - - 0 1", false, HORDE_VARIANT);
+    string mov = "c1c3";
+    Action action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    legalActions = pos.legal_actions();
+    legalActionsSan;
+    for (Action action : legalActions) {
+        legalActionsSan.push_back(pos.action_to_san(action, legalActions));
+    }
+    bool moveInLegalActions = std::find(legalActionsSan.begin(), legalActionsSan.end(), "bxc2") != legalActionsSan.end();
+    REQUIRE(moveInLegalActions == false);
+    moveInLegalActions = std::find(legalActionsSan.begin(), legalActionsSan.end(), "dxc2") != legalActionsSan.end();
+    REQUIRE(moveInLegalActions == false);
+
+    // However "normal" en passant from second row is possible
+
+    pos.set("1kb3nr/8/8/8/3p1pP1/8/1P2P3/P6P w - - 0 1", false, HORDE_VARIANT);
+    mov = "e2e4";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    legalActions = pos.legal_actions();
+    legalActionsSan;
+    for (Action action : legalActions) {
+        legalActionsSan.push_back(pos.action_to_san(action, legalActions));
+    }
+    moveInLegalActions = std::find(legalActionsSan.begin(), legalActionsSan.end(), "dxe3") != legalActionsSan.end();
+    REQUIRE(moveInLegalActions == true);
+    moveInLegalActions = std::find(legalActionsSan.begin(), legalActionsSan.end(), "fxe3") != legalActionsSan.end();
+    REQUIRE(moveInLegalActions == true);
+
+    // A pawn that moved from first row to second row can now move 2 squares
+
+    pos.set("1kb3nr/8/8/8/3p1pP1/8/1P2P3/P6P w - - 0 1", false, HORDE_VARIANT);
+    mov = "b1b2";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "h8h1";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    legalActions = pos.legal_actions();
+    legalActionsSan;
+    for (Action action : legalActions) {
+        legalActionsSan.push_back(pos.action_to_san(action, legalActions));
+    }
+    moveInLegalActions = std::find(legalActionsSan.begin(), legalActionsSan.end(), "b4") != legalActionsSan.end();
+    REQUIRE(moveInLegalActions == true);
+
+    // No draw by insufficient material
+    pos.set("4k3/8/8/6P1/8/8/8/8 w - - 0 1", false, HORDE_VARIANT);
+    REQUIRE(pos.check_result() == NO_RESULT);
+
+    // 3 fold repetition draw
+    pos.set("4k3/6R1/8/8/8/8/8/8 w - - 0 1", false, HORDE_VARIANT);
+    mov = "g7g8";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "e8e7";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "g8g7";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "e7e8";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "g7g8";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "e8e7";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "g8g7";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "e7e8";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "g7g8";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "e8e7";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "g8g7";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    mov = "e7e8";
+    action = pos.uci_to_action(mov);
+    pos.do_action(action);
+    REQUIRE(pos.check_result() == DRAW);
+}
+
+TEST_CASE("3check") {
+    init();
+    BoardState pos;
+
+    // Do we count checks
+    pos.init(THREECHECK_VARIANT, false);
+    REQUIRE("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1" == pos.fen());
+
+    // Do we decrement checks correctly
+    pos.set("1r4k1/1p2bp1p/3p2p1/PprPp2n/1R2PPq1/3Q4/1P1B1NPP/5RK1 b - - 3+3 2 22", false, THREECHECK_VARIANT);
+    string move = "g4g2";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE("1r4k1/1p2bp1p/3p2p1/PprPp2n/1R2PP2/3Q4/1P1B1NqP/5RK1 w - - 3+2 0 23" == pos.fen());
+
+    move = "g1g2";
+    pos.do_action(pos.uci_to_action(move));
+    move = "h5f4";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE("1r4k1/1p2bp1p/3p2p1/PprPp3/1R2Pn2/3Q4/1P1B1NKP/5R2 w - - 3+1 0 24" == pos.fen());
+
+    pos.set("2r3k1/1p2bp1p/3p2p1/Pp1P4/1R2Pp2/7Q/1P3N1P/2r2R1K w - - 3+1 4 27", false, THREECHECK_VARIANT);
+    move = "h3c8";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE("2Q3k1/1p2bp1p/3p2p1/Pp1P4/1R2Pp2/8/1P3N1P/2r2R1K b - - 2+1 0 27" == pos.fen());
+
+    pos.set("4Rr1k/3P3p/5pp1/8/8/4p3/1P3p1P/5R1K w - - 2+1 0 39", false, THREECHECK_VARIANT);
+    move = "e8f8";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE("5R1k/3P3p/5pp1/8/8/4p3/1P3p1P/5R1K b - - 1+1 0 39" == pos.fen());
+
+    pos.set("5R2/3P2kp/5pp1/8/8/4p3/1P3p1P/5R1K w - - 1+1 1 40", false, THREECHECK_VARIANT);
+    move = "f8f7";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE("8/3P1Rkp/5pp1/8/8/4p3/1P3p1P/5R1K b - - 0+1 2 40" == pos.fen());
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // More checks, if 3check win condition takes effect
+    pos.set("8/pk6/8/p1p4p/2P1p3/8/6p1/B2Kr3 w - - 3+0 2 44", false, THREECHECK_VARIANT);
+    REQUIRE(pos.check_result() == BLACK_WIN);
+    pos.set("8/ppp2k2/5b2/1P1n4/P3bP2/3PP1P1/5K1r/5R2 w - - 1+0 3 27", false, THREECHECK_VARIANT);
+    REQUIRE(pos.check_result() == BLACK_WIN);
+    pos.set("8/k1R1P3/p2p4/2pP4/8/1p2P2p/P6P/K7 b - - 0+3 1 34", false, THREECHECK_VARIANT);
+    REQUIRE(pos.check_result() == WHITE_WIN);
+    pos.set("6R1/6k1/8/5P1p/5P1P/8/6K1/8 b - - 0+2 4 56", false, THREECHECK_VARIANT);
+    REQUIRE(pos.check_result() == WHITE_WIN);
+}
+
+TEST_CASE("Racing_Kings") {
+    init();
+    BoardState pos;
+
+    // Check the starting position
+    pos.init(RACE_VARIANT, false);
+    REQUIRE(pos.fen() == "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1");
+
+    // Checks are forbidden
+    pos.set("8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1", false, RACE_VARIANT);
+    vector<string> uciMoves = {"e2c3", "e2a3"};
+    REQUIRE(are_uci_moves_legal_bool(pos, uciMoves, false));
+    pos.set("R2R4/4Q3/8/2r5/1q6/bk3N1K/2b5/8 b - - 6 13", false, RACE_VARIANT);
+    REQUIRE(are_uci_moves_legal_bool(pos, {"c2f5", "b4g4", "b4h4", "c5h5"}, false));
+    pos.set("R2R4/4Q3/8/2r5/1q6/1k3N1K/2b5/2b5 w - - 7 14", false, RACE_VARIANT);
+    REQUIRE(are_uci_moves_legal_bool(pos, {"f3d2", "f3d4", "e7e6", "e7f7", "e7e3", "d8d3", "a8a3"}, false));
+
+    // Win if a king reaches the 8th row
+    pos.set("1bk1q3/8/8/6K1/8/8/8/R7 w - - 2 47", false, RACE_VARIANT);
+    REQUIRE(pos.check_result() == BLACK_WIN);
+    pos.set("6K1/8/8/6Q1/8/8/n1k5/b7 b - - 2 25", false, RACE_VARIANT);
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // Draw, if white moves king to 8th row and black follows immediatly
+    pos.set("2r2NK1/kn2R3/8/8/8/8/8/8 b - - 8 26", false, RACE_VARIANT);
+    string move = "a7b8";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.check_result() == DRAW);
+
+    // Check for draw if both kings are on 8th row (e.g. bad init in selfplay)
+    pos.set("1k3K2/2qQ4/8/8/8/8/8/8 w - - 30 26", false, RACE_VARIANT);
+    REQUIRE(pos.check_result() == DRAW);
+}
+
+TEST_CASE("Atomic") {
+    init();
+    BoardState pos;
+
+    // Check starting position
+    pos.init(ATOMIC_VARIANT, false);
+    REQUIRE(pos.fen() == "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+
+    // The capturing and captured figure always die
+    // Everything within a radius of 1 square explodes, except pawns
+
+    pos.set("rn1qkb1r/p1p3pp/b3pp1n/3pP3/1P1P1P2/7P/P5P1/RNBQKBNR w KQkq - 1 7", false, ATOMIC_VARIANT);
+    string move = "f1a6";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "rn1qkb1r/p1p3pp/4pp1n/3pP3/1P1P1P2/7P/P5P1/RNBQK1NR b KQkq - 0 7");
+
+    pos.set("1r1qk2r/2p3pp/p1n1pp1n/1P1pP3/1b1P1P2/P6P/4Q1P1/RNB1K1NR w KQk - 1 11", false, ATOMIC_VARIANT);
+    move = "a3b4";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "1r1qk2r/2p3pp/p1n1pp1n/1P1pP3/3P1P2/7P/4Q1P1/RNB1K1NR b KQk - 0 11");
+
+    pos.set("1r2k2r/R1p3pp/7n/2npp3/1B1P1PP1/1q5P/2Q4R/1N3KN1 w k - 2 22", false, ATOMIC_VARIANT);
+    move = "c2b3";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "1r2k2r/R1p3pp/7n/2npp3/3P1PP1/7P/7R/1N3KN1 b k - 0 22");
+
+    pos.set("1r3rk1/R1p3p1/6Pp/2nppn2/3P1P2/7P/7R/1N3KN1 w - - 0 25", false, ATOMIC_VARIANT);
+    move = "a7c7";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "5rk1/6p1/6Pp/2nppn2/3P1P2/7P/7R/1N3KN1 b - - 0 25");
+
+    pos.set("2r3k1/6p1/6Pp/3pp3/3P1P2/2N3nP/1n5R/2K3N1 b - - 8 29", false, ATOMIC_VARIANT);
+    move = "e5d4";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "2r3k1/6p1/6Pp/3p4/5P2/6nP/1n5R/2K3N1 w - - 0 30");
+
+    pos.set("6k1/6p1/6Pp/3p4/5P2/6nP/Kn5R/2r3N1 b - - 3 31", false, ATOMIC_VARIANT);
+    move = "c1g1";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "6k1/6p1/6Pp/3p4/5P2/6nP/Kn6/8 w - - 0 32");
+
+    // Nuking the opposite king wins the game immediatly ...
+    pos.set("6k1/5Kp1/2q3P1/5n1p/5P1P/8/1n6/8 b - - 1 40", false, ATOMIC_VARIANT);
+    move = "c6g6";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.check_result() == BLACK_WIN);
+
+    // ... overriding checks ...
+    pos.set("8/1q6/8/8/8/5k2/1R4n1/1K6 w - - 0 1", false, ATOMIC_VARIANT);
+    move = "b2g2";
+    REQUIRE(is_uci_move_legal(pos, move));
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // ... and checkmates
+    pos.set("8/1q6/r7/8/8/5k2/R5n1/K7 w - - 0 1", false, ATOMIC_VARIANT);
+    move = "a2g2";
+    REQUIRE(is_uci_move_legal(pos, move));
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // Checkmating the king wins the game (the mating figures cannot be captured by the king)
+    pos.set("3q4/6Qk/4r3/p7/6Pp/7P/8/1R2R1K1 b - - 8 29", false, ATOMIC_VARIANT);
+    REQUIRE(pos.check_result() == WHITE_WIN);
+    // Mating figures cannot be captured by other figures, if the king would explode
+    pos.set("8/kQ3r2/6p1/2P3Pp/7P/4p3/1K2B3/n7 b - - 3 39", false, ATOMIC_VARIANT);
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // Kings are not allowed to attack each other
+    pos.set("6k1/6p1/4K1Pp/5n2/5P2/7P/1n6/3q4 w - - 0 37", false, ATOMIC_VARIANT);
+    move = "e6f7";
+    REQUIRE(is_uci_move_legal(pos, move));
+    pos.set("5Kk1/6p1/2q3Pp/5n2/5P1P/8/1n6/8 b - - 2 39", false, ATOMIC_VARIANT);
+    move = "g8f8";
+    REQUIRE(is_uci_move_legal(pos, move) == false);
+}
+
+TEST_CASE("Chess960") {
+    init();
+    BoardState pos;
+
+    // Check chess960 start pos
+    for(int i; i < 20; ++i) {
+        pos.init(CHESS_VARIANT, true);
+        std::istringstream ss(pos.fen());
+        string token;
+        ss >> token;
+
+        // Symmetry
+        string firstRank = token.substr(0, 8);
+        string lastRank = token.substr(35, 43);
+        std::transform(lastRank.begin(), lastRank.end(), lastRank.begin(), ::tolower);
+        REQUIRE(firstRank == lastRank);
+
+        // Rooks are on each side of the king
+        int posFirstRook = firstRank.find_first_of('r');
+        int posLastRook = firstRank.find_last_of('r');
+        int posKing = firstRank.find('k');
+        REQUIRE(posFirstRook < posKing);
+        REQUIRE(posKing < posLastRook);
+
+        // Bishops are on white and black squares
+        int posFirstBishop = firstRank.find_first_of('b');
+        int posLastBishop = firstRank.find_last_of('b');
+        int bishopDiff = posLastBishop - posFirstBishop;
+        REQUIRE((bishopDiff % 2) != 0);
+
+        // All other cases are general fen test cases
+        // Maybe test somewhere else, if the first and last rank are upper / lower case, etc.
+    }
+
+    // Are castling moves legal
+    pos.set("bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1RK1RQ w GDgd - 0 1", true, CHESS_VARIANT);
+    vector<string> moves = {"e1d1", "e1g1"};
+    REQUIRE(are_uci_moves_legal_bool(pos, moves, true));
+
+    // Not legal, if squares between king and rook aren't empty
+    pos.set("bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BNNRKBRQ w GDgd - 0 4", true, CHESS_VARIANT);
+    string move = "e1g1";
+    REQUIRE(is_uci_move_legal(pos, move) == false);
+
+    // Not legal through check
+    pos.set("1nnrkbrq/p1pppppp/1p6/1b6/4P3/8/PPPP1PPP/BN1RK1RQ w GDgd - 0 4", true, CHESS_VARIANT);
+    move = "e1g1";
+    REQUIRE(is_uci_move_legal(pos, move) == false);
+
+    // Not legal if rook is in check
+    pos.set("bnnrk1rq/p1pp1ppp/1p2p3/2b5/4P3/5P2/PPPP2PP/BN1RK1RQ w GDgd - 0 4", true, CHESS_VARIANT);
+    move = "e1g1";
+    REQUIRE(is_uci_move_legal(pos, move) == false);
+
+    // Not legal if king is in check
+    pos.set("bnnrkbr1/ppppppp1/8/4q2p/8/5P2/PPPP2PP/BN1RK1RQ w GDgd - 0 4", true, CHESS_VARIANT);
+    moves = {"e1d1", "e1g1"};
+    REQUIRE(are_uci_moves_legal_bool(pos, moves, false));
+
+    // Not legal, if the destination squares aren't empty
+    pos.set("nrbbqnkr/pppppppp/8/8/8/8/PPPPPPPP/NRBBQNKR w HBhb - 0 4", true, CHESS_VARIANT);
+    move = "g1h1";
+    REQUIRE(is_uci_move_legal(pos, move) == false);
+    pos.set("bnnrkbrq/pppppppp/8/8/8/4P3/PPPP1PPP/BNNRK1RQ w GDgd - 0 4", true, CHESS_VARIANT);
+    move = "e1d1";
+    REQUIRE(is_uci_move_legal(pos, move) == false);
+
+    // We can only castle, if fen says yes
+    pos.set("bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1RK1RQ w gd - 0 1", true, CHESS_VARIANT);
+    moves = {"e1d1", "e1g1"};
+    REQUIRE(are_uci_moves_legal_bool(pos, moves, false));
+
+    // If we move a rook, the fen castling should get removed
+    pos.set("bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1RK1RQ w GDgd - 0 1", true, CHESS_VARIANT);
+    move = "d1c1";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BNR1K1RQ b Ggd - 1 1");
+
+    pos.set("bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1RK1RQ w GDgd - 0 1", true, CHESS_VARIANT);
+    move = "g1f1";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1RKR1Q b Dgd - 1 1");
+
+    // If we move king, castling disappears
+    pos.set("bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1RK1RQ w GDgd - 0 1", true, CHESS_VARIANT);
+    move = "e1f1";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1R1KRQ b gd - 1 1");
+
+    // 'kingside' castling always lands on c1/d1
+    pos.set("bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1RK1RQ w GDgd - 0 1", true, CHESS_VARIANT);
+    move = "e1d1";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BNKR2RQ b gd - 1 1");
+
+    // 'queenside' castling always lands on f1/g1
+    pos.set("bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1RK1RQ w GDgd - 0 1", true, CHESS_VARIANT);
+    move = "e1g1";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "bnnrkbrq/pppppppp/8/8/8/8/PPPPPPPP/BN1R1RKQ b gd - 1 1");
+
+    pos.set("nrbbqnkr/pppppppp/8/8/8/8/PPPPPPPP/NR4KR w HBhb - 0 1", true, CHESS_VARIANT);
+    move = "g1h1";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.fen() == "nrbbqnkr/pppppppp/8/8/8/8/PPPPPPPP/NR3RK1 b hb - 1 1");
+
+    // TODO: Why is this important?
+    vector<string> castlingMoves = create_castling_moves(true);
+    REQUIRE(are_all_entries_true(castlingMoves, is_960_castling_candidate_move) == true);
+}
+
+TEST_CASE("Antichess") {
+    init();
+    BoardState pos;
+
+    // Check starting fen, esp. because there is no castling
+    pos.init(ANTI_VARIANT, false);
+    REQUIRE(pos.fen() == "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
+
+    // If we can, we must capture. If there are multiple captures, we may choose
+    pos.set("rnb1kbnr/pp1ppppp/8/q1p5/8/2P1P3/PP1PNPPP/RNBQKB1R b - - 0 3", false, ANTI_VARIANT);
+    vector<string> moves = {"a5a2", "a5c3"};
+    REQUIRE(legal_actions_equal_ucimoves(pos, moves));
+
+    // Figures can be moved, even if the king is in check, even checkmate:
+    pos.set("2Q1kb1r/3ppp1p/r4np1/p7/8/P1P1P1P1/4NP1P/RNB1KB1R b - - 0 11", false, ANTI_VARIANT);
+    REQUIRE(pos.check_result() == NO_RESULT);
+    REQUIRE(is_uci_move_legal(pos, "a6a8"));
+
+    // The king can be captured
+    pos.set("r1Q1kb1r/3ppp1p/5np1/p7/8/P1P1P1P1/4NP1P/RNB1KB1R w - - 1 12", false, ANTI_VARIANT);
+    REQUIRE(is_uci_move_legal(pos, "c8e8"));
+    string move = "c8e8";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.check_result() == NO_RESULT);
+
+    // The game is over, if a player lost all pieces
+    pos.set("8/8/6p1/7q/8/8/8/8 w - - 0 39", false, ANTI_VARIANT);
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // If a player has no legal moves (and still figures), he wins (no stalemate !!)
+    pos.set("5b2/4p3/1p3p2/1P5p/8/8/8/1r6 w - - 0 36", false, ANTI_VARIANT);
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // King promotion is legal
+    pos.set("2Q5/8/8/8/R6P/2B5/2pP4/8 b - - 1 35", false, ANTI_VARIANT);
+    REQUIRE(is_uci_move_legal(pos, "c2c1k"));
+
+    // Castling is not permitted
+    pos.set("r3kbnr/p2pp1pp/bp3p2/8/3P4/P1P5/1B1P1PPP/RN1QK2R b - - 0 9", false, ANTI_VARIANT);
+    REQUIRE(is_uci_move_legal(pos, "e8c8") == false);
+}
+
+TEST_CASE("Lichess Crazyhouse") {
+    init();
+    BoardState pos;
+
+    // Check pocket notation
+    pos.init(CRAZYHOUSE_VARIANT, false);
+    REQUIRE(pos.fen() == "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1");
+
+    // Captured pieces can be dropped
+    pos.set("1k1r3r/pppb1p2/2nbqn1p/3p2p1/3PP1P1/3Q1PP1/PPN2NBP/R1B2RK1[p] b - - 0 12", false, CRAZYHOUSE_VARIANT);
+    REQUIRE(is_uci_move_legal(pos, "P@c4"));
+
+    // Pieces cannot be dropped on other pieces
+    vector<string> moves = {"P@d5", "P@d4", "P@e4"};
+    REQUIRE(are_uci_moves_legal_bool(pos, moves, false));
+
+    // Dropping pawns on the 1. and 8. rank is prohibited
+    moves = {"P@b1", "P@d1", "P@e1", "P@e8", "P@f8", "P@g8"};
+    REQUIRE(are_uci_moves_legal_bool(pos, moves, false));
+
+    // Checkmating with a drop is allowed
+    pos.set("4R2b/1N3rkb/1p2P1pp/p2P4/2P1P3/8/PP4Q1/3R3K[QRBBNNNPPPPpp] w - - 2 53", false, CRAZYHOUSE_VARIANT);
+    REQUIRE(is_uci_move_legal(pos, "N@h5"));
+    string move = "N@h5";
+    pos.do_action(pos.uci_to_action(move));
+    REQUIRE(pos.check_result() == WHITE_WIN);
+
+    // If you have pieces in the pocket, you can prevent certain checks/checkmates by dropping pieces between
+    pos.set("r2qk3/1pP2r1n/p1nP4/8/3P1Bb1/2Pp1PP1/PPp2PP1/3q1K1R[Bbnnppr] w - - 2 29", false, CRAZYHOUSE_VARIANT);
+    REQUIRE(pos.check_result() == NO_RESULT);
+    REQUIRE(is_uci_move_legal(pos, "B@e1"));
+}
+
+
+#endif //MODE_LICHESS
 #endif
 

--- a/engine/tests/tests.h
+++ b/engine/tests/tests.h
@@ -101,19 +101,19 @@ Variant get_default_variant();
  * @brief is_uci_move_legal Check if a uci move, given as a string, is legal at a specific position
  * @return bool True, if the engine thinks the move is legal
  */
-bool is_uci_move_legal(const BoardState& pos, const string& move);
+bool is_uci_move_legal(const BoardState& pos, const string& move, bool is960);
 
 /**
  * @brief are_uci_moves_legal_bool Checks if all uci moves are either legal or not
  * @param equals Specifies if the moves have to be legal (true) or not (false) to return true.
  * @return bool True, if all moves equal the parameter 'equals', else false.
  */
-bool are_uci_moves_legal_bool(BoardState& pos, vector<string> uciMoves, bool equals);
+bool are_uci_moves_legal_bool(const BoardState& pos, const vector<string> uciMoves, bool equals, bool is960);
 
 /**
  * @brief legal_actions_equal_ucimoves Checks if the given uci moves is a permutation of the legal actions
  */
-bool legal_actions_equal_ucimoves(BoardState& pos, vector<string>& uciMoves);
+bool legal_actions_equal_ucimoves(const BoardState& pos, const vector<string>& uciMoves, bool is960);
 
 #endif
 

--- a/engine/tests/tests.h
+++ b/engine/tests/tests.h
@@ -97,6 +97,24 @@ GameInfo apply_random_moves(StateObj& state, uint movesToApply);
  */
 Variant get_default_variant();
 
+/**
+ * @brief is_uci_move_legal Check if a uci move, given as a string, is legal at a specific position
+ * @return bool True, if the engine thinks the move is legal
+ */
+bool is_uci_move_legal(const BoardState& pos, const string& move);
+
+/**
+ * @brief are_uci_moves_legal_bool Checks if all uci moves are either legal or not
+ * @param equals Specifies if the moves have to be legal (true) or not (false) to return true.
+ * @return bool True, if all moves equal the parameter 'equals', else false.
+ */
+bool are_uci_moves_legal_bool(BoardState& pos, vector<string> uciMoves, bool equals);
+
+/**
+ * @brief legal_actions_equal_ucimoves Checks if the given uci moves is a permutation of the legal actions
+ */
+bool legal_actions_equal_ucimoves(BoardState& pos, vector<string>& uciMoves);
+
 #endif
 
 #endif // TESTS_H


### PR DESCRIPTION
- Add `960` support
- Save all training `logs`, not only the most recent training log
- Adding some printouts
- Setting `model_contender_dir` explicitly when using Reinforcement Learning
- Updated `nn_update_index` logic, now it works properly (only trainer gpu needs the parameter now. But you may also pass it to the generator gpu)
- Support for different name of `variants` (e.g. standard/chess, antichess/giveaway, ...)
- Delete `gameIdx` and `gamePGNSelfplay` before starting selfplay (here, we should proabably choose a faster method)