### PR TITLE
Fix channel ordering for flip_board() == False

### DIFF
--- a/DeepCrazyhouse/src/domain/variants/game_state.py
+++ b/DeepCrazyhouse/src/domain/variants/game_state.py
@@ -34,13 +34,15 @@ import chess
 from DeepCrazyhouse.src.domain.variants.input_representation import board_to_planes
 from DeepCrazyhouse.src.domain.abstract_cls.abs_game_state import AbsGameState
 from DeepCrazyhouse.configs.main_config import main_config
-from DeepCrazyhouse.src.domain.variants.constants import MODE, MODE_LICHESS
+from DeepCrazyhouse.src.domain.variants.input_representation import flip_board
 
 
-def mirror_policy(board: chess.Board):
-    if MODE == MODE_LICHESS and board.uci_variant == "racingkings":
-        return False
-    return board.turn == chess.BLACK
+def mirror_policy(board: chess.Board) -> bool:
+    """
+    Decides if the policy should be mirrored.
+    :param board: Chess board object
+    """
+    return flip_board(board)
 
 
 class GameState(AbsGameState):

--- a/DeepCrazyhouse/src/domain/variants/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/input_representation.py
@@ -44,9 +44,11 @@ from DeepCrazyhouse.configs.main_config import main_config
 def _fill_position_planes(planes_pos, board, board_occ=0, mode=MODE_CRAZYHOUSE):
 
     # Fill in the piece positions
+    me = board.turn
+    you = ~board.turn
 
     # Iterate over both color starting with WHITE
-    for idx, color in enumerate(chess.COLORS):
+    for idx, color in enumerate([me, you]):
         # the PIECE_TYPE is an integer list in python-chess
         for piece_type in chess.PIECE_TYPES:
             # define the channel by the piece_type (the input representation uses the same ordering as python-chess)
@@ -77,9 +79,9 @@ def _fill_position_planes(planes_pos, board, board_occ=0, mode=MODE_CRAZYHOUSE):
             # p_type -1 because p_type starts with 1
             channel = CHANNEL_MAPPING_POS["prisoners"] + p_type - 1
 
-            planes_pos[channel, :, :] = board.pockets[chess.WHITE].count(p_type)
+            planes_pos[channel, :, :] = board.pockets[me].count(p_type)
             # the prison for black begins 5 channels later
-            planes_pos[channel + 5, :, :] = board.pockets[chess.BLACK].count(p_type)
+            planes_pos[channel + 5, :, :] = board.pockets[you].count(p_type)
 
     # (III) Fill in the promoted pieces
     # iterate over all promoted pieces according to the mask and set the according bit
@@ -119,20 +121,22 @@ def _fill_constant_planes(planes_const, board, board_turn):
     # has_kingside_castling_rights() and has_queenside_castling_rights() support chess960, too
     channel = CHANNEL_MAPPING_CONST["castling"]
 
+    me = board.turn
+    you = ~board.turn
     # WHITE
     # check for King Side Castling
-    if board.has_kingside_castling_rights(chess.WHITE):
+    if board.has_kingside_castling_rights(me):
         planes_const[channel, :, :] = 1
     # check for Queen Side Castling
-    if board.has_queenside_castling_rights(chess.WHITE):
+    if board.has_queenside_castling_rights(me):
         planes_const[channel + 1, :, :] = 1
 
     # BLACK
     # check for King Side Castling
-    if board.has_kingside_castling_rights(chess.BLACK):
+    if board.has_kingside_castling_rights(you):
         planes_const[channel + 2, :, :] = 1
     # check for Queen Side Castling
-    if board.has_queenside_castling_rights(chess.BLACK):
+    if board.has_queenside_castling_rights(you):
         planes_const[channel + 3, :, :] = 1
 
     # (IV.4) No Progress Count
@@ -149,13 +153,13 @@ def _fill_constant_planes(planes_const, board, board_turn):
     # set the remaining checks (only needed for "3check")
     if board.uci_variant == "3check":
         channel = CHANNEL_MAPPING_CONST["remaining_checks"]
-        if board.remaining_checks[chess.WHITE] <= 2:
+        if board.remaining_checks[me] <= 2:
             planes_const[channel, :, :] = 1
-            if board.remaining_checks[chess.WHITE] == 1:
+            if board.remaining_checks[me] == 1:
                 planes_const[channel+1, :, :] = 1
-        if board.remaining_checks[chess.BLACK] <= 2:
+        if board.remaining_checks[you] <= 2:
             planes_const[channel+2, :, :] = 1
