### PR TITLE
Reached tablebases funtionality

### DIFF
--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -48,7 +48,8 @@ MCTSAgent::MCTSAgent(NeuralNetAPI *netSingle, vector<unique_ptr<NeuralNetAPI>>& 
     isRunning(false),
     overallNPS(0.0f),
     nbNPSentries(0),
-    threadManager(nullptr)
+    threadManager(nullptr),
+    reachedTablebases(false)
 {
     mapWithMutex.hashTable.reserve(1e6);
 
@@ -130,6 +131,7 @@ size_t MCTSAgent::init_root_node(StateObj *state)
         create_new_root_node(state);
         nodesPreSearch = 0;
     }
+    reachedTablebases = rootNode->is_tablebase() || reachedTablebases;
     return nodesPreSearch;
 }
 
@@ -244,6 +246,7 @@ void MCTSAgent::clear_game_history()
     lastValueEval = -1.0f;
     nbNPSentries = 0;
     overallNPS = 0;
+    reachedTablebases = false;
 }
 
 bool MCTSAgent::is_policy_map()
@@ -313,6 +316,7 @@ void MCTSAgent::run_mcts_search()
         searchThreads[i]->set_root_node(rootNode.get());
         searchThreads[i]->set_root_state(rootState.get());
         searchThreads[i]->set_search_limits(searchLimits);
+        searchThreads[i]->set_reached_tablebases(reachedTablebases);
         threads[i] = new thread(run_search_thread, searchThreads[i]);
     }
     int curMovetime = timeManager->get_time_for_move(searchLimits, rootState->side_to_move(), rootNode->plies_from_null()/2);

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -82,7 +82,7 @@ private:
     GCThread gcThread;
 
     unique_ptr<ThreadManager> threadManager;
-
+    bool reachedTablebases;
 public:
     MCTSAgent(NeuralNetAPI* netSingle,
               vector<unique_ptr<NeuralNetAPI>>& netBatches,

--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -130,9 +130,11 @@ void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vect
     }
     pv.push_back(rootNode->get_action(childIdx));
 
-    const Node* nextNode = rootNode->get_child_node(childIdx);
+    rootNode->lock();
+    Node* nextNode = rootNode->get_child_node(childIdx);
     // make sure the nextNode has been expanded (e.g. when inference of the NN is too slow on the given hardware to evaluate the next node in time)
     if (nextNode != nullptr) {
+        rootNode->unlock();
         nextNode->get_principal_variation(pv, searchSettings->qValueWeight, searchSettings->qVetoDelta);
         evalInfo.pv[idx] = pv;
 
@@ -158,6 +160,7 @@ void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vect
     else {
         evalInfo.bestMoveQ[idx] = Q_INIT;
     }
+    rootNode->unlock();
     evalInfo.movesToMate[idx] = 0;
     evalInfo.centipawns[idx] = value_to_centipawn(evalInfo.bestMoveQ[idx]);
 }

--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -132,9 +132,9 @@ void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vect
 
     rootNode->lock();
     Node* nextNode = rootNode->get_child_node(childIdx);
+    rootNode->unlock();
     // make sure the nextNode has been expanded (e.g. when inference of the NN is too slow on the given hardware to evaluate the next node in time)
     if (nextNode != nullptr) {
-        rootNode->unlock();
         nextNode->get_principal_variation(pv, searchSettings->qValueWeight, searchSettings->qVetoDelta);
         evalInfo.pv[idx] = pv;
 
@@ -160,7 +160,6 @@ void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vect
     else {
         evalInfo.bestMoveQ[idx] = Q_INIT;
     }
-    rootNode->unlock();
     evalInfo.movesToMate[idx] = 0;
     evalInfo.centipawns[idx] = value_to_centipawn(evalInfo.bestMoveQ[idx]);
 }

--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -109,18 +109,12 @@ int value_to_centipawn(float value)
     return int(-(sgn(value) * std::log(1.0f - std::abs(value)) / std::log(VALUE_TO_CENTI_PARAM)) * 100.0f);
 }
 
