### PR TITLE
WDLP value head

### DIFF
--- a/DeepCrazyhouse/configs/train_config_template.py
+++ b/DeepCrazyhouse/configs/train_config_template.py
@@ -79,7 +79,10 @@ class TrainConfig:
     # how many epochs the network will be trained each time there is enough new data available
     nb_training_epochs: int = 1
 
-    policy_loss_factor: float = 1  # 0.99
+    policy_loss_factor: float = 0.5  # 0.99
+
+    # gradient scaling for the plys to end output
+    plys_to_end_loss_factor: float = 0.1
 
     # ratio for mixing the value return with the corresponding q-value
     # for a ratio of 0 no q-value information will be used
@@ -104,10 +107,19 @@ class TrainConfig:
     # Reinforcement Learning only works with gluon (== False) atm
     use_mxnet_style: bool = True
 
+    # adds a small mlp to infer the value loss from wdl and plys_to_end_output
+    use_mlp_wdl_ply: bool = False
+    # enables training with ply to end head
+    use_plys_to_end: bool = False
+    # enables training with a wdl head as intermediate target (mainly useful for environments with 3 outcomes)
+    use_wdl: bool = False
+
     # loads a previous checkpoint if the loss increased significantly
     use_spike_recovery: bool = True
     # weight the value loss a lot lower than the policy loss in order to prevent overfitting
     val_loss_factor: float = 0.5  # 0.01
