### PR TITLE
Generate random initialized neural network

### DIFF
--- a/DeepCrazyhouse/src/domain/neural_net/architectures/mxnet_alpha_zero.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/mxnet_alpha_zero.py
@@ -175,3 +175,15 @@ def alpha_zero_resnet(n_labels=4992, channels=256,  channels_value_head=1, chann
     """
     net = SymbolBlock(outputs=sym, inputs=mx.sym.var('data'))
     return net
+
+
+def get_alpha_zero_symbol(channels_policy_head, n_labels, select_policy_from_plane, val_loss_factor, policy_loss_factor):
+    """
+    Wrapper definition for AlphaZero's ResNet
+    :return: symbol
+    """
+    symbol = alpha_zero_symbol(num_filter=256, channels_value_head=4, channels_policy_head=channels_policy_head,
+                               workspace=1024, value_fc_size=256, num_res_blocks=19, bn_mom=0.9, act_type='relu',
+                               n_labels=n_labels, grad_scale_value=val_loss_factor, grad_scale_policy=policy_loss_factor,
+                               select_policy_from_plane=select_policy_from_plane)
+    return symbol

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/mxnet_alpha_zero.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/mxnet_alpha_zero.py
@@ -177,13 +177,14 @@ def alpha_zero_resnet(n_labels=4992, channels=256,  channels_value_head=1, chann
     return net
 
 
-def get_alpha_zero_symbol(channels_policy_head, n_labels, select_policy_from_plane, val_loss_factor, policy_loss_factor):
+def get_alpha_zero_symbol(args):
     """
     Wrapper definition for AlphaZero's ResNet
     :return: symbol
     """
-    symbol = alpha_zero_symbol(num_filter=256, channels_value_head=4, channels_policy_head=channels_policy_head,
+    symbol = alpha_zero_symbol(num_filter=256, channels_value_head=4, channels_policy_head=args.channels_policy_head,
                                workspace=1024, value_fc_size=256, num_res_blocks=19, bn_mom=0.9, act_type='relu',
-                               n_labels=n_labels, grad_scale_value=val_loss_factor, grad_scale_policy=policy_loss_factor,
-                               select_policy_from_plane=select_policy_from_plane)
+                               n_labels=args.n_labels, grad_scale_value=args.val_loss_factor,
+                               grad_scale_policy=args.policy_loss_factor,
+                               select_policy_from_plane=args.select_policy_from_plane)
     return symbol

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_mobile_v2.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_mobile_v2.py
@@ -224,6 +224,24 @@ def rise_mobile_v2_symbol(channels=256, channels_operating_init=128, channel_exp
     return sym
 
 
+def get_rise_v2_symbol(channels_policy_head, n_labels, select_policy_from_plane, val_loss_factor, policy_loss_factor):
+    """
+    Wrapper definition for RISEv2.0.
+    :return: symbol
+    """
+    bc_res_blocks = [3] * 13
+    symbol = rise_mobile_v2_symbol(channels=256, channels_operating_init=128, channel_expansion=64,
+                                   channels_value_head=8,
+                                   channels_policy_head=channels_policy_head, value_fc_size=256,
+                                   bc_res_blocks=bc_res_blocks, res_blocks=[], act_type='relu',
+                                   n_labels=n_labels, grad_scale_value=val_loss_factor,
+                                   grad_scale_policy=policy_loss_factor,
+                                   select_policy_from_plane=select_policy_from_plane,
+                                   use_se=True, dropout_rate=0,
+                                   use_extra_variant_input=False)
+    return symbol
+
+
 def preact_resnet_symbol(channels=256, channels_value_head=8,
                    channels_policy_head=81, value_fc_size=256, value_kernelsize=7, res_blocks=19, act_type='relu',
                    n_labels=4992, grad_scale_value=0.01, grad_scale_policy=0.99, select_policy_from_plane=True):

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_mobile_v2.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_mobile_v2.py
@@ -224,7 +224,7 @@ def rise_mobile_v2_symbol(channels=256, channels_operating_init=128, channel_exp
     return sym
 
 
-def get_rise_v2_symbol(channels_policy_head, n_labels, select_policy_from_plane, val_loss_factor, policy_loss_factor):
+def get_rise_v2_symbol(args):
     """
     Wrapper definition for RISEv2.0.
     :return: symbol
@@ -232,11 +232,11 @@ def get_rise_v2_symbol(channels_policy_head, n_labels, select_policy_from_plane,
     bc_res_blocks = [3] * 13
     symbol = rise_mobile_v2_symbol(channels=256, channels_operating_init=128, channel_expansion=64,
                                    channels_value_head=8,
-                                   channels_policy_head=channels_policy_head, value_fc_size=256,
+                                   channels_policy_head=args.channels_policy_head, value_fc_size=256,
                                    bc_res_blocks=bc_res_blocks, res_blocks=[], act_type='relu',
-                                   n_labels=n_labels, grad_scale_value=val_loss_factor,
-                                   grad_scale_policy=policy_loss_factor,
-                                   select_policy_from_plane=select_policy_from_plane,
+                                   n_labels=args.n_labels, grad_scale_value=args.val_loss_factor,
+                                   grad_scale_policy=args.policy_loss_factor,
+                                   select_policy_from_plane=args.select_policy_from_plane,
                                    use_se=True, dropout_rate=0,
                                    use_extra_variant_input=False)
     return symbol

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/rise_mobile_v3.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/rise_mobile_v3.py
@@ -166,7 +166,7 @@ def rise_mobile_v3_symbol(channels=256, channels_operating_init=224, channel_exp
     return sym
 
 
-def get_rise_v33_symbol(channels_policy_head, val_loss_factor, policy_loss_factor, select_policy_from_plane):
+def get_rise_v33_symbol(args):
     """
     Wrapper definition for RISEv3.3.
     :return: symbol
@@ -186,8 +186,8 @@ def get_rise_v33_symbol(channels_policy_head, val_loss_factor, policy_loss_facto
 
     symbol = rise_mobile_v3_symbol(channels=256, channels_operating_init=224, channel_expansion=32, act_type='relu',
                                    channels_value_head=8, value_fc_size=256,
-                                   channels_policy_head=channels_policy_head,
-                                   grad_scale_value=val_loss_factor, grad_scale_policy=policy_loss_factor,
-                                   dropout_rate=0, select_policy_from_plane=select_policy_from_plane,
-                                   kernels=kernels, se_types=se_types, use_avg_features=False)
+                                   channels_policy_head=args.channels_policy_head,
+                                   grad_scale_value=args.val_loss_factor, grad_scale_policy=args.policy_loss_factor,
+                                   dropout_rate=0, select_policy_from_plane=args.select_policy_from_plane,
+                                   kernels=kernels, se_types=se_types, use_avg_features=False, n_labels=args.n_labels)
     return symbol

--- a/DeepCrazyhouse/src/domain/neural_net/generate_random_nn.py
+++ b/DeepCrazyhouse/src/domain/neural_net/generate_random_nn.py
@@ -1,0 +1,82 @@
+"""
+@file: generate_random_nn.py
+Created on 27.05.21
+@project: crazyara
+@author: queensgambit
+
+Command-line tool to generate a random initialized neural network and export ONNX weights.
+"""
+import sys
+import argparse
+import mxnet as mx
+import logging
+from DeepCrazyhouse.src.domain.neural_net.architectures.mxnet_alpha_zero import get_alpha_zero_symbol
+from DeepCrazyhouse.src.domain.neural_net.architectures.rise_mobile_v3 import get_rise_v33_symbol
+from DeepCrazyhouse.src.domain.neural_net.architectures.rise_mobile_v2 import get_rise_v2_symbol
+
+
+def parse_args(cmd_args: list):
+    """
+    Parses command-line argument and returns them as a dictionary object
+    :param cmd_args: Command-line arguments (sys.argv[1:])
+    :return: Parsed arguments as dictionary object
+    """
+    parser = argparse.ArgumentParser(description='MXNet to ONN converter')
+
+    parser.add_argument("--model-type", type=str, default="risev2",
+                        help="model directory which contains the .param and .sym file (default: risev2")
+    parser.add_argument("--channels_policy_head", type=int, default=None,
+                        help=" (default: None)")
+    parser.add_argument("--n-labels", type=int, default=None,
+                        help=" (default: None)")
+    parser.add_argument("--select-policy-from-plane", default=False, action="store_true",
+                        help="If true, the ONNX model is validated after conversion (default: False)")
+    parser.add_argument("--val-loss-factor", type=float, default=0.01,
+                        help=" (default: 0.01)")
+    parser.add_argument("--policy-loss-factor", type=float, default=0.99,
+                        help=" (default: 0.99)")
+    args = parser.parse_args(cmd_args)
+
+    if args.input_shape is None:
+        raise ValueError('Given input shape must not be "None"')
+
+    # convert list to tuple
+    args.input_shape = tuple(args.input_shape)
+    return args
+
+
+def generate_random_nn(args):
+    if args.model_type == "alpha_zero":
+        symbol = get_alpha_zero_symbol(args.channels_policy_head, args.n_labels, args.select_policy_from_plane,
+                                       args.val_loss_factor, args.spolicy_loss_factor)
+    elif args.model_type == "risev2":
+        symbol = get_rise_v2_symbol(args.channels_policy_head, args.n_labels, args.select_policy_from_plane,
+                                       args.val_loss_factor, args.spolicy_loss_factor)
+    elif args.model_type == "risev3.3":
+        symbol = get_rise_v33_symbol(args.channels_policy_head, args.n_labels, args.select_policy_from_plane,
+                                       args.val_loss_factor, args.spolicy_loss_factor)
+    else:
+        raise NotImplementedError
+
+    model = mx.mod.Module(symbol=symbol, context=mx.cpu(), label_names=['value_label', 'policy_label'])
+    model.bind(for_training=True, data_shapes=[('data', (1, args.input_shape[0], args.input_shape[1], args.input_shape[2]))],
+               label_shapes=val_iter.provide_label)
+    model.init_params(mx.initializer.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24))
+
+    pass
+
+
+def main():
+    """
+    Main function which is executed on start-up
+
+    Exemplary call: e.g. TODO
+    :return:
+    """
+    args = parse_args(sys.argv[1:])
+    logging.basicConfig(level=logging.INFO)
+    generate_random_nn(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/DeepCrazyhouse/src/domain/neural_net/generate_random_nn.py
+++ b/DeepCrazyhouse/src/domain/neural_net/generate_random_nn.py
@@ -6,13 +6,22 @@ Created on 27.05.21
 
 Command-line tool to generate a random initialized neural network and export ONNX weights.
 """
-import sys
+import os
 import argparse
 import mxnet as mx
 import logging
+import numpy as np
+import sys
+sys.path.insert(0, '../../../../')
 from DeepCrazyhouse.src.domain.neural_net.architectures.mxnet_alpha_zero import get_alpha_zero_symbol
 from DeepCrazyhouse.src.domain.neural_net.architectures.rise_mobile_v3 import get_rise_v33_symbol
 from DeepCrazyhouse.src.domain.neural_net.architectures.rise_mobile_v2 import get_rise_v2_symbol
+from DeepCrazyhouse.src.domain.neural_net.onnx.convert_to_onnx import convert_mxnet_model_to_onnx
+from DeepCrazyhouse.src.domain.variants.constants import NB_LABELS, NB_POLICY_MAP_CHANNELS, NB_CHANNELS_TOTAL,\
+    BOARD_WIDTH, BOARD_HEIGHT
+from DeepCrazyhouse.src.runtime.color_logger import enable_color_logging
+
+enable_color_logging()
 
 
 def parse_args(cmd_args: list):
@@ -21,24 +30,42 @@ def parse_args(cmd_args: list):
     :param cmd_args: Command-line arguments (sys.argv[1:])
     :return: Parsed arguments as dictionary object
     """
-    parser = argparse.ArgumentParser(description='MXNet to ONN converter')
-
+    parser = argparse.ArgumentParser(description='Command-line tool to generate a random initialized neural network'
+                                                 ' and export MXNet and ONNX weights.')
     parser.add_argument("--model-type", type=str, default="risev2",
-                        help="model directory which contains the .param and .sym file (default: risev2")
-    parser.add_argument("--channels_policy_head", type=int, default=None,
+                        help="available model types [alphazero, risev2, risev33] (default: risev2)")
+    parser.add_argument("--channels-policy-head", type=int, default=None,
                         help=" (default: None)")
     parser.add_argument("--n-labels", type=int, default=None,
                         help=" (default: None)")
     parser.add_argument("--select-policy-from-plane", default=False, action="store_true",
-                        help="If true, the ONNX model is validated after conversion (default: False)")
+                        help="If true, the policy plane representation will be used (default: False)")
+    parser.add_argument("--input-shape", type=int, nargs="*", default=None,
+                        help="Input shape of the neural network. Arguments need to be passed as a list"
+                             'e.g. pass "--input-shape 34 8 8" for the default crazyhouse input (default: None)')
     parser.add_argument("--val-loss-factor", type=float, default=0.01,
-                        help=" (default: 0.01)")
+                        help="Value loss factor used during training. Only relevant if the MXNet symbol file will be"
+                             " directly used for training. (default: 0.01)")
     parser.add_argument("--policy-loss-factor", type=float, default=0.99,
-                        help=" (default: 0.99)")
+                        help="Policy loss factor used during training. Only relevant if the MXNet symbol will be"
+                             "directly used for training. (default: 0.99)")
+    parser.add_argument("--export-dir", type=str, default="./",
+                        help="Directory where the model files will be exported.")
     args = parser.parse_args(cmd_args)
 
     if args.input_shape is None:
-        raise ValueError('Given input shape must not be "None"')
+        args.input_shape = (NB_CHANNELS_TOTAL, BOARD_HEIGHT, BOARD_WIDTH)
+        logging.info(f"Given 'input_shape' is 'None'. It was set to {args.input_shape}.")
+    if not args.select_policy_from_plane and args.n_labels is None:
+        args.n_labels = NB_LABELS
+        logging.info(f"Given 'n_labels' is 'None'. It was set to {args.n_labels}.")
+    if args.select_policy_from_plane and args.channels_policy_head is None:
+        args.channels_policy_head = NB_POLICY_MAP_CHANNELS
+        logging.info(f"Given 'channels_policy_head' is 'None'. It was set to {args.channels_policy_head}.")
+    if not os.path.isdir(args.export_dir):
+        raise Exception("The given directory %s does not exist." % args.model_dir)
+    if args.export_dir[-1] != '/':
+        args.export_dir += '/'
 
     # convert list to tuple
     args.input_shape = tuple(args.input_shape)
@@ -46,31 +73,53 @@ def parse_args(cmd_args: list):
 
 
 def generate_random_nn(args):
+    """
+    Generates a new neural network model with random parameter initialization and exports it to ONNX.
+    """
     if args.model_type == "alpha_zero":
-        symbol = get_alpha_zero_symbol(args.channels_policy_head, args.n_labels, args.select_policy_from_plane,
-                                       args.val_loss_factor, args.spolicy_loss_factor)
+        symbol = get_alpha_zero_symbol(args)
     elif args.model_type == "risev2":
-        symbol = get_rise_v2_symbol(args.channels_policy_head, args.n_labels, args.select_policy_from_plane,
-                                       args.val_loss_factor, args.spolicy_loss_factor)
+        symbol = get_rise_v2_symbol(args)
     elif args.model_type == "risev3.3":
-        symbol = get_rise_v33_symbol(args.channels_policy_head, args.n_labels, args.select_policy_from_plane,
-                                       args.val_loss_factor, args.spolicy_loss_factor)
+        symbol = get_rise_v33_symbol(args)
     else:
         raise NotImplementedError
 
+    x_dummy = np.zeros(shape=(1, args.input_shape[0], args.input_shape[1], args.input_shape[2]))
+    y_value_dummy = np.zeros(shape=(1, 1))
+    if args.select_policy_from_plane:
+        y_policy_dummy = np.zeros(shape=(1, args.channels_policy_head + args.input_shape[1] * args.input_shape[2]))
+    else:
+        y_policy_dummy = np.zeros(shape=(1, args.n_labels))
+    data_iter = mx.io.NDArrayIter({'data': x_dummy}, {'value_label': y_value_dummy,
+                                                      'policy_label': y_policy_dummy.argmax(axis=1)}, 1)
+
     model = mx.mod.Module(symbol=symbol, context=mx.cpu(), label_names=['value_label', 'policy_label'])
-    model.bind(for_training=True, data_shapes=[('data', (1, args.input_shape[0], args.input_shape[1], args.input_shape[2]))],
-               label_shapes=val_iter.provide_label)
+    model.bind(for_training=True, data_shapes=[('data', x_dummy.shape)],
+               label_shapes=data_iter.provide_label)
     model.init_params(mx.initializer.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24))
 
-    pass
+    prefix = args.export_dir + args.model_type
+    sym_file = prefix + "-symbol.json"
+    params_file = prefix + "-" + "%04d.params" % 0
+
+    # the export function saves both the architecture and the weights
+    model.save_checkpoint(prefix, epoch=0)
+
+    # if convert_to_onnx:
+    convert_mxnet_model_to_onnx(sym_file, params_file, ["value_out_output", "policy_out_output"], args.input_shape,
+                                [1, 8, 16], False)
 
 
 def main():
     """
     Main function which is executed on start-up
 
-    Exemplary call: e.g. TODO
+    Exemplary calls:
+     e.g. call for CrazyAra model
+     python generate_random_nn.py --model-type risev2 --channels-policy-head 81 --input-shape 34 8 8 --select-policy-from-plane
+     e.g. call for MultiAra model
+     python generate_random_nn.py --model-type risev2 --channels-policy-head 84 --input-shape 63 8 8 --select-policy-from-plane
     :return:
     """
     args = parse_args(sys.argv[1:])


### PR DESCRIPTION
This PR adds a command-line tool to generate a random initialized neural network and export its MXNet and ONNX weights.
This functionality is useful for e.g. starting RL form zero knowledge.