-float get_best_move_q(const SearchSettings* searchSettings, const Node* nextNode)
+float get_best_move_q(const Node* nextNode)
 {
-#ifdef MCTS_TB_SUPPORT
-    // set eval to 0 for TB draw
-    if (searchSettings->useTablebase && nextNode->is_tablebase() && nextNode->get_node_type() == TB_DRAW) {
-        return DRAW_VALUE;
-    }
-#endif
 #ifndef MCTS_SINGLE_PLAYER
-    return -nextNode->get_value();
+    return -nextNode->get_value_display();
 #else
-    return nextNode->get_value();
+    return nextNode->get_value_display();
 #endif
 }
 
@@ -155,9 +149,11 @@ void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vect
                 evalInfo.movesToMate[idx] = -(int(pv.size())+1) / 2;
                 return;
             }
+            evalInfo.bestMoveQ[idx] = get_best_move_q(nextNode);
         }
-
-    evalInfo.bestMoveQ[idx] = get_best_move_q(searchSettings, nextNode);
+        else {
+            evalInfo.bestMoveQ[idx] = -nextNode->get_value();
+        }
     }
     else {
         evalInfo.bestMoveQ[idx] = Q_INIT;
@@ -212,7 +208,7 @@ void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t 
         // single move with no tree reuse
         evalInfo.pv[0] = {rootNode->get_action(0)};
         // there are no q-values available, therefore use the state value evaluation as bestMoveQ
-        evalInfo.bestMoveQ[0] = rootNode->get_value();
+        evalInfo.bestMoveQ[0] = rootNode->get_value_display();
         evalInfo.centipawns[0] = value_to_centipawn(evalInfo.bestMoveQ[0]);
     }
     else {

--- a/engine/src/evalinfo.h
+++ b/engine/src/evalinfo.h
@@ -91,7 +91,7 @@ void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t 
  * @param nextNode Node object
  * @return value evaluation
  */
-float get_best_move_q(const SearchSettings* searchSettings, const Node* nextNode);
+float get_best_move_q(const Node* nextNode);
 
 /**
  * @brief set_eval_for_single_pv Sets the eval struct pv line and score for a single pv

--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -304,14 +304,37 @@ void Node::mcts_policy_based_on_wins(DynamicVector<double> &mctsPolicy) const
     }
 }
 
+void Node::mcts_policy_based_on_losses(DynamicVector<double> &mctsPolicy) const
+{
+    mctsPolicy = 0;
+    ChildIdx childIdx = 0;
+    ChildIdx longestChildIdx = 0;
+    size_t endInPly = 0;
+    for (auto it = d->childNodes.begin(); it != d->childNodes.end(); ++it) {
+        const Node* childNode = it->get();
+        if (childNode != nullptr && childNode->d != nullptr) {
+            if (childNode->d->endInPly > endInPly) {
+                endInPly = childNode->d->endInPly;
+                longestChildIdx = childIdx;
+            }
+        }
+        ++childIdx;
+    }
+    mctsPolicy[longestChildIdx] = 1.0f;
+}
+
 void Node::prune_losses_in_mcts_policy(DynamicVector<double> &mctsPolicy) const
 {
     // check if PV line leads to a loss
-    if (d->numberUnsolvedChildNodes != get_number_child_nodes() && d->nodeType != LOSS) {
+    if (d->numberUnsolvedChildNodes != get_number_child_nodes() && !is_loss_node_type(d->nodeType)) {
         // set all entries which lead to a WIN of the opponent to zero
         for (size_t childIdx = 0; childIdx < d->noVisitIdx; ++childIdx) {
             const Node* childNode = d->childNodes[childIdx].get();
-            if (childNode != nullptr && childNode->is_playout_node() && childNode->d->nodeType == WIN) {
+#ifndef MCTS_SINGLE_PLAYER
+            if (childNode != nullptr && childNode->is_playout_node() && is_win_node_type(childNode->d->nodeType)) {
+#else
+            if (childNode != nullptr && childNode->is_playout_node() && is_loss_node_type(childNode->d->nodeType) {
+#endif
                 mctsPolicy[childIdx] = 0;
             }
         }
@@ -352,6 +375,12 @@ bool Node::solve_for_terminal(ChildIdx childIdx)
             break;
         default: ; // pass
         }
+    #ifdef MCTS_TB_SUPPORT
+        // disable draws for winning tb positions
+        if (d->nodeType == TB_WIN && d->nodeTypes[childIdx] == TB_DRAW) {
+            disable_action(childIdx);
+        }
+    #endif
     }
 
     if (solved_win(childNode)) {
@@ -530,6 +559,20 @@ void Node::fully_expand_node()
 
 float Node::get_value() const
 {
+    return valueSum / realVisitsSum;
+}
+
+float Node::get_value_display() const
+{
+    if (is_win_node_type(d->nodeType)) {
+        return WIN_VALUE;
+    }
+    if (is_loss_node_type(d->nodeType)) {
+        return LOSS_VALUE;
+    }
+    if (is_draw_node_type(d->nodeType)) {
+        return DRAW_VALUE;
+    }
     return valueSum / realVisitsSum;
 }
 
@@ -959,6 +1002,10 @@ void Node::get_mcts_policy(DynamicVector<double>& mctsPolicy, size_t& bestMoveId
     if (d->nodeType == WIN) {
         mctsPolicy = DynamicVector<float>(d->noVisitIdx);
         mcts_policy_based_on_wins(mctsPolicy);
+    }
+    else if (is_loss_node_type(d->nodeType)) {
+        mctsPolicy = DynamicVector<float>(d->noVisitIdx);
+        mcts_policy_based_on_losses(mctsPolicy);
     }
     else if (qValueWeight > 0) {
         size_t secondArg;

--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -1037,12 +1037,14 @@ void Node::get_mcts_policy(DynamicVector<double>& mctsPolicy, size_t& bestMoveId
     bestMoveIdx = argmax(mctsPolicy);
 }
 
-void Node::get_principal_variation(vector<Action>& pv, float qValueWeight, float qVetoDelta) const
+void Node::get_principal_variation(vector<Action>& pv, float qValueWeight, float qVetoDelta)
 {
-    const Node* curNode = this;
+    Node* curNode = this;
     while (curNode != nullptr && curNode->is_playout_node() && !curNode->is_terminal()) {
+        curNode->lock();
         size_t childIdx = get_best_action_index(curNode, true, qValueWeight, qVetoDelta);
         pv.push_back(curNode->get_action(childIdx));
+        curNode->unlock();
         curNode = curNode->d->childNodes[childIdx].get();
     }
 }

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -217,6 +217,14 @@ public:
     bool is_terminal() const;
     bool has_nn_results() const;
     float get_value() const;
+
+    /**
+     * @brief get_value_display Return value evaluation which can be used for logging
+     * Warning: Must be called with d != nullptr
+     * @return value() or pre-defined constant
+     */
+    float get_value_display() const;
+
     double get_value_sum() const;
     uint32_t get_real_visits() const;
 
@@ -628,10 +636,16 @@ private:
 
     /**
      * @brief mcts_policy_based_on_wins Sets all known winning moves in a given policy to 1 and all
-     * remaining moves to 0. Afterwards the policy is renormalized.
+     * remaining moves to 0.
      * @param mctsPolicy MCTS policy which will be set
      */
     void mcts_policy_based_on_wins(DynamicVector<double>& mctsPolicy) const;
+
+    /**
+     * @brief mcts_policy_based_on_losses Sets the policy entry which delays the mate the longest to 1 and remaining values to 0.
+     * @param mctsPolicy MCTS policy which will be set
+     */
+    void mcts_policy_based_on_losses(DynamicVector<double>& mctsPolicy) const;
 
     /**
      * @brief prune_losses_in_mcts_policy Sets all known losing moves in a given policy to 0 in case

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -359,7 +359,7 @@ public:
      * @param qValueWeight Decides if Q-values are taken into account
      * @param qVetoDelta Describes how much better the highest Q-Value has to be to replace the candidate move with the highest visit count
      */
-     void get_principal_variation(vector<Action>& pv, float qValueWeight, float qVetoDelta) const;
+     void get_principal_variation(vector<Action>& pv, float qValueWeight, float qVetoDelta);
 
     /**
      * @brief mark_nodes_as_fully_expanded Sets the noVisitIdx to be the number of child nodes.

--- a/engine/src/nodedata.cpp
+++ b/engine/src/nodedata.cpp
@@ -82,3 +82,30 @@ bool is_unsolved_or_tablebase(NodeType nodeType)
 {
     return nodeType > LOSS;
 }
+
+bool is_loss_node_type(NodeType nodeType)
+{
+#ifdef MCTS_TB_SUPPORT
+    return nodeType == LOSS || nodeType == TB_LOSS;
+#else
+    return nodeType == LOSS;
+#endif
+}
+
+bool is_win_node_type(NodeType nodeType)
+{
+#ifdef MCTS_TB_SUPPORT
+    return nodeType == WIN || nodeType == TB_WIN;
+#else
+    return nodeType == WIN;
+#endif
+}
+
+bool is_draw_node_type(NodeType nodeType)
+{
+#ifdef MCTS_TB_SUPPORT
+    return nodeType == DRAW || nodeType == TB_DRAW;
+#else
+    return nodeType == DRAW;
+#endif
+}

--- a/engine/src/nodedata.h
+++ b/engine/src/nodedata.h
@@ -52,6 +52,27 @@ enum NodeType : uint8_t {
 };
 
 /**
+ * @brief is_loss_node_type Returns true if given node type belongs to a loosing node type
+ * @param nodeType
+ * @return bool
+ */
+bool is_loss_node_type(NodeType nodeType);
+
+/**
+ * @brief is_win_node_type Returns true if given node type belongs to a win node type
+ * @param nodeType
+ * @return bool
+ */
+bool is_win_node_type(NodeType nodeType);
+
+/**
+ * @brief is_draw_node_type Returns true if given node type belongs to a drawubg node type
+ * @param nodeType
+ * @return  bool
+ */
+bool is_draw_node_type(NodeType nodeType);
+
+/**
  * @brief is_unsolved_or_tablebase Checks if the given node type is a win, draw, loss or a different type.
  * @param nodeType given node type
  * @return bool

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -80,6 +80,7 @@ private:
     size_t depthSum;
     size_t depthMax;
     size_t visitsPreSearch;
+    bool reachedTablebases;
 public:
     /**
      * @brief SearchThread
@@ -127,6 +128,7 @@ public:
     void set_root_node(Node *value);
     bool is_running() const;
     void set_is_running(bool value);
+    void set_reached_tablebases(bool value);
 
     /**
      * @brief add_new_node_to_tree Adds a new node to the search by either creating a new node or duplicating an exisiting node in case of transposition usage


### PR DESCRIPTION
* added reachedTablebases
* added get_value_display()
* added is_loss_node_type(), is_draw_node_type(), is_win_node_type()
* added mcts_policy_based_on_losses()
* fixed prune_losses_in_mcts_policy() for `MCTS_SINGLE_PLAYER`
* disabled drawing actions for winning TBs

```python
3s + 0.1s
Score of ClassicAra 0.9.3-Dev -6-Men-TB - 3 Threads - Reach-TB vs ClassicAra 0.9.3-Dev -6-Men-TB - 3 Threads - Master: 78 - 81 - 258 [0.496]
Elo difference: -2.5 +/- 20.6, LOS: 40.6 %, DrawRatio: 61.9 %

417 of 1000 games finished.
```