### PR TITLE
Fix antichess representation

### DIFF
--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -267,7 +267,6 @@ string OptionsUCI::check_uci_variant_input(const string &value, bool *is960) {
     if (value == "giveaway" || value == "losers") {
         return "antichess";
     }
-    return value;
 #endif // MODE_LICHESS
     // MODE_CRAZYHOUSE or others (keep value as is)
     return value;

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -264,8 +264,8 @@ string OptionsUCI::check_uci_variant_input(const string &value, bool *is960) {
        return "chess";
     }
 #ifdef MODE_LICHESS
-    if (value == "antichess" || value == "losers") {
-        return "giveaway";
+    if (value == "giveaway" || value == "losers") {
+        return "antichess";
     }
     return value;
 #endif // MODE_LICHESS

--- a/engine/src/uci/variants.h
+++ b/engine/src/uci/variants.h
@@ -47,12 +47,12 @@ const static vector<string> availableVariants = {
 #ifdef MODE_LICHESS
     "kingofthehill",
     "atomic",
-    "giveaway",
+    "antichess",
     "horde",
     "racingkings",
     "3check",
-    "antichess", // giveaway
-    "losers", // giveaway
+    "giveaway", // antichess
+    "losers", // antichess
 #endif
 };
 

--- a/engine/tests/tests.cpp
+++ b/engine/tests/tests.cpp
@@ -746,8 +746,8 @@ TEST_CASE("Variants_Horde"){
 
     // A pawn that moved from first row to second row can now move 2 squares
 
-    pos.set("1kb3nr/8/8/8/3p1pP1/8/1P2P3/P6P w - - 0 1", false, HORDE_VARIANT);
-    mov = "a1a3";
+    pos.set("1kb3nr/8/8/8/3p1pP1/8/4P3/PP5P w - - 0 1", false, HORDE_VARIANT);
+    mov = "b1b2";
     action = pos.uci_to_action(mov);
     pos.do_action(action);
     mov = "h8h1";


### PR DESCRIPTION
**Problem:**
* Internally we used the string `giveaway` as representation for the uci variant giveaway/antichess, without adding the `C directive` for giveaway. This way, the variants vector provided by multivariant stockfish did not recognize the variant and always returned the standard values for standard chess.

**Fix:**
* Now we use `antichess` as internal representation, as we have included the antichess directive.
* There is no need to include the `giveaway` directive, because the strings `giveaway` and `losers` get translated to `antichess`