### PR TITLE
Single Move Evaluation

### DIFF
--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -267,6 +267,18 @@ void MCTSAgent::update_stats()
     tbHits = get_tb_hits(searchThreads);
 }
 
+void MCTSAgent::handle_single_move()
+{
+    float targetEval = lastValueEval;
+#ifndef MCTS_SINGLE_PLAYER
+    if (lastSideToMove != state->side_to_move()) {
+        targetEval = -lastValueEval;
+    }
+#endif
+    rootNode->set_value(targetEval);
+    rootNode->set_q_value(0, targetEval);
+}
+
 void MCTSAgent::evaluate_board_state()
 {
     rootState = unique_ptr<StateObj>(state->clone());
@@ -278,6 +290,7 @@ void MCTSAgent::evaluate_board_state()
     evalInfo->isChess960 = state->is_chess960();
     if (rootNode->get_number_child_nodes() == 1) {
         info_string("Only single move available -> early stopping");
+        handle_single_move();
     }
     else if (rootNode->get_number_child_nodes() == 0) {
         info_string("The given position has no legal moves");
@@ -304,6 +317,7 @@ void MCTSAgent::evaluate_board_state()
     }
     update_eval_info(*evalInfo, rootNode.get(), tbHits, maxDepth, searchSettings);
     lastValueEval = evalInfo->bestMoveQ[0];
+    lastSideToMove = state->side_to_move();
     update_nps_measurement(evalInfo->calculate_nps());
 #ifndef USE_RL
     tGCThread.join();

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -65,6 +65,7 @@ public:
 
     MapWithMutex mapWithMutex;
     float lastValueEval;
+    SideToMove lastSideToMove;
 
     // boolean which indicates if the same node was requested twice for analysis
     bool reusedFullTree;
@@ -164,7 +165,12 @@ public:
      */
     void update_stats();
 
-public:
+    /**
+     * @brief handle_single_move Sets the value evaluation for a single move based on the last value evaluation.
+     * This is needed in cases the the tree is not reused for the next search to avoid artificats for the "bestQValue" feature.
+     */
+    void handle_single_move();
+
     /**
      * @brief reuse_tree Checks if the postion is know and if the tree or parts of the tree can be reused.
      * The old tree or former subtrees will be freed from memory.

--- a/engine/src/nn/neuralnetapi.cpp
+++ b/engine/src/nn/neuralnetapi.cpp
@@ -192,7 +192,7 @@ Version read_version_from_string(const string &modelFileName)
                 const string versionMajor = content.substr(prefix.size(), pointPos-prefix.size());  // skip "-v"
                 const string versionMinor = content.substr(pointPos+1);     // skip "."
                     return make_version(std::stoi(versionMajor), std::stoi(versionMinor), 0);
-                } catch (exception e) {
+                } catch (const exception& e) {
                     info_string(e.what());
                     break;
                 }

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -299,7 +299,7 @@ public:
      */
     void enhance_moves(const SearchSettings* searchSettings);
 
-    void set_value(float valueSum);
+    void set_value(float value);
     uint16_t main_child_idx_for_parent() const;
 
     /**
@@ -409,7 +409,7 @@ public:
      * @param idx Child index
      * @param value value to set
      */
-    void set_q_value(ChildIdx idx, float valueSum);
+    void set_q_value(ChildIdx idx, float value);
 
     /**
      * @brief get_best_q_idx Return the child index with the highest Q-value


### PR DESCRIPTION
Sets evaluation for rootNode in case of only a single legal available move based on the last search evaluation.
This avoids artificats for single moves in case the last tree is not re-used, e.g. reinforcement learning.
