### PR TITLE
Mirror policy

### DIFF
--- a/DeepCrazyhouse/src/domain/abstract_cls/abs_game_state.py
+++ b/DeepCrazyhouse/src/domain/abstract_cls/abs_game_state.py
@@ -53,6 +53,10 @@ class AbsGameState(ABC):
     def is_white_to_move(self):
         """Force the child to implement is_white_to_move method"""
 
+    @abstractmethod
+    def mirror_policy(self) -> bool:
+        """Force the child to implement mirror_policy method"""
+
     def __str__(self):
         return self.board.fen()
 

--- a/DeepCrazyhouse/src/domain/agent/player/alpha_beta_agent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/alpha_beta_agent.py
@@ -72,7 +72,7 @@ class AlphaBetaAgent(AbsAgent):
         best_value = -math.inf  # initialization
 
         legal_moves = state.get_legal_moves()
-        p_vec_small = get_probs_of_move_list(policy_vec, state.get_legal_moves(), state.is_white_to_move())
+        p_vec_small = get_probs_of_move_list(policy_vec, state.get_legal_moves(), state.mirror_policy())
 
         if all_moves > 0:
             mv_idces = list(np.argsort(p_vec_small)[::-1])

--- a/DeepCrazyhouse/src/domain/agent/player/mcts_agent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/mcts_agent.py
@@ -407,7 +407,7 @@ class MCTSAgent(AbsAgent):  # Too many instance attributes (31/7)
         is_leaf = False  # initialize is_leaf by default to false
         [value, policy_vec] = self.nets[0].predict_single(state.get_state_planes())  # start a brand new tree
         # extract a sparse policy vector with normalized probabilities
-        p_vec_small = get_probs_of_move_list(policy_vec, legal_moves, state.is_white_to_move())
+        p_vec_small = get_probs_of_move_list(policy_vec, legal_moves, state.mirror_policy())
         chess_board = state.get_pythonchess_board()
         if self.enhance_captures:
             self._enhance_captures(chess_board, legal_moves, p_vec_small)
@@ -464,7 +464,7 @@ class MCTSAgent(AbsAgent):  # Too many instance attributes (31/7)
                 [value, policy_vec] = self.nets[0].predict_single(state_child.get_state_planes())
                 # extract a sparse policy vector with normalized probabilities
                 p_vec_small_child = get_probs_of_move_list(
-                    policy_vec, legal_moves_child, state_child.is_white_to_move()
+                    policy_vec, legal_moves_child, state_child.mirror_policy()
                 )
 
             # create a new child node
@@ -716,7 +716,7 @@ class MCTSAgent(AbsAgent):  # Too many instance attributes (31/7)
                     else:
                         try:  # extract a sparse policy vector with normalized probabilities
                             p_vec_small = get_probs_of_move_list(
-                                policy_vec, legal_moves, is_white_to_move=state.is_white_to_move(), normalize=True
+                                policy_vec, legal_moves, mirror_policy=state.mirror_policy(), normalize=True
                             )
                         except KeyError:
                             raise Exception("Key Error for state: %s" % state)

--- a/DeepCrazyhouse/src/domain/agent/player/raw_net_agent.py
+++ b/DeepCrazyhouse/src/domain/agent/player/raw_net_agent.py
@@ -42,7 +42,7 @@ class RawNetAgent(AbsAgent):
         t_start_eval = time()
         pred_value, pred_policy = self._net.predict_single(state.get_state_planes())
         legal_moves = list(state.get_legal_moves())
-        p_vec_small = get_probs_of_move_list(pred_policy, legal_moves, state.is_white_to_move())
+        p_vec_small = get_probs_of_move_list(pred_policy, legal_moves, state.mirror_policy())
         # define the remaining return variables
         time_e = time() - t_start_eval
         centipawn = value_to_centipawn(pred_value)

--- a/DeepCrazyhouse/src/domain/variants/game_state.py
+++ b/DeepCrazyhouse/src/domain/variants/game_state.py
@@ -34,6 +34,13 @@ import chess
 from DeepCrazyhouse.src.domain.variants.input_representation import board_to_planes
 from DeepCrazyhouse.src.domain.abstract_cls.abs_game_state import AbsGameState
 from DeepCrazyhouse.configs.main_config import main_config
