### PR TITLE
Retrieve neural network indices in TensorrtAPI

### DIFF
--- a/engine/src/nn/neuralnetapi.h
+++ b/engine/src/nn/neuralnetapi.h
@@ -134,6 +134,13 @@ std::ostream& operator<<(std::ostream& os, const Shape& shape);
 struct NeuralNetDesign {
     bool isPolicyMap = false;
     bool hasAuxiliaryOutputs = false;
+    const int nbInputs = 1;
+    const string inputLayerName = "data";
+    const string policyOutputName = "policy_out";
+    const string policySoftmaxOutputName = "policy_softmax";
+    const string valueOutputName = "value_out";
+    const string auxiliaryOutputName = "auxiliary_out";
+    const int inputIdx = 0;
     const int valueOutputIdx = 0;
     const int policyOutputIdx = 1;
     const int auxiliaryOutputIdx = 2;
@@ -141,6 +148,7 @@ struct NeuralNetDesign {
     Shape valueOutputShape;
     Shape policyOutputShape;
     Shape auxiliaryOutputShape;
+
     /**
      * @brief print Prints the outputs shapes using info_string(...)
      */

--- a/engine/src/nn/tensorrtapi.h
+++ b/engine/src/nn/tensorrtapi.h
@@ -62,10 +62,10 @@ class TensorrtAPI : public NeuralNetAPI
 {
 private:
     // binding indices for the input, value and policy data
-    const int idxInput = 0;
-    const int idxValueOutput = 1;
-    const int idxPolicyOutput = 2;
-    const int idxAuxiliaryOutput = 3;
+    int idxInput;
+    int idxValueOutput;
+    int idxPolicyOutput;
+    int idxAuxiliaryOutput;
 
     // device memory, for input, value output and policy output, auxiliary outputs
     void* deviceMemory[4];
@@ -93,6 +93,12 @@ public:
     ~TensorrtAPI();
 
     void predict(float* inputPlanes, float* valueOutput, float* probOutputs, float* auxiliaryOutputs) override;
+
+    /**
+     * @brief retrieve_indices_by_name Sets the layer name indices by names.
+     * @return True if all layer names were found, else false
+     */
+    bool retrieve_indices_by_name();
 
 private:
     void load_model() override;


### PR DESCRIPTION
This PR retrieves the neural network indices for the output layers rather than hardcoding them.
Currently only supported in the TensorRT back-end.
* added `retrieve_indices_by_name()` for TensorrtAPI
* added constant layer name to `nnDesign`


