### PR TITLE
Time management refactoring & bugfix

### DIFF
--- a/engine/src/agents/config/searchlimits.cpp
+++ b/engine/src/agents/config/searchlimits.cpp
@@ -25,6 +25,7 @@
 
 #include "searchlimits.h"
 #include "state.h"
+#include "constants.h"
 
 std::ostream &operator<<(std::ostream &os, const SearchLimits &searchLimits)
 {
@@ -59,6 +60,11 @@ void SearchLimits::reset()
     time[FIRST_PLAYER_IDX+1] = 0;
     inc[FIRST_PLAYER_IDX] = 0;
     inc[FIRST_PLAYER_IDX+1] = 0;
+}
+
+int SearchLimits::get_safe_remaining_time(SideToMove sideToMove) const
+{
+    return max(time[sideToMove] - moveOverhead * TIME_BUFFER_FACTOR, 1);
 }
 
 bool is_game_sceneario(const SearchLimits* searchLimits)

--- a/engine/src/agents/config/searchlimits.h
+++ b/engine/src/agents/config/searchlimits.h
@@ -27,6 +27,7 @@
 
 #include <chrono>
 #include <ostream>
+#include "state.h"
 
 #ifndef SEARCHLIMITS_H
 #define SEARCHLIMITS_H
@@ -57,6 +58,14 @@ public:
      * @brief reset Resets all search limits
      */
     void reset();
+
+    /**
+     * @brief get_safe_remaining_time Leaves an additional time buffer to avoid losing on time
+     *  Factor which is applied on the moveOverhead to calculate a time buffer for avoiding losing on time
+     * @param sideToMove
+     * @return Total movetime in milli-seconds
+     */
+    int get_safe_remaining_time(SideToMove sideToMove) const;
 };
 
 /**

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -320,9 +320,10 @@ void MCTSAgent::run_mcts_search()
         threads[i] = new thread(run_search_thread, searchThreads[i]);
     }
     int curMovetime = timeManager->get_time_for_move(searchLimits, rootState->side_to_move(), rootNode->plies_from_null()/2);
-    threadManager = make_unique<ThreadManager>(rootNode.get(), evalInfo, searchThreads, curMovetime, 250, searchLimits->moveOverhead, searchSettings, overallNPS, lastValueEval,
-                                               is_game_sceneario(searchLimits),
-                                               can_prolong_search(rootNode->plies_from_null()/2, timeManager->get_thresh_move()));
+    ThreadManagerData tData(rootNode.get(), searchThreads, evalInfo, lastValueEval);
+    ThreadManagerInfo tInfo(searchSettings, searchLimits, overallNPS, rootState->side_to_move());
+    ThreadManagerParams tParams(curMovetime, 250, is_game_sceneario(searchLimits), can_prolong_search(rootNode->plies_from_null()/2, timeManager->get_thresh_move()));
+    threadManager = make_unique<ThreadManager>(&tData, &tInfo, &tParams);
     unique_ptr<thread> tManager = make_unique<thread>(run_thread_manager, threadManager.get());
     isRunning = true;
 

--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -74,9 +74,9 @@ const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al."
 #endif
 #define TIME_EXPECT_GAME_LENGTH 38
 #define TIME_THRESH_MOVE_PROP_SYSTEM 35
-#define TIME_PROP_MOVE_FACTOR 0.07f
+#define TIME_PROP_MOVES_TO_GO 14
 #define TIME_INCREMENT_FACTOR 0.7f
-#define TIME_BUFFER_FACTOR 30.0f
+#define TIME_BUFFER_FACTOR 30
 
 #ifndef MODE_POMMERMAN
 #define TERMINAL_NODE_CACHE 8192

--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -118,7 +118,7 @@ float get_best_move_q(const Node* nextNode)
 #endif
 }
 
-void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vector<size_t>& indices, const SearchSettings* searchSettings)
+void set_eval_for_single_pv(EvalInfo& evalInfo, const Node* rootNode, size_t idx, vector<size_t>& indices, const SearchSettings* searchSettings)
 {
     vector<Action> pv;
     size_t childIdx;
@@ -173,7 +173,7 @@ void sort_eval_lists(EvalInfo& evalInfo, vector<size_t>& indices)
     apply_permutation_in_place(indices, p);
 }
 
-void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t selDepth, const SearchSettings* searchSettings)
+void update_eval_info(EvalInfo& evalInfo, const Node* rootNode, size_t tbHits, size_t selDepth, const SearchSettings* searchSettings)
 {
     const size_t targetLength = rootNode->get_number_child_nodes();
     evalInfo.childNumberVisits = rootNode->get_child_number_visits();

--- a/engine/src/evalinfo.h
+++ b/engine/src/evalinfo.h
@@ -82,7 +82,7 @@ int value_to_centipawn(float value);
  * @param selDepth Selective depth, in this case the maximum reached depth
  * @param searchSettings searchSettings struct
  */
