### PR TITLE
Setting UCI_Variant and Model_Directory dynamically

### DIFF
--- a/engine/src/uci/optionsuci.h
+++ b/engine/src/uci/optionsuci.h
@@ -64,6 +64,13 @@ namespace OptionsUCI {
     string check_uci_variant_input(const string &value, bool *is960);
 
     /**
+     * @brief get_first_variant_with_model Return the name of the first variant in the vector
+     * of available variants that has a model saved in 'model/<variant_name>'.
+     * @return string UCI variant name.
+     */
+    const string get_first_variant_with_model();
+
+    /**
      * @brief init_new_search Initializes the struct according to the given OptionsMap for a new search
      * @param searchLimit search limits struct to be changed
      * @param options UCI Options struct (won't be changed)


### PR DESCRIPTION
**Old behavior:**
* When the binary supports multiple variants, the first variant of the `availableVariants` vector is set as default for the UCI options `UCI_variant` and `Model_Directory`

**New behavior:**
* When the binary is loaded, the default variant is set to the first variant in the `availableVariants` vector that has a model

**Solved problems:**
* When we run the binary, but we do not have a model for the first variant in the `availableVariants` vector, the binary does not crash when `isready` is called
* This way, we don't need to have a model for the first variant in `availableVariants` on our hard drive, if we want to play a different variant