+from DeepCrazyhouse.src.domain.variants.constants import MODE, MODE_LICHESS
+
+
+def mirror_policy(board: chess.Board):
+    if MODE == MODE_LICHESS and board.uci_variant == "racingkings":
+        return False
+    return board.turn == chess.BLACK
 
 
 class GameState(AbsGameState):
@@ -95,6 +102,10 @@ class GameState(AbsGameState):
     def is_white_to_move(self):
         """ Returns true if its whites turn"""
         return self.board.turn
+
+    def mirror_policy(self) -> bool:
+        """Decides if the policy should be mirrored."""
+        return mirror_policy(self.board)
 
     def __str__(self):
         return self.board.fen()

--- a/DeepCrazyhouse/src/domain/variants/output_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/output_representation.py
@@ -18,19 +18,19 @@ from DeepCrazyhouse.src.domain.variants.constants import (
 )
 
 
-def move_to_policy(move, is_white_to_move=True):
+def move_to_policy(move, mirror_policy: bool = False):
     """
     Returns a numpy vector with the bit set to 1 a the according index (one hot encoding)
 
     :param move Python chess obj. defining a move
-    :param is_white_to_move: Define the current player turn
+    :param mirror_policy: Decides if the policy should be mirrored
     :return: Policy numpy vector in boolean format
     """
 
-    if is_white_to_move is True:
-        mv_idx = MV_LOOKUP[move.uci()]
-    else:
+    if mirror_policy is True:
         mv_idx = MV_LOOKUP_MIRRORED[move.uci()]
+    else:
+        mv_idx = MV_LOOKUP[move.uci()]
 
     policy_vec = np.zeros(NB_LABELS, dtype=np.bool)
     # set the bit to 1 at the according move index
@@ -39,12 +39,12 @@ def move_to_policy(move, is_white_to_move=True):
     return policy_vec
 
 
-def policy_to_move(policy_vec_clean, is_white_to_move=True):
+def policy_to_move(policy_vec_clean, mirror_policy: bool = False):
     """
     Returns a python-chess move object based on the given move index
 
     :param policy_vec_clean: Numpy array which represents the moves
-    :param is_white_to_move: Define the current player turn
+    :param mirror_policy: Decides if policy should be mirrored
     :return: single move - Python chess move object
     """
 
@@ -53,10 +53,10 @@ def policy_to_move(policy_vec_clean, is_white_to_move=True):
     # ensure that the provided mv_idx is legal
     assert 0 <= mv_idx < NB_LABELS
 
-    if is_white_to_move is True:
-        mv_uci = LABELS[mv_idx]
-    else:
+    if mirror_policy is True:
         mv_uci = LABELS_MIRRORED[mv_idx]
+    else:
+        mv_uci = LABELS[mv_idx]
 
     move = chess.Move.from_uci(mv_uci)
 