-void update_eval_info(EvalInfo& evalInfo, Node* rootNode, size_t tbHits, size_t selDepth, const SearchSettings* searchSettings);
+void update_eval_info(EvalInfo& evalInfo, const Node* rootNode, size_t tbHits, size_t selDepth, const SearchSettings* searchSettings);
 
 /**
  * @brief get_best_move_q Return the value evaluation for the given next node.
@@ -100,7 +100,7 @@ float get_best_move_q(const Node* nextNode);
  * @param idx index of the pv line
  * @param indices sorted indices of each child node
  */
-void set_eval_for_single_pv(EvalInfo& evalInfo, Node* rootNode, size_t idx, vector<size_t>& indices, const SearchSettings* searchSettings);
+void set_eval_for_single_pv(EvalInfo& evalInfo, const Node* rootNode, size_t idx, vector<size_t>& indices, const SearchSettings* searchSettings);
 
 /**
  * @brief operator << Returns all MultiPV as a string sperated by endl

--- a/engine/src/manager/threadmanager.h
+++ b/engine/src/manager/threadmanager.h
@@ -37,6 +37,41 @@
 
 using namespace std;
 
+
+struct ThreadManagerData {
+    const Node* rootNode;
+    vector<SearchThread*> searchThreads;
+    EvalInfo* evalInfo;
+    int remainingMoveTimeMS;
+    float lastValueEval;
+
+    ThreadManagerData(const Node* rootNode, vector<SearchThread*> searchThreads, EvalInfo* evalInfo, float lastValueEval) :
+        rootNode(rootNode), searchThreads(searchThreads), evalInfo(evalInfo), remainingMoveTimeMS(0), lastValueEval(lastValueEval)
+    {}
+};
+
+struct ThreadManagerInfo {
+    const SearchSettings* searchSettings;
+    const SearchLimits* searchLimits;
+    const float overallNPS;
+    const SideToMove sideToMove;
+
+    ThreadManagerInfo(const SearchSettings* searchSettings, const SearchLimits* searchLimits, const float overallNPS, const SideToMove sideToMove) :
+        searchSettings(searchSettings), searchLimits(searchLimits), overallNPS(overallNPS), sideToMove(sideToMove)
+    {}
+};
+
+struct ThreadManagerParams {
+    const int moveTimeMS;
+    const int updateIntervalMS;
+    const bool inGame;
+    const bool canProlong;
+
+    ThreadManagerParams(const int moveTimeMS, const int updateIntervalMS, const bool inGame, const bool canProlong) :
+        moveTimeMS(moveTimeMS), updateIntervalMS(updateIntervalMS), inGame(inGame), canProlong(canProlong)
+    {}
+};
+
 /**
  * @brief The ThreadManager class contains a reference to all search threads and can trigger early stopping
  * or a stop when the given search time has been reached. It also logs intermdediate search results.
@@ -44,20 +79,10 @@ using namespace std;
 class ThreadManager : public KillableThread
 {
 private:
-    Node* rootNode;
-    EvalInfo* evalInfo;
-    vector<SearchThread*> searchThreads;
-    size_t movetimeMS;
-    size_t remainingMoveTimeMS;
-    size_t updateIntervalMS;
-    size_t moveOverhead;
-    const SearchSettings* searchSettings;
-    float overallNPS;
-    float lastValueEval;
-
+    ThreadManagerData* tData;
+    ThreadManagerInfo* tInfo;
+    ThreadManagerParams* tParams;
     int checkedContinueSearch = 0;
-    bool inGame;
-    bool canProlong;
     bool isRunning;
     /**
      * @brief check_early_stopping Checks if the search can be ended prematurely based on the current tree statistics (visits & Q-values)
@@ -77,7 +102,7 @@ private:
     void print_info();
 
 public:
-     ThreadManager(Node* rootNode, EvalInfo* evalInfo, vector<SearchThread*>& searchThreads, size_t movetimeMS, size_t updateIntervalMS, size_t moveOverhead, const SearchSettings* searchSettings, float overallNPS, float lastValueEval, bool inGame, bool canProlong);
+    ThreadManager(ThreadManagerData* tData, ThreadManagerInfo* tInfo, ThreadManagerParams* tParams);
 
     /**
     * @brief stop_search_based_on_limits Checks for the search limit condition and possible early break-ups

--- a/engine/src/manager/timemanager.cpp
+++ b/engine/src/manager/timemanager.cpp
@@ -30,19 +30,21 @@
 using namespace std;
 
 
-TimeManager::TimeManager(float randomMoveFactor, int expectedGameLength, int threshMove, float moveFactor, float incrementFactor, int timeBufferFactor):
+TimeManager::TimeManager(float randomMoveFactor, int expectedGameLength, int threshMove, int timePropMovesToGo, float incrementFactor):
     curMovetime(0),  // will be updated later
-    timeBuffer(0),   // will be updated later
     randomMoveFactor(randomMoveFactor),
     expectedGameLength(expectedGameLength),
     threshMove(threshMove),
-    moveFactor(moveFactor),
-    incrementFactor(incrementFactor),
-    timeBufferFactor(timeBufferFactor)
+    timePropMovesToGo(timePropMovesToGo),
+    incrementFactor(incrementFactor)
 {
     auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
     srand(unsigned(int(seed)));
     assert(threshMove < expectedGameLength);
+}
+
+inline int get_constant_movetime(const SearchLimits* searchLimits, SideToMove me, int movesToGo, float incrementFactor) {
+    return searchLimits->get_safe_remaining_time(me) / movesToGo + incrementFactor * searchLimits->inc[me];
 }
 
 int TimeManager::get_time_for_move(const SearchLimits* searchLimits, SideToMove me, int moveNumber)
@@ -56,38 +58,39 @@ int TimeManager::get_time_for_move(const SearchLimits* searchLimits, SideToMove 
         }
     }
 
-    // leave an additional time buffer to avoid losing on time
-    timeBuffer = searchLimits->moveOverhead * timeBufferFactor;
-
     if (searchLimits->movetime != 0) {
         // only return the plain move time substracted by the move overhead
-        curMovetime = searchLimits->movetime - searchLimits->moveOverhead;
+        curMovetime = searchLimits->movetime;
     }
     else if (searchLimits->movestogo != 0) {
         // calculate a constant move time based on increment and moves left
-        curMovetime = int(((searchLimits->time[me] - timeBuffer) / float(searchLimits->movestogo) + 0.5f)
-                + searchLimits->inc[me] - searchLimits->moveOverhead);
+        curMovetime = get_constant_movetime(searchLimits, me, searchLimits->movestogo, incrementFactor);
     }
     else if (searchLimits->time[me] != 0) {
         // calculate a movetime in sudden death mode
         if (moveNumber < threshMove) {
-            curMovetime = int((searchLimits->time[me] - timeBuffer) / float(expectedGameLength-moveNumber) + 0.5f)
-                    + int(searchLimits->inc[me] * incrementFactor) - searchLimits->moveOverhead;
+            curMovetime = get_constant_movetime(searchLimits, me, expectedGameLength-moveNumber, incrementFactor);
         }
         else {
-            curMovetime = int((searchLimits->time[me] - timeBuffer) * moveFactor + 0.5f)
-                    + int(searchLimits->inc[me] * incrementFactor) - searchLimits->moveOverhead;
+            curMovetime = get_constant_movetime(searchLimits, me, timePropMovesToGo, incrementFactor);
         }
     }
     else {
-        curMovetime = 1000 - searchLimits->moveOverhead;
+        curMovetime = 1000;
         info_string("No limit specification given, setting movetime[ms] to", curMovetime);
     }
+
+    // substract the move overhead
+    curMovetime -= searchLimits->moveOverhead;
 
     if (curMovetime <= 0) {
         curMovetime = searchLimits->moveOverhead * 2;
     }
-    return apply_random_factor(curMovetime);
+
+    curMovetime = apply_random_factor(curMovetime);
+
+    // make sure the returned movetime is within bounds
+    return min(searchLimits->get_safe_remaining_time(me), curMovetime);
 }
 
 int TimeManager::get_thresh_move() const
@@ -105,5 +108,5 @@ int TimeManager::apply_random_factor(int curMovetime)
 
 float TimeManager::get_current_random_factor()
 {
-    return (float(rand()) / RAND_MAX) * randomMoveFactor * 2 - randomMoveFactor;
+    return (double(rand()) / RAND_MAX) * randomMoveFactor * 2 - randomMoveFactor;
 }

--- a/engine/src/manager/timemanager.h
+++ b/engine/src/manager/timemanager.h
@@ -37,14 +37,12 @@ class TimeManager
 {
 private:
     int curMovetime;
-    int timeBuffer;
 
     float randomMoveFactor;
     int expectedGameLength;
     int threshMove;
-    float moveFactor;
+    int timePropMovesToGo;
     float incrementFactor;
-    int timeBufferFactor;
 
     /**
      * @brief apply_random_factor Applies the current randomly generated move factor on the given movetime.
@@ -67,11 +65,11 @@ public:
      * (e.g. when randomMoveFactor is 0.1, on every move the movtime will be either increased or decreased by a factor of between -10% and +10%)
      * @param expectedGameLength Expected game length for the game in full moves
      * @param threshMove Threshold move on which the constant move regime will switch to a proportional one
-     * @param moveFactor Portion of the current move time which will be used in the proportional movetime regime
+     * @param timePropMovesToGo Expected number moves to go in proportional time regime
      * @param timeBufferFactor Factor which is applied on the moveOverhead to calculate a time buffer for avoiding losing on time
      */
     TimeManager(float randomMoveFactor=0, int expectedGameLength=TIME_EXPECT_GAME_LENGTH, int threshMove=TIME_THRESH_MOVE_PROP_SYSTEM,
-                float moveFactor=TIME_PROP_MOVE_FACTOR, float incrementFactor=TIME_INCREMENT_FACTOR, int timeBufferFactor=TIME_BUFFER_FACTOR);
+                int timePropMovesToGo=TIME_PROP_MOVES_TO_GO, float incrementFactor=TIME_INCREMENT_FACTOR);
 
     /**
      * @brief get_time_for_move Calculates the movetime based on the searchSettigs
@@ -86,5 +84,16 @@ public:
     int get_thresh_move() const;
 };
 
+/**
+ * @brief get_constant_movetime Returns a constant movetime based on given left time, movesToGo and time increment.
+ * Warning: Due to increment being applied after the move was made and not before, the returned movetime can be greater than left time.
+ * @param searchLimits Search limits struct
+ * @param me Side to move
+ * @param timeBuffer Time buffer to avoid losing due to move overhead
+ * @param movesToGo Expected number of moves remaining
+ * @param incrementFactor Increment factor for increment
+ * @return Movetime
+ */
+inline int get_constant_movetime(const SearchLimits* searchLimits, SideToMove me, int timeBuffer, int movesToGo, float incrementFactor);
 
 #endif // TIMEMANAGER_H