-            if board.remaining_checks[chess.BLACK] == 1:
+            if board.remaining_checks[you] == 1:
                 planes_const[channel+3, :, :] = 1
 
     return planes_const

--- a/DeepCrazyhouse/src/domain/variants/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/input_representation.py
@@ -39,6 +39,7 @@ from DeepCrazyhouse.src.domain.variants.constants import (
     VARIANT_MAPPING_BOARDS)
 from DeepCrazyhouse.src.domain.util import get_board_position_index, get_row_col, np
 from DeepCrazyhouse.configs.main_config import main_config
+from DeepCrazyhouse.src.domain.variants.constants import MODE, MODE_LICHESS
 
 
 def _fill_position_planes(planes_pos, board, board_occ=0, mode=MODE_CRAZYHOUSE):
@@ -179,15 +180,14 @@ def _fill_variants_plane(board, planes_variants):
             break
 
 
-def flip_board(board, mode,) -> bool:
+def flip_board(board) -> bool:
     """
     Decides whether to flip the board based on the side to move.
     If the board is the racing variant, flipping the board is disabled
     :param board: Board object
-    ;param mode: Active config mode
     :return: bool
     """
-    if mode == MODE_LICHESS and board.uci_variant == "racingkings":
+    if MODE == MODE_LICHESS and board.uci_variant == "racingkings":
         return False
     return board.turn == chess.BLACK
 
@@ -231,7 +231,7 @@ def board_to_planes(board, board_occ=0, normalize=True, mode=MODE_CRAZYHOUSE, la
         planes_variants = np.zeros((NB_CHANNELS_VARIANTS, BOARD_HEIGHT, BOARD_WIDTH))
 
     # check who's player turn it is and flip the board if it's black turn (except for racing kings)
-    mirror_board = flip_board(board, mode)
+    mirror_board = flip_board(board)
 
     if mirror_board:
         board = board.mirror()

--- a/engine/src/environments/chess_related/boardstate.cpp
+++ b/engine/src/environments/chess_related/boardstate.cpp
@@ -56,12 +56,7 @@ BoardState::BoardState(const BoardState &b) :
 
 bool BoardState::mirror_policy(SideToMove sideToMove) const
 {
-#ifdef MODE_LICHESS
-    if (board.variant() == RACE_VARIANT) {
-        return false;
-    }
-#endif
-    return sideToMove != FIRST_PLAYER_IDX;
+    return flip_board(board, sideToMove);
 }
 
 vector<Action> BoardState::legal_actions() const

--- a/engine/src/environments/chess_related/inputrepresentation.cpp
+++ b/engine/src/environments/chess_related/inputrepresentation.cpp
@@ -45,13 +45,13 @@ inline void set_bits_from_bitmap(Bitboard bitboard, float *curIt, bool flipBoard
     }
 }
 
