### PR TITLE
Bugfix MCGS Solver

### DIFF
--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -719,7 +719,7 @@ float get_transposition_q_value(uint_fast32_t transposVisits, double transposQVa
  * @param trajectory Trajectory on how to get to the given value eval
  * @param solveForTerminal Decides if the terminal solver will be used
  */
-template <bool terminal>
+template <bool freeBackup>
 void backup_value(float value, float virtualLoss, const Trajectory& trajectory, bool solveForTerminal) {
     double targetQValue = 0;
     for (auto it = trajectory.rbegin(); it != trajectory.rend(); ++it) {
@@ -733,7 +733,7 @@ void backup_value(float value, float virtualLoss, const Trajectory& trajectory, 
 #ifndef MCTS_SINGLE_PLAYER
         value = -value;
 #endif
-        terminal ? it->node->revert_virtual_loss_and_update<true>(it->childIdx, value, virtualLoss, solveForTerminal) :
+        freeBackup ? it->node->revert_virtual_loss_and_update<true>(it->childIdx, value, virtualLoss, solveForTerminal) :
                    it->node->revert_virtual_loss_and_update<false>(it->childIdx, value, virtualLoss, solveForTerminal);
 
         if (it->node->is_transposition()) {

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -217,7 +217,7 @@ Node* SearchThread::get_new_child_to_evaluate(ChildIdx& childIdx, NodeDescriptio
             }
             return currentNode;
         }
-        if (nextNode->is_terminal() || nextNode->is_tablebase()) {
+        if (nextNode->is_playout_node() && nextNode->is_solved()) {
             description.type = NODE_TERMINAL;
             currentNode->unlock();
             return currentNode;


### PR DESCRIPTION
This PR fixes a bug in the solver for MCGS when a visit was back-propagated as a transposition value and the MCGS solver was not triggered. This could lead to stalling connection.

This seems also to reduce the search time for forced mates / tb-wins.

e.g. MCGS Solver (updated):
```python
info depth 10 seldepth 14 multipv 1 score mate -5 nodes 699 nps 11459 tbhits 0 time 61 pv b3c4 f3e4 c4b3 e4d3 b3b2 a5a4 b2b1 d3c3 b1c1 a4c2
info string 8/8/8/Q7/8/1k3K2/8/8 b - - 4 82
bestmove b3c4
```

e.g. MCGS Solver (old):
```python
info depth 10 seldepth 14 multipv 1 score mate -5 nodes 875 nps 9943 tbhits 0 time 88 pv b3c4 f3e4 c4b3 e4d3 b3b2 a5a4 b2b1 d3c3 b1c1 a4a1
info string 8/8/8/Q7/8/1k3K2/8/8 b - - 4 82
bestmove b3c4
```

e.g. MCTS Solver:
```python
info depth 10 seldepth 18 multipv 1 score mate -5 nodes 1815 nps 11067 tbhits 0 time 164 pv b3c4 f3e4 c4b3 e4d3 b3b2 a5a4 b2b1 d3c3 b1c1 a4a1
info string 8/8/8/Q7/8/1k3K2/8/8 b - - 4 82
bestmove b3c4
```