--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -506,7 +506,7 @@ float Node::get_q_value(ChildIdx childIdx) const
     return d->qValues[childIdx];
 }
 
-DynamicVector<float> Node::get_q_values()
+DynamicVector<float> Node::get_q_values() const
 {
     return d->qValues;
 }
@@ -733,12 +733,12 @@ float Node::max_policy_prob()
     return max(policyProbSmall);
 }
 
-ChildIdx Node::max_q_child()
+ChildIdx Node::max_q_child() const
 {
     return argmax(d->qValues);
 }
 
-ChildIdx Node::max_visits_child()
+ChildIdx Node::max_visits_child() const
 {
     return argmax(d->childNumberVisits);
 }
@@ -1202,7 +1202,7 @@ void Node::print_node_statistics(const StateObj* state, const vector<size_t>& cu
          << "freeVisits:\t" << get_free_visits() << "/" << get_visits() << endl;
 }
 
-uint32_t Node::get_node_count()
+uint32_t Node::get_node_count() const
 {
     return get_visits() - get_free_visits();
 }

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -326,13 +326,13 @@ public:
      * @brief max_q_child Returns the child index with the highest Q-value
      * @return size_t
      */
-    ChildIdx max_q_child();
+    ChildIdx max_q_child() const;
 
     /**
      * @brief max_visits_child Returns the child index with the most visits
      * @return size_t
      */