-inline bool flip_board(const Board *pos) {
+inline bool flip_board(const Board& pos, SideToMove sideToMove) {
 #ifdef MODE_LICHESS
-    if (pos->is_race()) {
+    if (pos.is_race()) {
         return false;
     }
 #endif
-    return pos->side_to_move() == BLACK;
+    return sideToMove != FIRST_PLAYER_IDX;
 }
 
 struct PlaneData {
@@ -61,7 +61,7 @@ struct PlaneData {
     float* curIt;
     bool normalize;
     PlaneData(const Board* pos, float* inputPlanes, bool normalize):
-        pos(pos), flipBoard(flip_board(pos)), inputPlanes(inputPlanes), curIt(inputPlanes), normalize(normalize)
+        pos(pos), flipBoard(flip_board(*pos, pos->side_to_move())), inputPlanes(inputPlanes), curIt(inputPlanes), normalize(normalize)
     {
         // intialize the input_planes with 0
         std::fill_n(curIt, StateConstants::NB_VALUES_TOTAL(), 0.0f);

--- a/engine/src/environments/chess_related/inputrepresentation.cpp
+++ b/engine/src/environments/chess_related/inputrepresentation.cpp
@@ -441,21 +441,21 @@ inline void board_to_planes_v3(PlaneData& planeData, size_t boardRepetition)
     set_plane_pieces(planeData);
     set_plane_repetition(planeData, boardRepetition);
     set_plane_ep_square(planeData);
-    assert(planeData.currentChannel == StateConstants::NB_CHANNELS_POS());
+    assert(planeData.current_channel() == StateConstants::NB_CHANNELS_POS());
     set_plane_castling_rights(planeData);
     set_no_progress_counter(planeData);
-    assert(planeData.currentChannel == StateConstants::NB_CHANNELS_POS() + StateConstants::NB_CHANNELS_CONST());
+    assert(planeData.current_channel() == StateConstants::NB_CHANNELS_POS() + StateConstants::NB_CHANNELS_CONST());
     set_last_moves(planeData);
-    assert(planeData.currentChannel == StateConstants::NB_CHANNELS_POS() + StateConstants::NB_CHANNELS_CONST() + StateConstants::NB_LAST_MOVES() * StateConstants::NB_CHANNELS_PER_HISTORY());
+    assert(planeData.current_channel() == StateConstants::NB_CHANNELS_POS() + StateConstants::NB_CHANNELS_CONST() + StateConstants::NB_LAST_MOVES() * StateConstants::NB_CHANNELS_PER_HISTORY());
     set_960(planeData);
-    assert(planeData.currentChannel == StateConstants::NB_CHANNELS_POS() + StateConstants::NB_CHANNELS_CONST() + StateConstants::NB_LAST_MOVES() * StateConstants::NB_CHANNELS_PER_HISTORY() + StateConstants::NB_CHANNELS_VARIANTS());
+    assert(planeData.current_channel() == StateConstants::NB_CHANNELS_POS() + StateConstants::NB_CHANNELS_CONST() + StateConstants::NB_LAST_MOVES() * StateConstants::NB_CHANNELS_PER_HISTORY() + StateConstants::NB_CHANNELS_VARIANTS());
     set_piece_masks(planeData);
     set_checkerboard(planeData);
     set_material_diff(planeData);
     set_opposite_bishops(planeData);
     set_checkers(planeData);
     set_material_count(planeData);
-    assert(planeData.currentChannel == StateConstants::NB_CHANNELS_TOTAL());
+    assert(planeData.current_channel() == StateConstants::NB_CHANNELS_TOTAL());
 }
 #endif
 

--- a/engine/src/environments/chess_related/inputrepresentation.h
+++ b/engine/src/environments/chess_related/inputrepresentation.h
@@ -55,7 +55,7 @@ inline void set_bits_from_bitmap(Bitboard bitboard, float *curIt, bool flipBoard
  * @param pos Board object
  * @return bool
  */
-inline bool flip_board(const Board *pos);
+inline bool flip_board(const Board& pos, SideToMove sideToMove);
 
 
 #endif // INPUTREPRESENTATION_H

--- a/engine/tests/tests.cpp
+++ b/engine/tests/tests.cpp
@@ -263,7 +263,37 @@ TEST_CASE("Draw_by_insufficient_material"){
 #endif
 }
 
+#ifdef MODE_LICHESS
+TEST_CASE("Racing Kings No Mirror Test, Input Representation Version 2"){
 
+    // initial position
+    BoardState state;
+    state.init(RACE_VARIANT, false);
+    PlaneStatistics stats;
+    stats = get_planes_statistics(state, false);
+    REQUIRE(stats.sum == 208);
+    REQUIRE(stats.argMax == 68);
+    REQUIRE(stats.maxNum == 1);
+    REQUIRE(stats.key == 425624);
+
+    // black to move
+    state.set("8/8/8/8/8/6K1/krbnNBR1/qrbnNBRQ b - - 1 1", false, RACE_VARIANT);
+    stats = get_planes_statistics(state, false);
+    REQUIRE(stats.sum == 208);
+    REQUIRE(stats.argMax == 67);
+    REQUIRE(stats.maxNum == 1);
+    REQUIRE(stats.key == 450207);
+
+    // last moves
+    state.init(RACE_VARIANT, false);
+    apply_given_moves(state, {"h2g3"});
+    stats = get_planes_statistics(state, false);
+    REQUIRE(stats.sum == 210);
+    REQUIRE(stats.argMax == 67);
+    REQUIRE(stats.maxNum == 1);
+    REQUIRE(stats.key == 456324);
+}
+#endif
 
 #ifdef MODE_CHESS
 #if VERSION == 1


### PR DESCRIPTION
* Fixes channel ordering for `flip_board() == False and sideToMove == chess.BLACK` in python code.
* Added 3 unit-tests to ensure that `get_state_planes()` works properly for racing kings.
* `mirror_policy()` now depends on `flip_board()`.

Related PRs: #137, #107