@@ -174,13 +174,13 @@ def set_illegal_moves_to_zero(board: chess.variant.CrazyhouseBoard, policy_vec, 
     return policy_vec_out, nb_legal_moves
 
 
-def get_probs_of_move_list(policy_vec: np.ndarray, mv_list: [chess.Move], is_white_to_move, normalize=True):
+def get_probs_of_move_list(policy_vec: np.ndarray, mv_list: [chess.Move], mirror_policy: bool, normalize: bool = True):
     """
     Returns an array in which entry relates to the probability for the given move list.
     Its assumed that the moves in the move list are legal and shouldn't be mirrored.
     :param policy_vec: Policy vector from the neural net prediction
     :param mv_list: List of legal moves for a specific board position
-    :param is_white_to_move: Determine if it's white's or black's turn to move
+    :param mirror_policy: Decides if the current policy shall be mirrored
     :param normalize: True, if the probability should be normalized
     :return: p_vec_small - A numpy vector which stores the probabilities for the given move list
     """
@@ -190,12 +190,12 @@ def get_probs_of_move_list(policy_vec: np.ndarray, mv_list: [chess.Move], is_whi
 
     for mv_idx, move in enumerate(mv_list):
 
-        if is_white_to_move is True:
-            # find the according index in the vector
-            idx = MV_LOOKUP[move.uci()]
-        else:
-            # use the mirrored look-up table instead
+        if mirror_policy is True:
+            # find the according index in the mirrored vector
             idx = MV_LOOKUP_MIRRORED[move.uci()]
+        else:
+            # use the non-mirrored look-up table instead
+            idx = MV_LOOKUP[move.uci()]
 
         # set the right prob value
         p_vec_small[mv_idx] = policy_vec[idx]

--- a/DeepCrazyhouse/src/preprocessing/pgn_converter_util.py
+++ b/DeepCrazyhouse/src/preprocessing/pgn_converter_util.py
@@ -14,6 +14,8 @@ from DeepCrazyhouse.src.domain.variants.constants import NB_LAST_MOVES
 from DeepCrazyhouse.src.domain.variants.output_representation import move_to_policy
 from DeepCrazyhouse.src.domain.variants.input_representation import board_to_planes
 from DeepCrazyhouse.configs.main_config import main_config
+from DeepCrazyhouse.src.domain.variants.game_state import mirror_policy
+
 
 NB_ITEMS_METADATA = 18  # constant which defines how many meta data items will be stored in a matrix
 # 2019-09-28: Increased NB_ITEMS_METADATA from 17 to 18 for chess 960
@@ -138,7 +140,7 @@ def get_planes_from_game(game, mate_in_one=False):
             y_value.append(y_init)
             # add the next move defined in policy vector notation to the policy list
             # the network always sees the board as if he's the white player, that's the move is mirrored fro black
-            y_policy.append(move_to_policy(next_move, is_white_to_move=board.turn))
+            y_policy.append(move_to_policy(next_move, mirror_policy=mirror_policy(board)))
 
         y_init *= -1  # flip the y_init value after each move
         board.push(move)  # push the next move on the board

--- a/DeepCrazyhouse/src/tests/full_round_trip_tests.py
+++ b/DeepCrazyhouse/src/tests/full_round_trip_tests.py
@@ -20,6 +20,7 @@ from DeepCrazyhouse.src.preprocessing.pgn_to_planes_converter import PGN2PlanesC
 from DeepCrazyhouse.src.preprocessing.dataset_loader import load_pgn_dataset
 from DeepCrazyhouse.configs.main_config import main_config
 from DeepCrazyhouse.src.domain.variants.constants import MODE, VERSION, MODE_CHESS
+from DeepCrazyhouse.src.domain.variants.game_state import mirror_policy
 
 # import the Colorer to have a nicer logging printout
 from DeepCrazyhouse.src.runtime.color_logger import enable_color_logging
@@ -92,7 +93,7 @@ def moves_single_game(params_inp):
     for i, move in enumerate(cur_game.main_line()):
 
         # get the move in python chess format based on the policy representation
-        converted_move = policy_to_move(yp_test[i], is_white_to_move=board.turn)
+        converted_move = policy_to_move(yp_test[i], mirror_policy=mirror_policy(board))
 
         cur_ok = converted_move == move
         all_ok = all_ok and cur_ok

--- a/DeepCrazyhouse/src/tests/move_round_trip_test.py
+++ b/DeepCrazyhouse/src/tests/move_round_trip_test.py
@@ -29,8 +29,8 @@ class MoveRoundTripTest(unittest.TestCase):
         """ TODO: docstring"""
         move = chess.Move.from_uci("e2e4")
 
-        policy_vec = move_to_policy(move, is_white_to_move=True)
-        mv_converted = policy_to_move(policy_vec, is_white_to_move=True)
+        policy_vec = move_to_policy(move, mirror_policy=False)
+        mv_converted = policy_to_move(policy_vec, mirror_policy=False)
 
         self.assertTrue(LABELS[policy_vec.argmax()] == move.uci())
         self.assertTrue(move == mv_converted)
@@ -39,8 +39,9 @@ class MoveRoundTripTest(unittest.TestCase):
         """ TODO: docstring"""
         move = chess.Move.from_uci("e7e5")
 
-        policy_vec = move_to_policy(move, is_white_to_move=False)
-        mv_conv = policy_to_move(policy_vec, is_white_to_move=False)
+        # TODO: This does not work for racing kings
+        policy_vec = move_to_policy(move, mirror_policy=True)
+        mv_conv = policy_to_move(policy_vec, mirror_policy=True)
 
         self.assertTrue(LABELS_MIRRORED[policy_vec.argmax()] == move.uci())
         self.assertTrue(move == mv_conv)
@@ -51,7 +52,7 @@ class MoveRoundTripTest(unittest.TestCase):
         :return:
         """
         _, _, _, yp_val, _ = load_pgn_dataset(
-            dataset_type="test", part_id=0, print_statistics=True, print_parameters=True, normalize=True
+            dataset_type="test", part_id=0, verbose=True, normalize=True
         )
 
         board = chess.variant.CrazyhouseBoard()
@@ -90,7 +91,7 @@ class MoveRoundTripTest(unittest.TestCase):
         :return:
         """
         _, _, _, yp_val, _ = load_pgn_dataset(
-            dataset_type="test", part_id=0, print_statistics=True, print_parameters=True, normalize=True
+            dataset_type="test", part_id=0, verbose=True, normalize=True
         )
 
         board = chess.variant.CrazyhouseBoard()

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -181,7 +181,8 @@ void MCTSAgent::create_new_root_node(StateObj* state)
     state->get_state_planes(true, inputPlanes);
     net->predict(inputPlanes, valueOutputs, probOutputs, auxiliaryOutputs);
     size_t tbHits = 0;
-    fill_nn_results(0, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, rootNode.get(), tbHits, state->side_to_move(), searchSettings, rootNode->is_tablebase());
+    fill_nn_results(0, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, rootNode.get(), tbHits,
+                    rootState->mirror_policy(state->side_to_move()), searchSettings, rootNode->is_tablebase());
 #endif
     rootNode->prepare_node_for_visits();
 }

--- a/engine/src/agents/rawnetagent.cpp
+++ b/engine/src/agents/rawnetagent.cpp
@@ -58,7 +58,7 @@ void RawNetAgent::evaluate_board_state()
     state->set_auxiliary_outputs(auxiliaryOutputs);
 
     evalInfo->policyProbSmall.resize(evalInfo->legalMoves.size());
-    get_probs_of_move_list(0, probOutputs, evalInfo->legalMoves, state->side_to_move(),
+    get_probs_of_move_list(0, probOutputs, evalInfo->legalMoves, state->mirror_policy(state->side_to_move()),
                            !net->is_policy_map(), evalInfo->policyProbSmall, net->is_policy_map());
     size_t selIdx = argmax(evalInfo->policyProbSmall);
     Action bestmove = evalInfo->legalMoves[selIdx];

--- a/engine/src/environments/chess_related/boardstate.cpp
+++ b/engine/src/environments/chess_related/boardstate.cpp
@@ -54,6 +54,16 @@ BoardState::BoardState(const BoardState &b) :
     states->emplace_back(b.states->back());
 }
 
+bool BoardState::mirror_policy(SideToMove sideToMove) const
+{
+#ifdef MODE_LICHESS
+    if (board.variant() == RACE_VARIANT) {
+        return false;
+    }
+#endif
+    return sideToMove != FIRST_PLAYER_IDX;
+}
+
 vector<Action> BoardState::legal_actions() const
 {
     vector<Action> legalMoves;

--- a/engine/src/environments/chess_related/boardstate.h
+++ b/engine/src/environments/chess_related/boardstate.h
@@ -268,6 +268,7 @@ public:
     BoardState(const BoardState& b);
 
     // State interface
+    bool mirror_policy(SideToMove sideToMove) const;
     vector<Action> legal_actions() const override;
     void set(const string &fenStr, bool isChess960, int variant) override;
     void get_state_planes(bool normalize, float *inputPlanes) const override;

--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -920,7 +920,7 @@ void Node::apply_temperature_to_prior_policy(float temperature)
     apply_temperature(policyProbSmall, temperature);
 }
 
-void Node::set_probabilities_for_moves(const float *data, SideToMove sideToMove)
+void Node::set_probabilities_for_moves(const float *data, bool mirrorPolicy)
 {
     // allocate sufficient memory -> is assumed that it has already been done
     assert(legalActions.size() == policyProbSmall.size());
@@ -929,12 +929,13 @@ void Node::set_probabilities_for_moves(const float *data, SideToMove sideToMove)
         // set the right prob value
         // accessing the data on the raw floating point vector is faster
         // than calling policyProb.At(batchIdx, vectorIdx)
-        if (sideToMove == FIRST_PLAYER_IDX) {
-            // use the look-up table for the first player
-            policyProbSmall[mvIdx] = data[StateConstants::action_to_index<normal,notMirrored>(legalActions[mvIdx])];
+        if (mirrorPolicy) {
+            // use mirrored action_to_index
+            policyProbSmall[mvIdx] = data[StateConstants::action_to_index<normal,mirrored>(legalActions[mvIdx])];
         }
         else {
-            policyProbSmall[mvIdx] = data[StateConstants::action_to_index<normal,mirrored>(legalActions[mvIdx])];
+            // use non-mirrored action_to_index
+            policyProbSmall[mvIdx] = data[StateConstants::action_to_index<normal,notMirrored>(legalActions[mvIdx])];
         }
     }
 }

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -289,7 +289,7 @@ public:
 
     DynamicVector<float>& get_policy_prob_small();
 
-    void set_probabilities_for_moves(const float *data, SideToMove sideToMove);
+    void set_probabilities_for_moves(const float *data, bool mirrorPolicy);
 
     void apply_softmax_to_policy();
 

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -282,9 +282,9 @@ void SearchThread::reset_stats()
     depthSum = 0;
 }
 