-    ChildIdx max_visits_child();
+    ChildIdx max_visits_child() const;
 
     /**
      * @brief update_value_eval Returns the updated state evaluation based on the Q-value of the most visited child node
@@ -402,7 +402,7 @@ public:
      * @brief get_q_values Returns the Q-values for all child nodes
      * @return Q-values
      */
-    DynamicVector<float> get_q_values();
+    DynamicVector<float> get_q_values() const;
 
     /**
      * @brief set_q_value Sets a Q-value for a given child index
@@ -437,7 +437,7 @@ public:
      * @brief get_node_count Returns the number of nodes in the subgraph of this nodes without counting terminal simulations
      * @return uint32_t
      */
-    uint32_t get_node_count();
+    uint32_t get_node_count() const;
 
     bool is_transposition() const;
 


### PR DESCRIPTION
Refactored time management and fixed bug when losing on time.
Now it is taken into account that increment is applied after the move is done (and not before).

Thanks to AdminX and Werner Schüle for reporting it:
* http://talkchess.com/forum3/viewtopic.php?f=2&t=77020&p=895388&hilit=classicara#p895388


---

```python

./cutechess-cli -variant standard -openings file="/data/SL/opening_suites/UHO_V3_6mvs_+090_+099.pgn" format=pgn plies=100 -pgnout "/data/SL/pgn_out/time_manag_refactor.pgn" -resign movecount=5 score=600 -draw movenumber=30 movecount=4 score=20 -concurrency 1 -engine name=ClassicAra-0.9.5_time_refactor_70e37e5 cmd=/data/SL/@JC_ClassicAra_time_refactor_70e37e5 -engine name=ClassicAra-0.9.5_e17e608_wdlp_input_3.0 cmd=/data/SL/@JC_ClassicAra_input_3.0 -each dir=/data/SL/ option.Threads=3 proto=uci tc=0/0:30+0.25 option.Model_Directory=/data/SL/model/input_3.0/7_wdlp_head_7_epochs option.First_Device_ID=15 option.Last_Device_ID=15 -games 2 -rounds 300 -repeat&

TC: 30s +  0.25s
File: /data/SL/pgn_out/time_manag_refactor.pgn

Name                        :  Games                 Elo    Pts   Pts%   Win  Loss  Draw  Tf  Sc
ClassicAra-0.9.5_e17e608_wd :    600     1.16 +/-  18.08  301.0   50.2   128   126   346   0   0
ClassicAra-0.9.5_time_refac :    600    -1.16 +/-  18.08  299.0   49.8   126   128   346   0   0

Name                        :  W_win  B_win   Draw
ClassicAra-0.9.5_e17e608_wd :    123      5    346
ClassicAra-0.9.5_time_refac :    117      9    346


Name                        :   Wapc     Sd
ClassicAra-0.9.5_e17e608_wd :    130     35
ClassicAra-0.9.5_time_refac :    131     38

Finished games   : 600
White wins       : 240 (40.0%)
Black wins       : 14 (2.3%)
Draws            : 692 (115.3%)
Unfinished games : 0 (0.0%)

Tf = time forfeit
Sc = stalled connection
Wapc = win average ply count, lower is better
Sd = standard deviation
```