### PR TITLE
RL Logging: Found tablebases and Configs

### DIFF
--- a/engine/src/rl/binaryio.py
+++ b/engine/src/rl/binaryio.py
@@ -171,6 +171,14 @@ class BinaryIO:
                                                                  bytes(str(value), encoding="utf-8")))
         self.proc.stdin.flush()
 
+        # Log how many tablebases could be found
+        if name == f'SyzygyPath' and value != '' and value != '<empty>':
+            while True:
+                line = self.proc.stdout.readline().decode().rstrip('\n')
+                if line.startswith('info string Found') and line.endswith('tablebases'):
+                    logging.info(line[12:])
+                    break
+
     def stop_process(self):
         """
         Kills the process that is attached to the binary.

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -12,6 +12,7 @@ import sys
 import logging
 import argparse
 from rtpt import RTPT
+import dataclasses
 from multiprocessing import Process, Queue
 
 assert os.getcwd().endswith(f'engine/src/rl'), f'Please change working directory'
@@ -213,11 +214,18 @@ def main():
                                                          rl_loop.rtpt._get_title(), rl_loop.nn_update_index)
     rl_loop.initialize()
 
-    logging.info(f'Command line parameters: {str(args)}')
-    logging.info(f'RL Options: {rl_config}')
-    logging.info(f'UCI Options: {rl_loop.binary_io.get_uci_options()}')
-    logging.info(f'UCI changes for arena: {UCIConfigArena()}')
-    logging.info(rl_loop.tc)
+    logging.info(f'--------------- CONFIG SETTINGS ---------------')
+    for key, value in sorted(vars(args).items()):
+        logging.info(f'CMD line args:      {key} = {value}')
+    for key, value in sorted(dataclasses.asdict(rl_loop.tc).items()):
+        logging.info(f'Train Config:       {key} = {value}')
+    for key, value in sorted(dataclasses.asdict(rl_config).items()):
+        logging.info(f'RL Options:         {key} = {value}')
+    for key, value in rl_loop.binary_io.get_uci_options().items():
+        logging.info(f'UCI Options:        {key} = {value}')
+    for key, value in sorted(dataclasses.asdict(UCIConfigArena()).items()):
+        logging.info(f'UCI Options Arena:  {key} = {value}')
+    logging.info(f'-----------------------------------------------')
 
     while True:
         if args.trainer:


### PR DESCRIPTION
* Adds a logging statement with the number of found tablebases
* Changes logging of config files to increase readability

An example logging output is shown on the following image:

![image](https://user-images.githubusercontent.com/10214256/121193792-6b794700-c86e-11eb-8a40-d7e8da573c7a.png)
