### PR TITLE
Shared pointer atomic operation

### DIFF
--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -130,9 +130,7 @@ void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vect
     }
     pv.push_back(rootNode->get_action(childIdx));
 
-    rootNode->lock();
     Node* nextNode = rootNode->get_child_node(childIdx);
-    rootNode->unlock();
     // make sure the nextNode has been expanded (e.g. when inference of the NN is too slow on the given hardware to evaluate the next node in time)
     if (nextNode != nullptr) {
         nextNode->get_principal_variation(pv, searchSettings->qValueWeight, searchSettings->qVetoDelta);

--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -681,28 +681,31 @@ Node* Node::add_new_node_to_tree(MapWithMutex* mapWithMutex, StateObj* newState,
         mapWithMutex->mtx.lock();
         HashMap::const_iterator it = mapWithMutex->hashTable.find(newState->hash_key());
         if (it != mapWithMutex->hashTable.end()) {
-            d->childNodes[childIdx] = it->second.lock();
-        }
-        Node* tranpositionNode = get_child_node(childIdx);
-        if (tranpositionNode != nullptr) {
-            if(is_transposition_verified(tranpositionNode, newState)) {
-                mapWithMutex->mtx.unlock();
-                tranpositionNode->lock();
-                tranpositionNode->add_transposition_parent_node();
-                tranpositionNode->unlock();
-#ifndef MCTS_SINGLE_PLAYER
-                if (tranpositionNode->is_playout_node() && tranpositionNode->get_node_type() == LOSS) {
-                    set_checkmate_idx(childIdx);
+            shared_ptr<Node> transpositionNode = it->second.lock();
+            Node* tranpositionNode = get_child_node(childIdx);
+            if (tranpositionNode != nullptr) {
+                if(is_transposition_verified(tranpositionNode, newState)) {
+                    d->childNodes[childIdx] = atomic_load(&transpositionNode);
+                    mapWithMutex->mtx.unlock();
+                    tranpositionNode->lock();
+                    tranpositionNode->add_transposition_parent_node();
+                    tranpositionNode->unlock();
+    #ifndef MCTS_SINGLE_PLAYER
+                    if (tranpositionNode->is_playout_node() && tranpositionNode->get_node_type() == LOSS) {
+                        set_checkmate_idx(childIdx);
+                    }
+    #endif
+                    transposition = true;
+                    return tranpositionNode;
                 }
-#endif
-                transposition = true;
-                return tranpositionNode;
             }
         }
         mapWithMutex->mtx.unlock();
     }
+
     // connect the Node to the parent
-    d->childNodes[childIdx] = make_shared<Node>(newState, searchSettings);
+    shared_ptr<Node> newNode = make_shared<Node>(newState, searchSettings);
+    atomic_store(&d->childNodes[childIdx], newNode);
     if (searchSettings->useMCGS) {
         mapWithMutex->mtx.lock();
         mapWithMutex->hashTable.insert({d->childNodes[childIdx]->hash_key(), d->childNodes[childIdx]});


### PR DESCRIPTION
This PR adds shared pointer operations when accessing other shared pointers form the hash table and adding new nodes to the tree as shared pointers are not thread safe.

Stable for 572 games. However, the lower performance with TB should be addressed again.

```python
Score of ClassicAra 0.9.4-Dev -6-Men-TB - 2 Threads - Master vs ClassicAra 0.9.4-Dev - 2 Threads - Master:
 142 - 177 - 253 [0.469]
Elo difference: -21.3 +/- 21.3, LOS: 2.5 %, DrawRatio: 44.2 %

572 of 1000 games finished.
```

