### PR TITLE
Chess input representation v2.1

### DIFF
--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_mobile_v3.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_mobile_v3.py
@@ -164,3 +164,30 @@ def rise_mobile_v3_symbol(channels=256, channels_operating_init=224, channel_exp
     sym = mx.symbol.Group([value_out, policy_out])
 
     return sym
+
+
+def get_rise_v33_symbol(channels_policy_head, val_loss_factor, policy_loss_factor, select_policy_from_plane):
+    """
+    Wrapper definition for RISEv3.3.
+    :return: symbol
+    """
+    kernels = [3] * 15
+    kernels[7] = 5
+    kernels[11] = 5
+    kernels[12] = 5
+    kernels[13] = 5
+
+    se_types = [None] * len(kernels)
+    se_types[5] = "eca_se"
+    se_types[8] = "eca_se"
+    se_types[12] = "eca_se"
+    se_types[13] = "eca_se"
+    se_types[14] = "eca_se"
+
+    symbol = rise_mobile_v3_symbol(channels=256, channels_operating_init=224, channel_expansion=32, act_type='relu',
+                                   channels_value_head=8, value_fc_size=256,
+                                   channels_policy_head=channels_policy_head,
+                                   grad_scale_value=val_loss_factor, grad_scale_policy=policy_loss_factor,
+                                   dropout_rate=0, select_policy_from_plane=select_policy_from_plane,
+                                   kernels=kernels, se_types=se_types, use_avg_features=False)
+    return symbol

--- a/DeepCrazyhouse/src/domain/util.py
+++ b/DeepCrazyhouse/src/domain/util.py
@@ -26,7 +26,7 @@ from DeepCrazyhouse.src.domain.variants.constants import (
 mirrored_files_lookup = {'a': 'i', 'b': 'h', 'c': 'g', 'd': 'f', 'e': 'e', 'f': 'd', 'g': 'c', 'h': 'b', 'i': 'a'}
 
 
-def checkerboard(shape=(8,8)):
+def checkerboard(shape=(8, 8)):
     """
     Generates a checkerboard, by Eelco Hoogendoorn
     https://stackoverflow.com/questions/2169478/how-to-make-a-checkerboard-in-numpy
@@ -44,7 +44,7 @@ def opposite_colors(square1, square2):
     :param square2: Second square
     :return: True if on opposite squares, else false
     """
-    return square1 + chess.square_rank(square1) + square2 + chess.square_rank(square2) and 1
+    return square1 + chess.square_rank(square1) + square2 + chess.square_rank(square2) & 1
 
 
 def opposite_colored_bishops(board: chess.Board):
@@ -54,9 +54,10 @@ def opposite_colored_bishops(board: chess.Board):
     :return: True if on opposite colors else false
     """
     white_bishops = list(board.pieces(chess.BISHOP, chess.WHITE))
-    black_bishops = list(board.pieces(chess.BISHOP, chess.WHITE))
+    black_bishops = list(board.pieces(chess.BISHOP, chess.BLACK))
     if len(white_bishops) == 1 and len(black_bishops) == 1:
         return opposite_colors(white_bishops[0], black_bishops[0])
+    return False
 
 
 def get_row_col(position, mirror=False):
@@ -313,3 +314,19 @@ def get_check_move_indices(board, legal_moves):
             check_move_indices.append(idx)
             nb_checks += 1
     return check_move_indices, nb_checks
+
+
+if __name__ == '__main__':
+    print("Unit-Test: opposite_colored_bishops() & opposite_colors()")
+    b = chess.Board()
+    assert(not opposite_colored_bishops(b))
+    b = chess.Board(fen='r4rk1/1pp2p2/3pq1np/pP2p1p1/P3Pn2/2PPPNB1/2Q3PP/3R1RK1 b - - 0 23')
+    assert(not opposite_colored_bishops(b))
+    b = chess.Board(fen='r4rk1/1pp1bp2/3pq1np/pP2p1p1/P3Pn2/2PPPNB1/2Q3PP/3R1RK1 b - - 0 1')
+    assert(not opposite_colored_bishops(b))
+    b = chess.Board(fen='r4rk1/1ppbbp2/3pq1np/pP2p1p1/P3Pn2/1BPPPN2/2Q3PP/3R1RK1 b - - 0 1')
+    assert(not opposite_colored_bishops(b))
+    b = chess.Board(fen='r4rk1/1ppb1p2/3pq1np/pP2p1p1/P3Pn2/2PPPNB1/2Q3PP/3R1RK1 b - - 0 1')
+    assert(opposite_colored_bishops(b))
+    b = chess.Board(fen='r4rk1/1pp2pb1/3pq1np/pP2p1p1/P3Pn2/2PPPN2/B1Q3PP/3R1RK1 b - - 0 1')
+    assert(opposite_colored_bishops(b))

--- a/DeepCrazyhouse/src/domain/variants/classical_chess/v2/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/classical_chess/v2/input_representation.py
@@ -1,0 +1,293 @@
+"""
+@file: input_representation.py
+Created on 26.05.21
+@project: CrazyAra
+@author: queensgambit
+
+Input representation for chess v2.0.
+This presentation avoids potential overfitting and bias, e.g. no color information, no move counter, no progress counter
+and adds features which are hard for the CNN to extract, e.g. material info, number legal moves, checkerboard,
+opposite color bishops.
+"""
+import chess
+from DeepCrazyhouse.src.domain.variants.constants import BOARD_WIDTH, BOARD_HEIGHT, NB_CHANNELS_TOTAL, PIECES
+from DeepCrazyhouse.src.domain.util import MATRIX_NORMALIZER, opposite_colored_bishops, get_row_col, np, checkerboard,\
+    get_board_position_index
+
+NORMALIZE_NB_LEGAL_MOVES = 200
+NORMALIZE_PIECE_NUMBER = 8
+# These constant describe the starting channel for the corresponding info
+CHANNEL_PIECES = 0
+CHANNEL_EN_PASSANT = 12
+CHANNEL_CASTLING = 13
+CHANNEL_LAST_MOVES = 17
+CHANNEL_IS_960 = 33
+CHANNELS_MATERIAL = 37
+CHANNELS_NB_LEGAL_MOVES = 42
+
+
+def board_to_planes(board: chess.Board, normalize=True, last_moves=None):
+    """
+    Gets the plane representation of a given board state.
+
+    ## Chess:
+
+    Feature | Planes
+
+    --- | ---
+
+    P1 piece | 6 (pieces are ordered: PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING)
+
+    P2 piece | 6 (pieces are ordered: PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING)
+
+    En-passant square | 1 (Binary map indicating the square where en-passant capture is possible)
+
+    ---
+    13 planes
+
+    * * *
+
+    P1 castling | 2 (One if castling is possible, else zero)
+
+    P2 castling | 2 (One if castling is possible, else zero)
+
+    ---
+    4 planes
+
+    * * *
+
+    Last 8 moves | 16 (indicated by origin and destination square, the most recent move is described by first 2 planes)
+
+    ---
+    16 planes
+
+    * * *
+
+    is960 = | 1 (boolean, 1 when active)
+
+    ---
+    1 plane
+
+    ---
+
+    P1 pieces | 1 | A grouped mask of all WHITE pieces |
+    P2 pieces | 1 | A grouped mask of all BLACK pieces |
+    Chessboard | 1 | A chess board pattern |
+    P1 Material Diff | 5 | (pieces are ordered: PAWN, KNIGHT, BISHOP, ROOK, QUEEN), normalized with 8, + means positive, - means negative |
+    P1 Number legal moves | 1 | Gives the number of legal moves for the active player |
+    Opposite Color Bishops | 1 | Indicates if they are only two bishops and the bishops are opposite color |
+
+    ---
+    10 planes
+
+    The total number of planes is calculated as follows:
+    # --------------
+    13 + 4 + 16 + 1 + 10
+    Total: 44 planes
+
+    :param board: Board handle (Python-chess object)
+    :param board_occ: Sets how often the board state has occurred before (by default 0)
+    :param normalize: True if the inputs shall be normalized to the range [0.-1.]
+    :param last_moves: List of last last moves. The most recent move is the first entry.
+    :return: planes - the plane representation of the current board state
+    """
+
+    # return the plane representation of the given board
+    # return variants.board_to_planes(board, board_occ, normalize, mode=MODE_CHESS)
+
+    planes = np.zeros((NB_CHANNELS_TOTAL, BOARD_HEIGHT, BOARD_WIDTH))
+
+    # channel will be incremented by 1 at first plane
+    channel = -1
+    me = board.turn
+    you = not board.turn
+    colors = [me, you]
+
+    # mirror all bitboard entries for the black player
+    mirror = board.turn == chess.BLACK
+
+    assert (channel + 1 == CHANNEL_PIECES)
+    # Fill in the piece positions
+    # Channel: 0 - 11
+    # Iterate over both color starting with WHITE
+    for color in colors:
+        # the PIECE_TYPE is an integer list in python-chess
+        for piece_type in chess.PIECE_TYPES:
+            # iterate over the piece mask and receive every position square of it
+            for pos in board.pieces(piece_type, color):
+                row, col = get_row_col(pos, mirror=mirror)
+                # set the bit at the right position
+                planes[++channel, row, col] = 1
+
+    # Channel: 12
+    # En Passant Square
+    channel += 1
+    assert(channel == CHANNEL_EN_PASSANT)
+    if board.ep_square is not None:
+        row, col = get_row_col(board.ep_square, mirror=mirror)
+        planes[channel, row, col] = 1
+
+    # Channel: 13 - 16
+    assert (channel+1 == CHANNEL_CASTLING)
+    for color in colors:
+        # check for King Side Castling
+        channel += 1
+        if board.has_kingside_castling_rights(color):
+            planes[channel, :, :] = 1
+        # check for Queen Side Castling
+        channel += 1
+        if board.has_queenside_castling_rights(color):
+            planes[channel, :, :] = 1
+
+    # Channel: 17 - 32
+    assert(channel+1 == CHANNEL_LAST_MOVES)
+    # Last 8 moves
+    for move in last_moves:
+        if move:
+            from_row, from_col = get_row_col(move.from_square, mirror=mirror)
+            to_row, to_col = get_row_col(move.to_square, mirror=mirror)
+            planes[++channel, from_row, from_col] = 1
+            planes[++channel, to_row, to_col] = 1
+        else:
+            channel += 2
+
+    # Channel: 33
+    # Chess960
+    channel += 1
+    assert (channel == CHANNEL_IS_960)
+    if board.chess960:
+        planes[channel + 1, :, :] = 1
+
+    # Channel: 34 - 35
+    # All white pieces and black pieces in a single map
+    for color in colors:
+        channel += 1
+        # the PIECE_TYPE is an integer list in python-chess
+        for piece_type in chess.PIECE_TYPES:
+            # iterate over the piece mask and receive every position square of it
+            for pos in board.pieces(piece_type, color):
+                row, col = get_row_col(pos, mirror=mirror)
+                # set the bit at the right position
+                planes[channel, row, col] = 1
+
+    # Channel: 36
+    # Checkerboard
+    planes[++channel, :, :] = checkerboard()
+
+    # Channel: 37 - 41
+    # Relative material difference (negative if less pieces than opponent and positive if more)
+    # iterate over all pieces except the king
+    assert(channel + 1 == CHANNELS_MATERIAL)
+    for piece_type in chess.PIECE_TYPES[:-1]:
+        matt_diff = len(board.pieces(piece_type, me)) - len(board.pieces(piece_type, you))
+        planes[++channel, :, :] = matt_diff / NORMALIZE_PIECE_NUMBER if normalize else matt_diff
+
+    # Channel: 42
+    # Number legal moves
+    assert (channel+1 == CHANNELS_NB_LEGAL_MOVES)
+    planes[++channel, :, :] = len(board.legal_moves) / NORMALIZE_NB_LEGAL_MOVES if normalize else len(board.legal_moves)
+
+    # Opposite color bishops
+    channel += 1
+    if opposite_colored_bishops(board):
+        planes[channel, :, :] = 1
+
+    if normalize is True:
+        planes *= MATRIX_NORMALIZER
+
+    return planes
+
+
+def planes_to_board(planes):
+    """
+    Converts a board in plane representation to the python chess board representation
+    see get_planes_of_board() for input encoding description
+    ! Board is always returned with WHITE to move and move number and no progress counter = 0 !
+
+    :param planes: Input plane representation
+    :return: python chess board object
+    """
+    is960 = planes[CHANNEL_IS_960, 0, 0] == 1
+    board = chess.Board(chess960=is960)
+    # clear the full board (the pieces will be set later)
+    board.clear()
+
+    # iterate over all piece types
+    for idx, piece in enumerate(PIECES):
+        # iterate over all fields and set the current piece type
+        for row in range(BOARD_HEIGHT):
+            for col in range(BOARD_WIDTH):
+                # check if there's a piece at the current position
+                if planes[idx, row, col] == 1:
+                    # check if the piece was promoted
+                    promoted = False
+                    board.set_piece_at(
+                        square=get_board_position_index(row, col),
+                        piece=chess.Piece.from_symbol(piece),
+                        promoted=promoted,
+                    )
+
+    # (I.5) En Passant Square
+    # mark the square where an en-passant capture is possible
+    channel = CHANNEL_EN_PASSANT
+    ep_square = np.argmax(planes[channel])
+    if ep_square != 0:
+        # if no entry 'one' exists, index 0 will be returned
+        board.ep_square = ep_square
+
+    # (II.2) Castling Rights
+    channel = CHANNEL_CASTLING
+    set_castling_rights(board, channel, planes, is960)
+
+    return board
+
+
+def set_castling_rights(board, channel, planes, is960):
+    # reset the castling_rights for initialization
+    # set to 0, previously called chess.BB_VOID for chess version of 0.23.X and chess.BB_EMPTY for versions > 0.27.X
+    board.castling_rights = 0
+    # WHITE
+    # check for King Side Castling
+    # White can castle with the h1 rook
+    # add castling option by modifying the castling fen
+    castling_fen = ""
+    # check for King Side Castling
+    if planes[channel, 0, 0] == 1:
+        if is960:
+            castling_fen += "K"
+        else:
+            board.castling_rights |= chess.BB_H1
+    # check for Queen Side Castling
+    if planes[channel + 1, 0, 0] == 1:
+        if is960:
+            castling_fen += "Q"
+        else:
+            board.castling_rights |= chess.BB_A1
+    # BLACK
+    # check for King Side Castling
+    if planes[channel + 2, 0, 0] == 1:
+        if is960:
+            castling_fen += "k"
+        else:
+            board.castling_rights |= chess.BB_H8
+    # check for Queen Side Castling
+    if planes[channel + 3, 0, 0] == 1:
+        if is960:
+            castling_fen += "q"
+        else:
+            board.castling_rights |= chess.BB_A8
+    # configure the castling rights
+    if castling_fen:
+        board.set_castling_fen(castling_fen)
+
+
+def normalize_input_planes(planes):
+    """
+    Normalizes input planes to range [0,1]. Works in place / meaning the input parameter x is manipulated
+    :param planes: Input planes representation
+    :return: The normalized planes
+    """
+    planes[CHANNELS_NB_LEGAL_MOVES, :, :] /= NORMALIZE_NB_LEGAL_MOVES
+    channel = CHANNELS_MATERIAL - 1
+    for _ in chess.PIECE_TYPES[:-1]:
+        planes[++channel, :, :] /= CHANNELS_MATERIAL

--- a/DeepCrazyhouse/src/domain/variants/classical_chess/v2/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/classical_chess/v2/input_representation.py
@@ -14,7 +14,7 @@ from DeepCrazyhouse.src.domain.variants.constants import BOARD_WIDTH, BOARD_HEIG
 from DeepCrazyhouse.src.domain.util import opposite_colored_bishops, get_row_col, np, checkerboard,\
     get_board_position_index
 
-NORMALIZE_NB_LEGAL_MOVES = 200
+NORMALIZE_NB_LEGAL_MOVES = 100
 NORMALIZE_PIECE_NUMBER = 8
 # These constant describe the starting channel for the corresponding info
 CHANNEL_PIECES = 0

--- a/DeepCrazyhouse/src/domain/variants/classical_chess/v2/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/classical_chess/v2/input_representation.py
@@ -4,7 +4,7 @@ Created on 26.05.21
 @project: CrazyAra
 @author: queensgambit
 
-Input representation for chess v2.0.
+Input representation for chess v2.1.
 This presentation avoids potential overfitting and bias, e.g. no color information, no move counter, no progress counter
 and adds features which are hard for the CNN to extract, e.g. material info, number legal moves, checkerboard,
 opposite color bishops.

--- a/DeepCrazyhouse/src/domain/variants/constants.py
+++ b/DeepCrazyhouse/src/domain/variants/constants.py
@@ -136,8 +136,14 @@ elif MODE == MODE_XIANGQI:
     NB_LAST_MOVES = 0
     NB_CHANNELS_PER_HISTORY_ITEM = 0
 else:  # MODE = MODE_CHESS
-    NB_CHANNELS_POS = 15
-    NB_CHANNELS_CONST = 7
+    if VERSION == 1:
+        NB_CHANNELS_POS = 15
+    else:  # VERSION == 2
+        NB_CHANNELS_POS = 13 + 10  # 12 pieces + 1 en-passant and 10 auxiliary
+    if VERSION == 1:
+        NB_CHANNELS_CONST = 7
+    else:  # VERSION == 2
+        NB_CHANNELS_CONST = 4  # only castling info
     NB_CHANNELS_VARIANTS = 1  # is960
     # No dropping moves, king promotion moves
     NB_POLICY_MAP_CHANNELS = 76

--- a/DeepCrazyhouse/src/domain/variants/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/input_representation.py
@@ -9,8 +9,10 @@ which is passed to the neural network
 """
 
 from chess.variant import CrazyhouseBoard
+import classical_chess.v2.input_representation as chess_v2
 from DeepCrazyhouse.src.domain.variants.constants import (
     MODES,
+    VERSION,
     MODE_CRAZYHOUSE,
     MODE_LICHESS,
     MODE_CHESS,
@@ -199,6 +201,9 @@ def board_to_planes(board, board_occ=0, normalize=True, mode=MODE_CRAZYHOUSE, la
 
     # TODO: Remove board.mirror() for black by addressing the according color channel
 
+    if mode == MODE_CHESS and VERSION == 2:
+        return chess_v2.board_to_planes(board, normalize, last_moves)
+
     # (I) Define the Input Representation for one position
     planes_pos = np.zeros((NB_CHANNELS_POS, BOARD_HEIGHT, BOARD_WIDTH))
     planes_const = np.zeros((NB_CHANNELS_CONST, BOARD_HEIGHT, BOARD_WIDTH))
@@ -272,6 +277,9 @@ def planes_to_board(planes, normalized_input=False, mode=MODE_CRAZYHOUSE):
     """
     if mode not in MODES:
         raise ValueError(f"Given {mode} is not {MODES}.")
+
+    if mode == MODE_CHESS and VERSION == 2:
+        return chess_v2.planes_to_board(planes)
 
     # extract the maps for the board position
     planes_pos = planes[:NB_CHANNELS_POS]

--- a/DeepCrazyhouse/src/domain/variants/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/input_representation.py
@@ -475,8 +475,7 @@ def normalize_input_planes(x):
         x = x.astype(np.float32)
 
     if MODE == MODE_CHESS and VERSION == 2:
-        chess_v2.normalize_input_planes(x)
-        return
+        return chess_v2.normalize_input_planes(x)
 
     mat_pos = x[:NB_CHANNELS_POS, :, :]
     mat_const = x[NB_CHANNELS_POS:, :, :]

--- a/DeepCrazyhouse/src/domain/variants/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/input_representation.py
@@ -9,13 +9,17 @@ which is passed to the neural network
 """
 
 from chess.variant import CrazyhouseBoard
-import classical_chess.v2.input_representation as chess_v2
+import DeepCrazyhouse.src.domain.variants.classical_chess.v2.input_representation as chess_v2
 from DeepCrazyhouse.src.domain.variants.constants import (
+    MODE,
+    NB_CHANNELS_TOTAL,
     MODES,
     VERSION,
     MODE_CRAZYHOUSE,
     MODE_LICHESS,
     MODE_CHESS,
+    MODE_XIANGQI,
+    POCKETS_SIZE_PIECE_TYPE,
     BOARD_HEIGHT,
     BOARD_WIDTH,
     CHANNEL_MAPPING_CONST,
@@ -31,7 +35,7 @@ from DeepCrazyhouse.src.domain.variants.constants import (
     PIECES,
     chess,
     VARIANT_MAPPING_BOARDS)
-from DeepCrazyhouse.src.domain.util import MATRIX_NORMALIZER, get_board_position_index, get_row_col, np
+from DeepCrazyhouse.src.domain.util import get_board_position_index, get_row_col, np
 
 
 def _fill_position_planes(planes_pos, board, board_occ=0, mode=MODE_CRAZYHOUSE):
@@ -457,3 +461,53 @@ def planes_to_board(planes, normalized_input=False, mode=MODE_CRAZYHOUSE):
         board.board_turn = chess.BLACK
 
     return board
+
+
+def normalize_input_planes(x):
+    """
+    Normalizes input planes to range [0,1]. Works in place / meaning the input parameter x is manipulated
+    :param x: Input planes representation
+    :return: The normalized planes
+    """
+
+    # convert the input planes to float32 assuming that the datatype is int
+    if x.dtype != np.float32:
+        x = x.astype(np.float32)
+
+    if MODE == MODE_CHESS and VERSION == 2:
+        chess_v2.normalize_input_planes(x)
+        return
+
+    mat_pos = x[:NB_CHANNELS_POS, :, :]
+    mat_const = x[NB_CHANNELS_POS:, :, :]
+
+    # iterate over all pieces except the king, (because the king can't be in a pocket)
+    if MODE == MODE_CRAZYHOUSE or MODE == MODE_LICHESS:
+        for p_type in chess.PIECE_TYPES[:-1]:
+            # p_type -1 because p_type starts with 1
+            channel = CHANNEL_MAPPING_POS["prisoners"] + p_type - 1
+            mat_pos[channel, :, :] /= MAX_NB_PRISONERS
+            # the prison for black begins 5 channels later
+            mat_pos[channel + POCKETS_SIZE_PIECE_TYPE, :, :] /= MAX_NB_PRISONERS
+    # xiangqi has 7 piece types (king/general is excluded as prisoner)
+    elif MODE == MODE_XIANGQI:
+        for p_type in range(6):
+            channel = CHANNEL_MAPPING_POS["prisoners"] + p_type
+            mat_pos[channel, :, :] /= MAX_NB_PRISONERS
+            # the prison for opponent begins 6 channels later
+            mat_pos[channel + POCKETS_SIZE_PIECE_TYPE, :, :] /= MAX_NB_PRISONERS
+
+    # Total Move Count
+    # 500 was set as the max number of total moves
+    mat_const[CHANNEL_MAPPING_CONST["total_mv_cnt"], :, :] /= MAX_NB_MOVES
+    # No progress count
+    # after 40 moves of no progress the 40 moves rule for draw applies
+    if MODE != MODE_XIANGQI:
+        mat_const[CHANNEL_MAPPING_CONST["no_progress_cnt"], :, :] /= MAX_NB_NO_PROGRESS
+
+    return x
+
+
+# use a constant matrix for normalization to allow broad cast operations
+# in policy version 2, the king promotion moves were added to support antichess, this deprecates older nets
+MATRIX_NORMALIZER = normalize_input_planes(np.ones((NB_CHANNELS_TOTAL, BOARD_HEIGHT, BOARD_WIDTH)))

--- a/DeepCrazyhouse/src/preprocessing/dataset_loader.py
+++ b/DeepCrazyhouse/src/preprocessing/dataset_loader.py
@@ -11,7 +11,8 @@ import logging
 import numpy as np
 import zarr
 from DeepCrazyhouse.configs.main_config import main_config
-from DeepCrazyhouse.src.domain.util import get_numpy_arrays, get_x_y_and_indices, MATRIX_NORMALIZER
+from DeepCrazyhouse.src.domain.util import get_numpy_arrays, get_x_y_and_indices
+from DeepCrazyhouse.src.domain.variants.input_representation import MATRIX_NORMALIZER
 
 
 def _load_dataset_file(dataset_filepath):

--- a/DeepCrazyhouse/src/training/train_cnn.ipynb
+++ b/DeepCrazyhouse/src/training/train_cnn.ipynb
@@ -432,10 +432,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "kernels = [3] * 15\n",
     "kernels[7] = 5\n",
@@ -459,8 +457,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "kernels = [3,3,3,3,3,3,5,5]\n",
     "\n",
@@ -1011,7 +1011,7 @@
    "source": [
     "s_idcs_mate, x_mate, yv_mate, yp_mate, _, pgn_dataset_mate = load_pgn_dataset(dataset_type='mate_in_one', part_id=0,\n",
     "                                                                              verbose=True, normalize=tc.normalize)\n",
-    "yp_mate = prepare_policy(y_policy=yp_mate, select_policy_from_plane=tc.select_policy_from_plane,\n",
+    "yp_mate_new = prepare_policy(y_policy=yp_mate, select_policy_from_plane=tc.select_policy_from_plane,\n",
     "                          sparse_policy_label=False,\n",
     "                          is_policy_from_plane_data=tc.is_policy_from_plane_data)"
    ]
@@ -1022,7 +1022,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mate_dataset = mx.gluon.data.dataset.ArrayDataset(nd.array(x_mate), nd.array(yv_mate), nd.array(yp_mate.argmax(axis=1)))\n",
+    "mate_dataset = mx.gluon.data.dataset.ArrayDataset(nd.array(x_mate), nd.array(yv_mate), nd.array(yp_mate_new.argmax(axis=1)))\n",
     "mate_data = mx.gluon.data.DataLoader(mate_dataset, batch_size=tc.batch_size, num_workers=tc.cpu_count)"
    ]
   },

--- a/DeepCrazyhouse/src/training/train_cnn.ipynb
+++ b/DeepCrazyhouse/src/training/train_cnn.ipynb
@@ -162,7 +162,7 @@
     "# ratio for mixing the value return with the corresponding q-value\n",
     "# for a ratio of 0 no q-value information will be used\n",
     "tc.q_value_ratio = 0\n",
-    "        \n",
+    "\n",
     "# define if policy training target is one-hot encoded a distribution (e.g. mcts samples, knowledge distillation)\n",
     "tc.sparse_policy_label = True\n",
     "# define if the policy data is also defined in \"select_policy_from_plane\" representation\n",
@@ -459,10 +459,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "kernels = [3,3,3,3,3,3,5,5]\n",
     "\n",
@@ -980,6 +978,9 @@
    "source": [
     "s_idcs_test, x_test, yv_test, yp_test, _, pgn_datasets_test = load_pgn_dataset(dataset_type='test', part_id=0,\n",
     "                                                                               verbose=True, normalize=True)\n",
+    "yp_test = prepare_policy(y_policy=yp_test, select_policy_from_plane=tc.select_policy_from_plane,\n",
+    "                          sparse_policy_label=False,\n",
+    "                          is_policy_from_plane_data=tc.is_policy_from_plane_data)\n",
     "test_dataset = gluon.data.ArrayDataset(nd.array(x_test), nd.array(yv_test), nd.array(yp_test.argmax(axis=1)))\n",
     "test_data = gluon.data.DataLoader(test_dataset, batch_size=tc.batch_size, shuffle=True, num_workers=tc.cpu_count)"
    ]
@@ -1009,7 +1010,10 @@
    "outputs": [],
    "source": [
     "s_idcs_mate, x_mate, yv_mate, yp_mate, _, pgn_dataset_mate = load_pgn_dataset(dataset_type='mate_in_one', part_id=0,\n",
-    "                                                                              verbose=True, normalize=tc.normalize)"
+    "                                                                              verbose=True, normalize=tc.normalize)\n",
+    "yp_mate = prepare_policy(y_policy=yp_mate, select_policy_from_plane=tc.select_policy_from_plane,\n",
+    "                          sparse_policy_label=False,\n",
+    "                          is_policy_from_plane_data=tc.is_policy_from_plane_data)"
    ]
   },
   {
@@ -1314,6 +1318,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Input Representation

This presentation avoids potential overfitting and bias, e.g. no color information, no move counter, no progress counter
and adds features which are hard for the CNN to extract, e.g. material info, number legal moves, checkerboard,
opposite color bishops.

| Feature | Planes | Description |
| --- | --- | --- |
| P1 piece | 6 | (pieces are ordered: PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING) |
| P2 piece | 6 | (pieces are ordered: PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING) |
| En-passant square | 1 | (Binary map indicating the square where en-passant capture is possible) |
| P1 castling | 2 | (One if castling is possible, else zero) |
| P2 castling | 2 | (One if castling is possible, else zero) |
| Last Moves | 16 | Trajectory of last 8 moves played |
| is960 | 1 | indicate if 960 is active |
| P1 pieces | 1 | A grouped mask of all WHITE pieces |
| P2 pieces | 1 | A grouped mask of all BLACK pieces |
| Chessboard | 1 | A chess board pattern |
| P1 Material Diff | 5 | (pieces are ordered: PAWN, KNIGHT, BISHOP, ROOK, QUEEN), normalized with 8, + means positive, - means negative |
| P1 Number legal moves | 1 | Gives the number of legal moves for the active player |
| Opposite Color Bishops | 1 | Indicates if they are only two bishops and the bishops are opposite color |

Total Planes: 44

## Constants
```python
NORMALIZE_NB_LEGAL_MOVES = 100
NORMALIZE_PIECE_NUMBER = 8
# These constant describe the starting channel for the corresponding info
CHANNEL_PIECES = 0
CHANNEL_EN_PASSANT = 12
CHANNEL_CASTLING = 13
CHANNEL_LAST_MOVES = 17
CHANNEL_IS_960 = 33
CHANNEL_PIECE_MASK = 34
CHANNEL_CHECKERBOARD = 36
CHANNEL_MATERIAL = 37
CHANNEL_NB_LEGAL_MOVES = 42
CHANNEL_OPP_BISHOPS = 43
```

The new representation leads to a significant lower value loss at the cost of only a slight worse policy-loss.
Tested on a data set of 10k games, Kingbase-2019lite.


## Model Info
```python
kernels = [3] * 7

se_types = [None] * len(kernels)
se_types[5] = "eca_se"

symbol = rise_mobile_v3_symbol(channels=256, channels_operating_init=224, channel_expansion=32, act_type='relu',
                               channels_value_head=8, value_fc_size=256,
                               channels_policy_head=NB_POLICY_MAP_CHANNELS,
                               grad_scale_value=tc.val_loss_factor, grad_scale_policy=tc.policy_loss_factor, 
                               dropout_rate=tc.dropout_rate, select_policy_from_plane=True,
                               kernels=kernels, se_types=se_types, use_avg_features=False)
```

## Performance

### Old representation
```python
print(val_metric_values_best)
{'value_loss': 0.5473433423500794, 'policy_loss': 1.9628524352342656, 'value_acc_sign': 0.5859467445018944, 'policy_acc': 0.41995943509615385, 'loss': 1.9486973443054236}

metrics = metrics_gluon
evaluate_metrics(metrics, test_data, net, nb_batches=None, sparse_policy_label=True, ctx=ctx,
                 apply_select_policy_from_plane=tc.select_policy_from_plane)

{'loss': 1.959696855299039,
 'value_loss': 0.578331029131299,
 'policy_loss': 1.9736500454623496,
 'value_acc_sign': 0.5984901690112123,
 'policy_acc': 0.4142091782785441}
```


### New representation
```python
print(val_metric_values_best)
{'value_loss': 0.5150652776161829, 'policy_loss': 1.9784341469789162, 'value_acc_sign': 0.6325511886919106, 'policy_acc': 0.41377453926282054, 'loss': 1.9638004582852888}
```

```python
metrics = metrics_gluon
evaluate_metrics(metrics, test_data, net, nb_batches=None, sparse_policy_label=True, ctx=ctx,
                 apply_select_policy_from_plane=tc.select_policy_from_plane)

{'loss': 1.9717789994696473,
 'value_loss': 0.5351700612476894,
 'policy_loss': 1.9862902008658287,
 'value_acc_sign': 0.6482085350169101,
 'policy_acc': 0.40913363253988766}
```

