### PR TITLE
TensorRT 8.0 Compability

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -387,11 +387,6 @@ if (BACKEND_TENSORRT)
     link_directories("$ENV{CUDA_PATH}/lib64")
     link_directories("$ENV{CUDA_PATH}/lib/x64")
     link_directories("$ENV{TENSORRT_PATH}/lib")
-if(WIN32)
-  find_library(TENSORRT_LIBRARY_MYELIN myelin64_1
-    HINTS  ${TENSORRT_PATH}
-    PATH_SUFFIXES lib lib64 lib/x64)
-endif()
     include_directories("$ENV{TENSORRT_PATH}/include")
     include_directories("$ENV{TENSORRT_PATH}/samples/common/")
     add_definitions(-DTENSORRT)
@@ -404,7 +399,7 @@ endif()
 add_executable(${PROJECT_NAME} ${source_files})
 
 if (BACKEND_TENSORRT)
-    target_link_libraries(${PROJECT_NAME} nvonnxparser nvinfer cudart myelin ${CUDART_LIB} ${CUBLAS_LIB} ${CUDNN_LIB})
+    target_link_libraries(${PROJECT_NAME} nvonnxparser nvinfer cudart ${CUDART_LIB} ${CUBLAS_LIB} ${CUDNN_LIB})
 endif()
 
 if (USE_RL)

--- a/engine/src/environments/chess_related/chessbatchstream.cpp
+++ b/engine/src/environments/chess_related/chessbatchstream.cpp
@@ -153,7 +153,13 @@ int ChessBatchStream::getBatchSize() const
 
 nvinfer1::Dims ChessBatchStream::getDims() const
 {
-    return Dims{4, {mBatchSize, mDims.d[0], mDims.d[1], mDims.d[2]}, {}};
+    Dims dims;
+    dims.nbDims = 4;
+    dims.d[0] = mBatchSize;
+    dims.d[1] = mDims.d[0];
+    dims.d[2] = mDims.d[1];
+    dims.d[3] = mDims.d[2];
+    return dims;
 }
 
 void reset_to_startpos(Board& pos, Thread* uiThread, StateListPtr& states)


### PR DESCRIPTION
This PR aims to enable TensorRT 8 support. 
* removed `myelin` from `CMakeLists.txt`
* updated `ChessBatchStream::getDims()`

Related issue: #109 