-void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, SideToMove sideToMove, const SearchSettings* searchSettings, bool isRootNodeTB)
+void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, bool mirrorPolicy, const SearchSettings* searchSettings, bool isRootNodeTB)
 {
-    node->set_probabilities_for_moves(get_policy_data_batch(batchIdx, probOutputs, isPolicyMap), sideToMove);
+    node->set_probabilities_for_moves(get_policy_data_batch(batchIdx, probOutputs, isPolicyMap), mirrorPolicy);
     node_post_process_policy(node, searchSettings->nodePolicyTemperature, isPolicyMap, searchSettings);
     node_assign_value(node, valueOutputs, tbHits, batchIdx, isRootNodeTB);
 #ifdef MCTS_STORE_STATES
@@ -298,7 +298,9 @@ void SearchThread::set_nn_results_to_child_nodes()
     size_t batchIdx = 0;
     for (auto node: *newNodes) {
         if (!node->is_terminal()) {
-            fill_nn_results(batchIdx, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, node, tbHits, newNodeSideToMove->get_element(batchIdx), searchSettings, rootNode->is_tablebase());
+            fill_nn_results(batchIdx, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, node,
+                            tbHits, rootState->mirror_policy(newNodeSideToMove->get_element(batchIdx)),
+                            searchSettings, rootNode->is_tablebase());
         }
         ++batchIdx;
     }

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -190,7 +190,7 @@ private:
 
 void run_search_thread(SearchThread *t);
 
-void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, SideToMove sideToMove, const SearchSettings* searchSettings, bool isRootNodeTB);
+void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, bool mirrorPolicy, const SearchSettings* searchSettings, bool isRootNodeTB);
 void node_post_process_policy(Node *node, float temperature, bool isPolicyMap, const SearchSettings* searchSettings);
 void node_assign_value(Node *node, const float* valueOutputs, size_t& tbHits, size_t batchIdx, bool isRootNodeTB);
 

--- a/engine/src/state.cpp
+++ b/engine/src/state.cpp
@@ -100,6 +100,11 @@ float State::random_rollout()
     return customEval;
 }
 
+bool State::mirror_policy(SideToMove sideToMove) const
+{
+    return sideToMove != FIRST_PLAYER_IDX;
+}
+
 bool is_win(Result res)
 {
     switch (res) {

--- a/engine/src/state.h
+++ b/engine/src/state.h
@@ -251,6 +251,13 @@ public:
     float random_rollout();
 
     /**
+     * @brief mirror_policy Decides if the policy should be mirrored given the current side to move.
+     * @param sideToMove Current side to move
+     * @return bool
+     */
+    bool mirror_policy(SideToMove sideToMove) const;
+
+    /**
      * @brief legal_actions Returns all legal actions as a vector list
      * @return vector of legal actions
      */


### PR DESCRIPTION
This PR allows the state environment to disable the policy.
This can be useful for environments such as racing kings.

Implementation is both available in python as well as C++.