### PR TITLE
Release 0.9.3

### DIFF
--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -53,7 +53,7 @@ const string engineName = "MultiAra";
 const string engineName = "ClassicAra";
 #endif
 
-const string engineVersion = "0.9.3-Dev";
+const string engineVersion = "0.9.3";
 const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al.";
 
 #define LOSS_VALUE -1

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -229,9 +229,9 @@ Node* SearchThread::get_new_child_to_evaluate(NodeDescription& description)
             return nextNode;
         }
 #ifdef MCTS_TB_SUPPORT
-        if (nextNode->is_terminal() || (!reachedTablebases && nextNode->is_tablebase())) {
+        if (nextNode->is_terminal() || (!reachedTablebases && nextNode->is_playout_node() && nextNode->is_solved())) {
 #else
-        if (nextNode->is_terminal()) {
+        if (nextNode->is_playout_node() && nextNode->is_solved()) {
 #endif
             description.type = NODE_TERMINAL;
             currentNode->unlock();

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -228,7 +228,11 @@ Node* SearchThread::get_new_child_to_evaluate(NodeDescription& description)
             }
             return nextNode;
         }
-        if (nextNode->is_terminal() || (!reachedTablebases && nextNode->is_playout_node() && nextNode->is_solved())) {
+#ifdef MCTS_TB_SUPPORT
+        if (nextNode->is_terminal() || (!reachedTablebases && nextNode->is_tablebase())) {
+#else
+        if (nextNode->is_terminal()) {
+#endif
             description.type = NODE_TERMINAL;
             currentNode->unlock();
             return nextNode;
@@ -344,7 +348,7 @@ void SearchThread::create_mini_batch()
     while (!newNodes->is_full() &&
            collisionTrajectories.size() != searchSettings->batchSize &&
            !transpositionValues->is_full() &&
-           numTerminalNodes < TERMINAL_NODE_CACHE) {
+           numTerminalNodes < searchSettings->batchSize*2) {
 
         trajectoryBuffer.clear();
         actionsBuffer.clear();


### PR DESCRIPTION
replaced TERMINAL_NODE_CACHE by batchSize x 2

```python
TC 7s + 0.1s
Score of CrazyAra 0.9.3 - Release vs CrazyAra 0.9.0 - Release: 99 - 97 -
28 [0.504]
Elo difference: 3.1 +/- 42.7, LOS: 55.7 %, DrawRatio: 12.5 %

224 of 1000 games finished.
```