+    # weight for the wdl loss
+    wdl_loss_factor: float = 0.4
 
     # weight decay
     wd: float = 1e-4

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util_symbol.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util_symbol.py
@@ -98,8 +98,8 @@ def ic_layer(data, name, droupout_rate):
 
 
 def value_head(data, channels_value_head=4, value_kernelsize=1, act_type='relu', value_fc_size=256,
-               grad_scale_value=0.01, use_se=False, use_mix_conv=False, orig_data=None, use_avg_features=False,
-               use_raw_features=False, use_bn=False):
+               grad_scale_value=0.01, grad_scale_wdl=None, grad_scale_ply=None, use_se=False, use_mix_conv=False, orig_data=None, use_avg_features=False,
+               use_raw_features=False, use_bn=False, use_wdl=False, use_plys_to_end=False, use_mlp_wdl_ply=False):
     """
     Value head of the network which outputs the value evaluation. A floating point number in the range [-1,+1].
     :param data: Input data
@@ -146,11 +146,38 @@ def value_head(data, channels_value_head=4, value_kernelsize=1, act_type='relu',
     value_out = mx.sym.FullyConnected(data=value_flatten, num_hidden=value_fc_size, name='value_fc0')
     if use_bn:
         value_out = mx.sym.BatchNorm(data=value_out, name='value_bn2')
-    value_out = get_act(data=value_out, act_type=act_type, name='value_act1')
-    value_out = mx.sym.FullyConnected(data=value_out, num_hidden=1, name='value_fc1')
-    value_out = get_act(data=value_out, act_type='tanh', name=main_config["value_output"])
-    value_out = mx.sym.LinearRegressionOutput(data=value_out, name='value', grad_scale=grad_scale_value)
-    return value_out
+
+    value_main_features = get_act(data=value_out, act_type=act_type, name='value_act1')
+
+    wdl_out = None
+    plys_to_end_out = None
+    wdl_softmax = None
+    if use_wdl:
+        wdl_out = mx.sym.FullyConnected(data=value_main_features, num_hidden=3, name=main_config["wdl_output"])
+        wdl_out = mx.sym.SoftmaxOutput(data=wdl_out, name='wdl', grad_scale=grad_scale_wdl)
+        wdl_softmax = mx.sym.SoftmaxActivation(data=wdl_out, name='wdl_softmax')
+    if use_plys_to_end:
+        plys_to_end_out = mx.sym.FullyConnected(data=value_main_features, num_hidden=1, name='value_plys_to_end_fc')
+        plys_to_end_out = get_act(data=plys_to_end_out, act_type='sigmoid', name=main_config["plys_to_end_output"])
+        plys_to_end_out = mx.sym.LinearRegressionOutput(data=plys_to_end_out, name='plys_to_end', grad_scale=grad_scale_ply)
+
+    if use_wdl and use_plys_to_end:
+        if use_mlp_wdl_ply:
+            value_out = mx.sym.Concat(wdl_softmax, plys_to_end_out, dim=1, name='value_concat_0')
+            value_out = mx.sym.FullyConnected(data=value_out, num_hidden=8, name='value_wdl_ply_fc')
+            value_out = get_act(data=value_out, act_type=act_type, name='value_wdl_ply_act')
+            value_out = mx.sym.FullyConnected(data=value_out, num_hidden=1, name='value_fc1')
+            value_out = get_act(data=value_out, act_type='tanh', name=main_config["value_output"])
+            value_out = mx.sym.LinearRegressionOutput(data=value_out, name='value', grad_scale=1)
+        else:  # hard-coded
+            (loss_out, _, win_out) = mx.sym.split(wdl_softmax, axis=1, num_outputs=3, name='win_loss_split')
+            value_out = mx.sym.broadcast_add(1/3 * loss_out, 1/3 * win_out, name=main_config["value_output"])
+            value_out = mx.sym.LinearRegressionOutput(data=value_out, name='value', grad_scale=0)
+    else:
+        value_out = mx.sym.FullyConnected(data=value_out, num_hidden=1, name='value_fc1')
+        value_out = get_act(data=value_out, act_type='tanh', name=main_config["value_output"])
+        value_out = mx.sym.LinearRegressionOutput(data=value_out, name='value', grad_scale=grad_scale_value)
+    return value_out, wdl_out, wdl_softmax, plys_to_end_out
 
 
 def policy_head(data, channels, act_type, channels_policy_head, select_policy_from_plane, n_labels,

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util_symbol.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/builder_util_symbol.py
@@ -171,7 +171,7 @@ def value_head(data, channels_value_head=4, value_kernelsize=1, act_type='relu',
             value_out = mx.sym.LinearRegressionOutput(data=value_out, name='value', grad_scale=1)
         else:  # hard-coded
             (loss_out, _, win_out) = mx.sym.split(wdl_softmax, axis=1, num_outputs=3, name='win_loss_split')
-            value_out = mx.sym.broadcast_add(1/3 * loss_out, 1/3 * win_out, name=main_config["value_output"])
+            value_out = mx.sym.broadcast_add(-loss_out, win_out, name=main_config["value_output"])
             value_out = mx.sym.LinearRegressionOutput(data=value_out, name='value', grad_scale=0)
     else:
         value_out = mx.sym.FullyConnected(data=value_out, num_hidden=1, name='value_fc1')

--- a/DeepCrazyhouse/src/training/train_cnn.ipynb
+++ b/DeepCrazyhouse/src/training/train_cnn.ipynb
@@ -14,7 +14,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
@@ -24,7 +26,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "%reload_ext autoreload"
@@ -33,7 +37,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
@@ -66,12 +72,11 @@
     "from DeepCrazyhouse.configs.main_config import main_config\n",
     "from DeepCrazyhouse.configs.train_config import TrainConfig, TrainObjects\n",
     "from DeepCrazyhouse.src.training.trainer_agent import TrainerAgent, evaluate_metrics, acc_sign\n",
-    "from DeepCrazyhouse.src.training.trainer_agent_mxnet import TrainerAgentMXNET, get_context, prepare_policy\n",
+    "from DeepCrazyhouse.src.training.trainer_agent_mxnet import TrainerAgentMXNET, get_context, prepare_policy, value_to_wdl_label, prepare_plys_label\n",
     "from DeepCrazyhouse.src.training.lr_schedules.lr_schedules import *\n",
     "from DeepCrazyhouse.src.domain.variants.plane_policy_representation import FLAT_PLANE_IDX\n",
     "from DeepCrazyhouse.src.domain.variants.constants import NB_POLICY_MAP_CHANNELS, NB_LABELS\n",
     "from DeepCrazyhouse.src.domain.neural_net.onnx.convert_to_onnx import convert_mxnet_model_to_onnx\n",
-    "\n",
     "enable_color_logging()\n",
     "%matplotlib inline"
    ]
@@ -86,7 +91,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "tc = TrainConfig()\n",
@@ -96,7 +103,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# set the context on CPU, switch to GPU if there is one available (strongly recommended for training)\n",
@@ -147,7 +156,9 @@
     "tc.dropout_rate = 0 #0.15\n",
     "# weight the value loss a lot lower than the policy loss in order to prevent overfitting\n",
     "tc.val_loss_factor = 0.01\n",
-    "tc.policy_loss_factor = 0.99\n",
+    "tc.policy_loss_factor = 0.988\n",
+    "tc.plys_to_end_loss_factor = 0.002\n",
+    "tc.wdl_loss_factor = 0.01\n",
     "tc.discount = 1.0\n",
     "\n",
     "tc.normalize = True # define whether to normalize input data to [0,1]\n",
@@ -167,13 +178,24 @@
     "tc.sparse_policy_label = True\n",
     "# define if the policy data is also defined in \"select_policy_from_plane\" representation\n",
     "tc.is_policy_from_plane_data = False\n",
-    "tc.name_initials = \"JC\""
+    "tc.name_initials = \"JC\"\n",
+    "\n",
+    "# enables training with a wdl head as intermediate target (mainly useful for environments with 3 outcomes)\n",
+    "tc.use_wdl = True\n",
+    "\n",
+    "\n",
+    "# enables training with ply to end head\n",
+    "tc.use_plys_to_end = True\n",
+    "# adds a small mlp to infer the value loss from wdl and plys_to_end_output\n",
+    "tc.use_mlp_wdl_ply = True"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "mode = main_config[\"mode\"]\n",
@@ -188,7 +210,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "mx.__version__"
@@ -204,7 +228,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "if not os.path.exists(tc.export_dir + \"logs\"):\n",
@@ -223,7 +249,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print(main_config)"
@@ -232,7 +260,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print(tc)"
@@ -241,7 +271,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print(to)"
@@ -264,17 +296,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "s_idcs_val, x_val, yv_val, yp_val, plys_to_end, pgn_datasets_val = load_pgn_dataset(dataset_type='val', part_id=0,\n",
     "                                                                           verbose=True, normalize=tc.normalize)\n",
     "if tc.discount != 1:\n",
     "    yv_val *= tc.discount**plys_to_end\n",
-    "\n",
+    "    \n",
     "if tc.use_mxnet_style:\n",
     "    if tc.select_policy_from_plane:\n",
-    "        val_iter = mx.io.NDArrayIter({'data': x_val}, {'value_label': yv_val, 'policy_label': np.array(FLAT_PLANE_IDX)[yp_val.argmax(axis=1)]}, tc.batch_size)\n",
+    "        if tc.use_wdl and tc.use_wdl:\n",
+    "            val_iter = mx.io.NDArrayIter({'data': x_val},\n",
+    "                                         {'value_label': yv_val,\n",
+    "                                          'policy_label': np.array(FLAT_PLANE_IDX)[yp_val.argmax(axis=1)],\n",
+    "                                          'wdl_label': value_to_wdl_label(yv_val),\n",
+    "                                          'plys_to_end_label': prepare_plys_label(plys_to_end)},\n",
+    "                                          tc.batch_size)\n",
+    "        else:\n",
+    "            val_iter = mx.io.NDArrayIter({'data': x_val},\n",
+    "                                         {'value_label': yv_val,\n",
+    "                                          'policy_label': np.array(FLAT_PLANE_IDX)[yp_val.argmax(axis=1)]},\n",
+    "                                         tc.batch_size)\n",
     "    else:\n",
     "        val_iter = mx.io.NDArrayIter({'data': x_val}, {'value_label': yv_val, 'policy_label': yp_val.argmax(axis=1)}, tc.batch_size)\n",
     "else:\n",
@@ -285,7 +330,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "val_iter.provide_label"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "tc.nb_parts = len(glob.glob(main_config['planes_train_dir'] + '**/*'))\n",
@@ -295,7 +353,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "nb_it_per_epoch = (len(x_val) * tc.nb_parts) // tc.batch_size # calculate how many iterations per epoch exist\n",
@@ -315,7 +375,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -337,7 +397,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "to.momentum_schedule = MomentumSchedule(to.lr_schedule, tc.min_lr, tc.max_lr, tc.min_momentum, tc.max_momentum)\n",
@@ -354,7 +416,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "input_shape = x_val[0].shape\n",
@@ -364,7 +428,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "try:\n",
@@ -383,7 +449,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "symbol = None"
@@ -392,7 +460,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "#net = AlphaZeroResnet(n_labels=2272, channels=256, channels_value_head=8, channels_policy_head=81, num_res_blocks=19, value_fc_size=256, bn_mom=0.9, act_type='relu', select_policy_from_plane=select_policy_from_plane)"
@@ -401,7 +471,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "#net = alpha_zero_resnet(n_labels=2272, channels=256, channels_value_head=1, channels_policy_head=81, num_res_blocks=19, value_fc_size=256, bn_mom=0.9, act_type='relu')"
@@ -410,7 +482,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "#symbol = alpha_zero_symbol(num_filter=256, channels_value_head=4, channels_policy_head=81, workspace=1024, value_fc_size=256, num_res_blocks=19, bn_mom=0.9, act_type='relu',\n",
@@ -432,8 +506,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "kernels = [3] * 15\n",
     "kernels[7] = 5\n",
@@ -446,21 +522,44 @@
     "se_types[8] = \"eca_se\"\n",
     "se_types[12] = \"eca_se\"\n",
     "se_types[13] = \"eca_se\"\n",
-    "se_types[14] = \"eca_se\"\n",
+    "se_types[14] = \"eca_se\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "kernels = [3] * 7\n",
     "\n",
-    "symbol = rise_mobile_v3_symbol(channels=256, channels_operating_init=224, channel_expansion=32, act_type='relu',\n",
-    "                               channels_value_head=8, value_fc_size=256,\n",
-    "                               channels_policy_head=NB_POLICY_MAP_CHANNELS,\n",
-    "                               grad_scale_value=tc.val_loss_factor, grad_scale_policy=tc.policy_loss_factor, \n",
-    "                               dropout_rate=tc.dropout_rate, select_policy_from_plane=True,\n",
-    "                               kernels=kernels, se_types=se_types, use_avg_features=False)"
+    "se_types = [None] * len(kernels)\n",
+    "se_types[5] = \"eca_se\"\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
+   "source": [
+    "symbol = rise_mobile_v3_symbol(channels=256, channels_operating_init=224, channel_expansion=32, act_type='relu',\n",
+    "                               channels_value_head=8, value_fc_size=256,\n",
+    "                               channels_policy_head=NB_POLICY_MAP_CHANNELS,\n",
+    "                               grad_scale_value=tc.val_loss_factor,\n",
+    "                               grad_scale_policy=tc.policy_loss_factor,\n",
+    "                               grad_scale_wdl=tc.wdl_loss_factor,\n",
+    "                               grad_scale_ply=tc.plys_to_end_loss_factor,\n",
+    "                               dropout_rate=tc.dropout_rate, select_policy_from_plane=True,\n",
+    "                               kernels=kernels, se_types=se_types, use_avg_features=False,\n",
+    "                               use_wdl=tc.use_wdl, use_plys_to_end=tc.use_plys_to_end,\n",
+    "                               use_mlp_wdl_ply=tc.use_mlp_wdl_ply\n",
+    "                               )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "kernels = [3,3,3,3,3,3,5,5]\n",
     "\n",
@@ -493,7 +592,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "if not tc.use_mxnet_style and symbol is not None:\n",
@@ -514,7 +615,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "if not tc.use_mxnet_style:\n",
@@ -547,7 +650,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -575,13 +678,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
     "# create a trainable module on compute context\n",
+    "if tc.use_wdl and tc.use_wdl:\n",
+    "    label_names=['value_label', 'policy_label', 'wdl_label', 'plys_to_end_label']\n",
+    "else:\n",
+    "    label_names=['value_label', 'policy_label']\n",
     "if tc.use_mxnet_style:\n",
-    "    model = mx.mod.Module(symbol=symbol, context=ctx, label_names=['value_label', 'policy_label'])\n",
+    "    model = mx.mod.Module(symbol=symbol, context=ctx, label_names=label_names)\n",
     "    model.bind(for_training=True, data_shapes=[('data', (tc.batch_size, input_shape[0], input_shape[1], input_shape[2]))],\n",
     "             label_shapes=val_iter.provide_label)\n",
     "    model.init_params(mx.initializer.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24))\n",
@@ -611,7 +718,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "metrics_mxnet = [\n",
@@ -632,6 +741,16 @@
     "'policy_acc': metric.Accuracy(axis=1, name='policy_acc', output_names=['policy_output'],\n",
     "                                       label_names=['policy_label'])\n",
     "}\n",
+    "\n",
+    "if tc.use_mxnet_style and tc.use_wdl:\n",
+    "    metrics_mxnet.append(metric.CrossEntropy(name='wdl_loss',\n",
+    "                                             output_names=['wdl_output'], label_names=['wdl_label']))\n",
+    "    metrics_mxnet.append(metric.Accuracy(axis=1, name='wdl_acc', output_names=['wdl_output'],\n",
+    "                                         label_names=['wdl_label']))\n",
+    "if tc.use_mxnet_style and tc.use_plys_to_end:\n",
+    "    metrics_mxnet.append(metric.MSE(name='plys_to_end_loss', output_names=['plys_to_end_output'],\n",
+    "                                    label_names=['plys_to_end_label']))\n",
+    "    \n",
     "if tc.use_mxnet_style:\n",
     "    to.metrics = metrics_mxnet\n",
     "else:\n",
@@ -648,7 +767,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "if tc.use_mxnet_style:\n",
@@ -667,7 +788,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "if tc.use_mxnet_style:\n",
@@ -703,7 +826,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "prefix = tc.export_dir + \"weights/model-%.5f-%.3f\" % (policy_loss_final, val_p_acc_final)\n",
@@ -727,7 +852,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print(val_metric_values_best)"
@@ -743,7 +870,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# delete the current net object form memory\n",
@@ -755,7 +884,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "val_loss_best = val_metric_values_best[\"loss\"]\n",
@@ -771,7 +902,13 @@
     "inputs = mx.sym.var('data', dtype='float32')\n",
     "value_out = symbol.get_internals()[main_config['value_output']+'_output']\n",
     "policy_out = symbol.get_internals()[main_config['policy_output']+'_output']\n",
-    "sym = mx.symbol.Group([value_out, policy_out])\n",
+    "if tc.use_wdl and tc.use_plys_to_end:\n",
+    "    auxiliary_out = symbol.get_internals()[main_config['auxiliary_output']+'_output']\n",
+    "    wdl_out = symbol.get_internals()[main_config['wdl_output']+'_output']\n",
+    "    ply_to_end_out = symbol.get_internals()[main_config['plys_to_end_output']+'_output']\n",
+    "    sym = mx.symbol.Group([value_out, policy_out, auxiliary_out, wdl_out, ply_to_end_out])\n",
+    "else:\n",
+    "    sym = mx.symbol.Group([value_out, policy_out])\n",
     "net = mx.gluon.SymbolBlock(sym, inputs)\n",
     "net.collect_params().load(model_params_path, ctx)"
    ]
@@ -779,7 +916,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print('best val_loss: %.5f with v_policy_acc: %.5f at k_steps_best %d' % (val_loss_best, val_p_acc_best, k_steps_best))"
@@ -795,7 +934,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "if not os.path.exists(tc.export_dir + \"best-model\"):\n",
@@ -808,15 +949,24 @@
     "shutil.copy(model_arch_path, best_model_arch_path)\n",
     "shutil.copy(model_params_path, best_model_params_path)\n",
     "\n",
+    "if tc.use_wdl and tc.use_plys_to_end:\n",
+    "    outputs = [main_config['value_output']+'_output', main_config['policy_output']+'_output',\n",
+    "               main_config['auxiliary_output']+'_output',\n",
+    "               main_config['wdl_output']+'_output', main_config['plys_to_end_output']+'_output']\n",
+    "else:\n",
+    "    outputs = [main_config['value_output']+'_output', main_config['policy_output']+'_output',]\n",
+    "\n",
     "convert_mxnet_model_to_onnx(best_model_arch_path, best_model_params_path, \n",
-    "                            [\"value_out_output\", \"policy_out_output\"], \n",
+    "                            outputs, \n",
     "                            tuple(input_shape), tuple([1, 8, 16]), True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print(\"Saved json, weight & onnx files of the best model to %s\" % (tc.export_dir + \"best-model\"))"
@@ -832,7 +982,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "idx = 0"
@@ -841,7 +993,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "board = planes_to_board(x_val[idx], normalized_input=tc.normalize, mode=mode)\n",
@@ -855,7 +1009,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "def predict_single(net, x, select_policy_from_plane=False):\n",
@@ -874,7 +1030,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "pred = predict_single(net, x_val[0], tc.select_policy_from_plane)\n",
@@ -884,7 +1042,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "pred = predict_single(net, x_val[0], tc.select_policy_from_plane)"
@@ -893,7 +1053,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "policy_to_best_move(board, yp_val[idx])"
@@ -902,7 +1064,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "opts = 5\n",
@@ -913,7 +1077,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "plt.barh(range(opts)[::-1], probs[:opts])\n",
@@ -925,7 +1091,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "board = planes_to_board(x_val[0], normalized_input=True, mode=mode)\n",
@@ -941,7 +1109,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "pred = predict_single(net, x_scholar_atck, tc.select_policy_from_plane)\n",
@@ -956,7 +1126,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "board.push(selected_moves[0])\n",
@@ -973,7 +1145,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "s_idcs_test, x_test, yv_test, yp_test, _, pgn_datasets_test = load_pgn_dataset(dataset_type='test', part_id=0,\n",
@@ -988,7 +1162,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "metrics = metrics_gluon\n",
@@ -1006,7 +1182,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "s_idcs_mate, x_mate, yv_mate, yp_mate, _, pgn_dataset_mate = load_pgn_dataset(dataset_type='mate_in_one', part_id=0,\n",
@@ -1019,7 +1197,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "mate_dataset = mx.gluon.data.dataset.ArrayDataset(nd.array(x_mate), nd.array(yv_mate), nd.array(yp_mate_new.argmax(axis=1)))\n",
@@ -1036,7 +1216,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "metrics = metrics_gluon\n",
@@ -1054,7 +1236,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "from IPython.core.interactiveshell import InteractiveShell\n",
@@ -1071,7 +1255,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "def eval_pos(net, x_mate, yp_mate, verbose=False, select_policy_from_plane=False):\n",
@@ -1124,7 +1310,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "len(x_mate)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "nb_pos = len(x_mate)\n",
@@ -1144,7 +1343,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "np.array(mate_mv_cnts).mean()"
@@ -1153,7 +1354,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "np.array(legal_mv_cnts).mean()"
@@ -1169,7 +1372,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "np.array(mate_mv_cnts).mean() / np.array(legal_mv_cnts).mean()"
@@ -1185,7 +1390,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print('mate_in_one_acc:', sum(mates_found) / nb_pos)"
@@ -1194,7 +1401,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "sum(mates_5_top_found) / nb_pos"
@@ -1203,7 +1412,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "pgn_dataset_mate.tree()"
@@ -1212,7 +1423,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "metadata = np.array(pgn_dataset_mate['metadata'])\n",
@@ -1223,7 +1436,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "site_mate = metadata[1:, 1]"
@@ -1232,7 +1447,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "def clean_string(np_string):\n",
@@ -1246,7 +1463,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "import chess.svg\n",
@@ -1264,7 +1483,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -1287,7 +1506,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -1308,7 +1527,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": []
   }

--- a/DeepCrazyhouse/src/training/train_cnn.ipynb
+++ b/DeepCrazyhouse/src/training/train_cnn.ipynb
@@ -789,7 +789,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [
@@ -864,6 +864,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Copy best model to best-model directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "val_loss_best = val_metric_values_best[\"loss\"]\n",
+    "val_p_acc_best = val_metric_values_best[\"policy_acc\"]\n",
+    "\n",
+    "model_name = \"model-%.5f-%.3f\" % (val_loss_best, val_p_acc_best)\n",
+    "model_prefix = tc.export_dir + \"weights/\" + model_name\n",
+    "model_arch_path = '%s-symbol.json' % model_prefix\n",
+    "model_params_path = '%s-%04d.params' % (model_prefix, k_steps_best)\n",
+    "\n",
+    "if not os.path.exists(tc.export_dir + \"best-model\"):\n",
+    "    os.mkdir(tc.export_dir + \"best-model\")\n",
+    "    \n",
+    "best_model_prefix = tc.export_dir + \"best-model/\" + model_name\n",
+    "best_model_arch_path = '%s-symbol.json' % best_model_prefix\n",
+    "best_model_params_path = '%s-%04d.params' % (best_model_prefix, k_steps_best)\n",
+    "\n",
+    "shutil.copy(model_arch_path, best_model_arch_path)\n",
+    "shutil.copy(model_params_path, best_model_params_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Load the best model once again"
    ]
   },
@@ -889,13 +921,6 @@
    },
    "outputs": [],
    "source": [
-    "val_loss_best = val_metric_values_best[\"loss\"]\n",
-    "val_p_acc_best = val_metric_values_best[\"policy_acc\"]\n",
-    "\n",
-    "model_name = \"model-%.5f-%.3f\" % (val_loss_best, val_p_acc_best)\n",
-    "model_prefix = tc.export_dir + \"weights/\" + model_name\n",
-    "model_arch_path = '%s-symbol.json' % model_prefix\n",
-    "model_params_path = '%s-%04d.params' % (model_prefix, k_steps_best)\n",
     "print('load current best model:', model_params_path)\n",
     "\n",
     "symbol = mx.sym.load(model_arch_path)\n",
@@ -928,7 +953,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Copy best model & convert to onnx"
+    "## Convert to onnx"
    ]
   },
   {
@@ -939,16 +964,6 @@
    },
    "outputs": [],
    "source": [
-    "if not os.path.exists(tc.export_dir + \"best-model\"):\n",
-    "    os.mkdir(tc.export_dir + \"best-model\")\n",
-    "    \n",
-    "best_model_prefix = tc.export_dir + \"best-model/\" + model_name\n",
-    "best_model_arch_path = '%s-symbol.json' % best_model_prefix\n",
-    "best_model_params_path = '%s-%04d.params' % (best_model_prefix, k_steps_best)\n",
-    "\n",
-    "shutil.copy(model_arch_path, best_model_arch_path)\n",
-    "shutil.copy(model_params_path, best_model_params_path)\n",
-    "\n",
     "if tc.use_wdl and tc.use_plys_to_end:\n",
     "    outputs = [main_config['value_output']+'_output', main_config['policy_output']+'_output',\n",
     "               main_config['auxiliary_output']+'_output',\n",

--- a/engine/src/environments/chess_related/boardstate.h
+++ b/engine/src/environments/chess_related/boardstate.h
@@ -223,6 +223,7 @@ public:
     static float MAX_NB_NO_PROGRESS() {
         return 50;
     }
+#endif
     // normalize the relative material by 8
     static float NORMALIZE_PIECE_NUMBER() {
         return 8;
@@ -235,7 +236,6 @@ public:
     static float NORMALIZE_MOBILITY() {
         return 64;
     }
-#endif
     static uint NB_CHANNELS_POLICY_MAP() {
 #ifdef MODE_CRAZYHOUSE
         return 81;

--- a/engine/src/environments/chess_related/inputrepresentation.cpp
+++ b/engine/src/environments/chess_related/inputrepresentation.cpp
@@ -382,6 +382,7 @@ inline void set_opposite_bishops(PlaneData& p) {
     ++p.currentChannel;
 }
 
+#ifdef MODE_CHESS
 void board_to_planes_v_2_7(const Board *pos, bool normalize, float *inputPlanes, const vector<Action>& legalMoves)
 {
     // Fill in the piece positions
@@ -404,6 +405,7 @@ void board_to_planes_v_2_7(const Board *pos, bool normalize, float *inputPlanes,
     set_mobility(planeData, legalMoves);
     assert(planeData.currentChannel == StateConstants::NB_CHANNELS_TOTAL());
 }
+#endif
 
 void board_to_planes(const Board *pos, size_t boardRepetition, bool normalize, float *inputPlanes, const vector<Action>& legalMoves)
 {


### PR DESCRIPTION
This PR adds  Win-Draw-Loss-Plys_to_End (WDLP) Head as well as a seperate WDL and plys to end head.

## Hyperparamters

```python
tc.val_loss_factor = 0.01
tc.policy_loss_factor = 0.988
tc.plys_to_end_loss_factor = 0.002
tc.wdl_loss_factor = 0.01
```

## Model Info
```python
kernels = [3] * 7

se_types = [None] * len(kernels)
se_types[5] = "eca_se"

symbol = rise_mobile_v3_symbol(channels=256, channels_operating_init=224, channel_expansion=32, act_type='relu',
                               channels_value_head=8, value_fc_size=256,
                               channels_policy_head=NB_POLICY_MAP_CHANNELS,
                               grad_scale_value=tc.val_loss_factor,
                               grad_scale_policy=tc.policy_loss_factor,
                               grad_scale_wdl=tc.wdl_loss_factor,
                               grad_scale_ply=tc.plys_to_end_loss_factor,
                               dropout_rate=tc.dropout_rate, select_policy_from_plane=True,
                               kernels=kernels, se_types=se_types, use_avg_features=False,
                               use_wdl=tc.use_wdl, use_plys_to_end=tc.use_plys_to_end,
                               )

```


## Performance


### Value-Policy Head as proposed by AlphaZero authors
```python
print(val_metric_values_best)
{'value_loss': 0.5191286853872813, 'policy_loss': 1.9544962583444057, 'value_acc_sign': 0.6256210535194651, 'policy_acc': 0.4121719751602564, 'loss': 1.9401425826148344}
```

```python
metrics = metrics_gluon
evaluate_metrics(metrics, test_data, net, nb_batches=None, sparse_policy_label=True, ctx=ctx,
                 apply_select_policy_from_plane=tc.select_policy_from_plane)

{'loss': 1.948354888682973,
 'value_loss': 0.5401958049762816,
 'policy_loss': 1.9625787178113232,
 'value_acc_sign': 0.6418024494760046,
 'policy_acc': 0.4118828864816599}
```

### Seperate WDL and Moves Left Head as proposed by [Henrik Forstén](https://github.com/Ttl)

* https://github.com/LeelaChessZero/lc0/pull/961
* https://github.com/LeelaChessZero/lc0/pull/635

```python
print(val_metric_values_best)

{'value_loss': 0.5345622066121835, 'policy_loss': 1.9655941877609644, 'value_acc_sign': 0.6294331479152006, 'policy_acc': 0.41353665865384615, 'wdl_loss': 1.0160043002703252, 'wdl_acc': 0.4817207532051282, 'plys_to_end_loss': 0.07706669999811894, 'loss': 1.9512838679494766}
```

The network uses a hard-coded formula 
```python
value_out = -loss_out + win_out
```
to map the WDL output to a single value in [-1,+1].

![wdl_hardcoded_fixed](https://user-images.githubusercontent.com/15967624/120070024-38260380-c089-11eb-863d-0ca7bd60531e.png)



### WDLP Value Head as proposed by [Johannes Czech](https://github.com/QueensGambit)


The Win-Draw-Loss-Plys_to_End (WDLP) Head predicts three intermediate targets.
The network uses a small MLP with given WDL and plys_to_end information to predict the value.

![wdl_ply_value_mlp](https://user-images.githubusercontent.com/15967624/120069759-cd27fd00-c087-11eb-817a-af7e66d7e431.png)


#### Benefits

* Resulted in a lower value and policy loss in an initial evaluation.
* The search can directly make use of the `plys_to_end` information for value estimation
* `plys_to_end` is used before arriving in either lost or winning positions.
* One can still build its own hand-crafted value estimate if one wishes to do so as WDL and plys to end is available in the auxiliary outputs.

```python
print(val_metric_values_best)

{'value_loss': 0.513670441813958, 'policy_loss': 1.963799155675448, 'value_acc_sign': 0.6301636476655295, 'policy_acc': 0.4133112980769231, 'wdl_loss': 1.01574011414479, 'wdl_acc': 0.4786783854166667, 'plys_to_end_loss': 0.07809940844965287, 'loss': 1.9492978685368332}
```



