### PR TITLE
Chess960

### DIFF
--- a/engine/src/environments/chess_related/board.cpp
+++ b/engine/src/environments/chess_related/board.cpp
@@ -299,11 +299,10 @@ std::string pgn_move(Move m, bool chess960, const Board& pos, const std::vector<
         ambiguous = "";
     }
 
-    if (type_of(m) == CASTLING && !chess960) {
-        if (file_of(to) == FILE_G || file_of(to) == FILE_H) {
+    if (type_of(m) == CASTLING) {
+        if (file_of(from) < file_of(to)) {
             move = "O-O";
-        }
-        else {
+        } else {
             move = "O-O-O";
         }
     }

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -221,6 +221,7 @@ Result SelfPlay::generate_arena_game(MCTSAgent* whitePlayer, MCTSAgent* blackPla
     gamePGN.black = blackPlayer->get_name();
     unique_ptr<StateObj> state= make_unique<StateObj>();
     state->init(variant, is960);
+    gamePGN.fen = state->fen();
     EvalInfo evalInfo;
 
     MCTSAgent* activePlayer;

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -215,12 +215,19 @@ void SelfPlay::generate_game(Variant variant, bool verbose)
     ++gameIdx;
 }
 
-Result SelfPlay::generate_arena_game(MCTSAgent* whitePlayer, MCTSAgent* blackPlayer, Variant variant, bool verbose)
+Result SelfPlay::generate_arena_game(MCTSAgent* whitePlayer, MCTSAgent* blackPlayer, Variant variant, bool verbose, string* fen)
 {
     gamePGN.white = whitePlayer->get_name();
     gamePGN.black = blackPlayer->get_name();
     unique_ptr<StateObj> state= make_unique<StateObj>();
-    state->init(variant, is960);
+    if (*fen != "") {
+        // set starting fen
+        state->set(*fen, is960, variant);
+    } else {
+        // create new starting fen and return it
+        state->init(variant, is960);
+        *fen = state->fen();
+    }
     gamePGN.fen = state->fen();
     EvalInfo evalInfo;
 
@@ -331,9 +338,11 @@ TournamentResult SelfPlay::go_arena(MCTSAgent *mctsContender, size_t numberOfGam
     tournamentResult.playerA = mctsContender->get_name();
     tournamentResult.playerB = mctsAgent->get_name();
     Result gameResult;
+    string fen;
     for (size_t idx = 0; idx < numberOfGames; ++idx) {
         if (idx % 2 == 0) {
-            gameResult = generate_arena_game(mctsContender, mctsAgent, variant, true);
+            fen = "";
+            gameResult = generate_arena_game(mctsContender, mctsAgent, variant, true, &fen);
             if (gameResult == WHITE_WIN) {
                 ++tournamentResult.numberWins;
             }
@@ -342,7 +351,7 @@ TournamentResult SelfPlay::go_arena(MCTSAgent *mctsContender, size_t numberOfGam
             }
         }
         else {
-            gameResult = generate_arena_game(mctsAgent, mctsContender, variant, true);
+            gameResult = generate_arena_game(mctsAgent, mctsContender, variant, true, &fen);
             if (gameResult == BLACK_WIN) {
                 ++tournamentResult.numberWins;
             }

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -114,9 +114,10 @@ private:
      * @param whitePlayer MCTSAgent which will play with the white pieces
      * @param blackPlayer MCTSAgent which will play with the black pieces
      * @param variant Current chess variant
+     * @param fen Starting position. If empty, the standard starting or a random position (for 960 games) will be used.
      * @param verbose If true the games will printed to stdout
      */
-    Result generate_arena_game(MCTSAgent *whitePlayer, MCTSAgent *blackPlayer, Variant variant, bool verbose);
+    Result generate_arena_game(MCTSAgent *whitePlayer, MCTSAgent *blackPlayer, Variant variant, bool verbose, string* fen);
 
     /**
      * @brief write_game_to_pgn Writes the game log to a pgn file


### PR DESCRIPTION
**Small fixes for chess960:** 
* Adding fens for arena games in RL
* Adding correctly pgn printing for castling in chess960
* In arena mode, each opening is now played twice, where player are switched after each game. 
---

@QueensGambit Please have a look at the last commit. You said you wanted some changes regarding the usage of pointers?! Please let me know what I can do.
