### PR TITLE
RL: Save intermediate model files and delete them after training

### DIFF
--- a/engine/src/rl/fileio.py
+++ b/engine/src/rl/fileio.py
@@ -90,7 +90,7 @@ class FileIO:
         self.export_dir_gen_data = binary_dir + "export/new_data/" + variant_suffix
         self.train_dir = binary_dir + "export/train/" + variant_suffix
         self.val_dir = binary_dir + "export/val/" + variant_suffix
-        self.weight_dir = binary_dir+"weights/" + variant_suffix
+        self.weight_dir = binary_dir + "weights/" + variant_suffix
         self.train_dir_archive = binary_dir + "export/archive/train/" + variant_suffix
         self.val_dir_archive = binary_dir + "export/archive/val/" + variant_suffix
         self.model_contender_dir = binary_dir + "model_contender/" + variant_suffix
@@ -277,10 +277,19 @@ class FileIO:
         self._remove_files_in_weight_dir()
         self._include_data_from_replay_memory(rm_nb_files, rm_fraction_for_selection)
 
+    def remove_intermediate_weight_files(self):
+        """
+        Deletes all files (excluding folders) inside the weight directory
+        """
+        # Replace _weight_dir with self.weight_dir, if the trainer can save weights dynamically
+        _weight_dir = self.binary_dir + 'weights/'
+        files = glob.glob(_weight_dir + 'model-*')
+        for f in files:
+            os.remove(f)
+
     def replace_current_model_with_contender(self):
         """
         Moves the previous model into archive directory and the model-contender into the model directory
-        :return:
         """
         move_all_files(self.model_dir, self.model_dir_archive)
         move_all_files(self.model_contender_dir, self.model_dir)

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -150,6 +150,8 @@ class RLLoop:
             else:
                 logging.info("KEEPING current generator")
 
+            self.file_io.remove_intermediate_weight_files()
+
             self.binary_io.stop_process()
             self.rtpt.step()  # BUG: process changes it's name 1 iteration too late, fix?
             self.current_binary_name = change_binary_name(self.file_io.binary_dir, self.current_binary_name,

--- a/engine/src/rl/rl_training.py
+++ b/engine/src/rl/rl_training.py
@@ -109,7 +109,7 @@ def update_network(queue, nn_update_idx, symbol_filename, params_filename, conve
 
     train_objects.metrics = metrics_gluon
 
-    train_config.export_weights = False  # don't save intermediate weights
+    train_config.export_weights = True  # save intermediate results to handle spikes
     train_agent = TrainerAgent(net, val_data, train_config, train_objects, use_rtpt=False)
 
     # iteration counter used for the momentum and learning rate schedule


### PR DESCRIPTION
**Changes:**
* Removes a `bug`, where the GPU crashed if a spike occurred during training
* The spike could not load the latest model, because no intermediate models where saved during training
* Set `export_weights` in `rl_training.py` to true
* Added function in `fileio` that removes all model files in the weight directory
* Calling the function at the end of training

**TODO:**
* if a spike occures before the first intermediate model is saved, the GPU will still crash. A fix to this is a little more challenging, because the `rl_loop` saves the models in a different format and we cannot reconstruct the file name that the trainer class needs. 
