### PR TITLE
Update Timemanagement Constants

### DIFF
--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -72,9 +72,9 @@ const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al."
 #else
 #define VALUE_TO_CENTI_PARAM 1.2f
 #endif
-#define TIME_EXPECT_GAME_LENGTH 60
-#define TIME_THRESH_MOVE_PROP_SYSTEM 50
-#define TIME_PROP_MOVE_FACTOR 0.05f
+#define TIME_EXPECT_GAME_LENGTH 38
+#define TIME_THRESH_MOVE_PROP_SYSTEM 35
+#define TIME_PROP_MOVE_FACTOR 0.07f
 #define TIME_INCREMENT_FACTOR 0.7f
 #define TIME_BUFFER_FACTOR 30.0f
 

--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -53,7 +53,7 @@ const string engineName = "MultiAra";
 const string engineName = "ClassicAra";
 #endif
 
-const string engineVersion = "0.9.3";
+const string engineVersion = "0.9.4-Dev";
 const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al.";
 
 #define LOSS_VALUE -1
@@ -72,6 +72,11 @@ const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al."
 #else
 #define VALUE_TO_CENTI_PARAM 1.2f
 #endif
+#define TIME_EXPECT_GAME_LENGTH 60
+#define TIME_THRESH_MOVE_PROP_SYSTEM 50
+#define TIME_PROP_MOVE_FACTOR 0.05f
+#define TIME_INCREMENT_FACTOR 0.7f
+#define TIME_BUFFER_FACTOR 30.0f
 
 #ifndef MODE_POMMERMAN
 #define TERMINAL_NODE_CACHE 8192

--- a/engine/src/manager/timemanager.h
+++ b/engine/src/manager/timemanager.h
@@ -31,6 +31,7 @@
 
 #include "../agents/config/searchlimits.h"
 #include "state.h"
+#include "constants.h"
 
 class TimeManager
 {
@@ -69,7 +70,8 @@ public:
      * @param moveFactor Portion of the current move time which will be used in the proportional movetime regime
      * @param timeBufferFactor Factor which is applied on the moveOverhead to calculate a time buffer for avoiding losing on time
      */
-    TimeManager(float randomMoveFactor=0, int expectedGameLength=40, int threshMove=30, float moveFactor=0.05f, float incrementFactor=0.7f, int timeBufferFactor=30.0f);
+    TimeManager(float randomMoveFactor=0, int expectedGameLength=TIME_EXPECT_GAME_LENGTH, int threshMove=TIME_THRESH_MOVE_PROP_SYSTEM,
+                float moveFactor=TIME_PROP_MOVE_FACTOR, float incrementFactor=TIME_INCREMENT_FACTOR, int timeBufferFactor=TIME_BUFFER_FACTOR);
 
     /**
      * @brief get_time_for_move Calculates the movetime based on the searchSettigs


### PR DESCRIPTION
This PR updates the constants of the time-management.


```shell
./cutechess-cli -variant standard -openings file="/data/SL/Drawkiller_unbalanced_V4_3mvs_+070_+099.pgn" format=pgn plies=100 -pgnout time_manag.pgn -resign movecount=5 score=600 -draw movenumber=30 movecount=4 score=20 -concurrency 1 -engine name=ClassicAra-0.9.4_Time_Manag option.Threads=3 cmd=./@JC_ClassicAra_time_manag -engine name=ClassicAra-0.9.4_8007fa0 option.Threads=3 cmd=./@JC_ClassicAra_8007fa0 -each dir=/data/SL/ proto=uci tc=0/1:0+0.25 option.First_Device_ID=5 option.Last_Device_ID=5 -games 2 -rounds 300 -repeat&
```

```python
tc=0/1:0+0.25

Name                        :  Games                 Elo    Pts   Pts%   Win  Loss  Draw  Tf  Sc
ClassicAra-0.9.4_8007fa0    :    426   -97.06 +/-  22.94  155.0   36.4    46   162   218   0   0
ClassicAra-0.9.4_Time_Manag :    426    97.06 +/-  22.94  271.0   63.6   162    46   218   0   0

Name                        :  W_win  B_win   Draw
ClassicAra-0.9.4_8007fa0    :     43      3    218
ClassicAra-0.9.4_Time_Manag :    137     25    218


Name                        :   Wapc     Sd
ClassicAra-0.9.4_8007fa0    :    141     44
ClassicAra-0.9.4_Time_Manag :    129     38

Finished games   : 426
White wins       : 180 (42.3%)
Black wins       : 28 (6.6%)
Draws            : 436 (102.3%)
Unfinished games : 0 (0.0%)

Tf = time forfeit
Sc = stalled connection
Wapc = win average ply count, lower is better
Sd = standard deviation
```