### PR TITLE
Include binary name in Model_Directory and miscellaneous

### DIFF
--- a/engine/src/agents/config/searchsettings.cpp
+++ b/engine/src/agents/config/searchsettings.cpp
@@ -27,7 +27,7 @@
 
 SearchSettings::SearchSettings():
         threads(2),
-        batchSize(2),
+        batchSize(8),
         dirichletEpsilon(0.25f),
         dirichletAlpha(0.2f),
         nodePolicyTemperature(1.0f),

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -353,10 +353,13 @@ void MCTSAgent::run_mcts_search()
 
 void MCTSAgent::stop()
 {
-    isRunning = false;
+    if (!isRunning) {
+        return;
+    }
     if (threadManager != nullptr) {
         threadManager->stop_search();
     }
+    isRunning = false;
 }
 
 void MCTSAgent::print_root_node()

--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -53,7 +53,7 @@ const string engineName = "MultiAra";
 const string engineName = "ClassicAra";
 #endif
 
-const string engineVersion = "0.9.4";
+const string engineVersion = "0.9.5";
 const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al.";
 
 #define LOSS_VALUE -1

--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -49,12 +49,30 @@ using namespace std;
 const string engineName = "CrazyAra";
 #elif defined MODE_LICHESS
 const string engineName = "MultiAra";
+#elif defined MODE_XIANGQI
+const string engineName = "XiangqiAra";
+#elif defined MODE_STRATEGO
+const string engineName = "StrategoAra";
+#elif defined MODE_OPEN_SPIEL
+const string engineName = "OpenSpielAra";
 #else  // MODE_CHESS
 const string engineName = "ClassicAra";
 #endif
 
 const string engineVersion = "0.9.5";
-const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer et al.";
+#ifdef MODE_CRAZYHOUSE
+const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer and CrazyAra developers (see AUTHORS file)";
+#elif defined MODE_LICHESS
+const string engineAuthors = "Johannes Czech, Maximilian Alexander Gehrke and CrazyAra developers (see AUTHORS file)";
+#elif defined MODE_XIANGQI
+const string engineAuthors = "Johannes Czech, Maximilian Langer and CrazyAra developers (see AUTHORS file)";
+#elif defined MODE_STRATEGO
+const string engineAuthors = "Johannes Czech, Jannis Blüml and CrazyAra developers (see AUTHORS file)";
+#elif defined MODE_OPEN_SPIEL
+const string engineAuthors = "Johannes Czech and CrazyAra developers (see AUTHORS file)";
+#else  // MODE_CHESS
+const string engineAuthors = "Johannes Czech and CrazyAra developers (see AUTHORS file)";
+#endif
 
 #define LOSS_VALUE -1
 #define DRAW_VALUE 0

--- a/engine/src/rl/fileio.py
+++ b/engine/src/rl/fileio.py
@@ -70,7 +70,7 @@ class FileIO:
     Class to facilitate creation of directories, reading of file
     names and moving of files during Reinforcement Learning.
     """
-    def __init__(self, binary_dir: str, uci_variant: str):
+    def __init__(self, orig_binary_name: str, binary_dir: str, uci_variant: str):
         """
         Creates all necessary directories and sets all path variables.
         If no '*.param' file can be found in the 'binary-dir/model/' directory,
@@ -86,14 +86,14 @@ class FileIO:
             variant_suffix = f'{uci_variant}/'
 
         # Hard coded directory paths
-        self.model_dir = binary_dir + "model/" + variant_suffix
+        self.model_dir = binary_dir + "model/" + orig_binary_name + "/" + variant_suffix
         self.export_dir_gen_data = binary_dir + "export/new_data/" + variant_suffix
         self.train_dir = binary_dir + "export/train/" + variant_suffix
         self.val_dir = binary_dir + "export/val/" + variant_suffix
         self.weight_dir = binary_dir + "weights/" + variant_suffix
         self.train_dir_archive = binary_dir + "export/archive/train/" + variant_suffix
         self.val_dir_archive = binary_dir + "export/archive/val/" + variant_suffix
-        self.model_contender_dir = binary_dir + "model_contender/" + variant_suffix
+        self.model_contender_dir = binary_dir + "model_contender/" + orig_binary_name + "/" + variant_suffix
         self.model_dir_archive = binary_dir + "export/archive/model/" + variant_suffix
         self.logs_dir_archive = binary_dir + "export/logs/" + variant_suffix
         self.logs_dir = binary_dir + "logs"

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -48,7 +48,8 @@ class RLLoop:
         self.tc = TrainConfig()
         self.rl_config = rl_config
 
-        self.file_io = FileIO(binary_dir=self.rl_config.binary_dir, uci_variant=self.rl_config.uci_variant)
+        self.file_io = FileIO(orig_binary_name=self.rl_config.binary_name, binary_dir=self.rl_config.binary_dir,
+                              uci_variant=self.rl_config.uci_variant)
         self.binary_io = None
 
         if nb_arena_games % 2 == 1:

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -649,7 +649,6 @@ unique_ptr<MCTSAgent> CrazyAra::create_new_mcts_agent(NeuralNetAPI* netSingle, v
 {   
     switch (type) {
     case MCTSAgentType::kDefault:
-        info_string("TYP 0 -> Default");
         return make_unique<MCTSAgent>(netSingle, netBatches, searchSettings, &playSettings);
     case MCTSAgentType::kBatch1:
         info_string("TYP 1 -> Batch 1");

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -178,7 +178,7 @@ void OptionsUCI::init(OptionsMap &o)
     o["Centi_Resign_Threshold"]        << Option(-90, -100, 100);
     o["MaxInitPly"]                    << Option(30, 0, 99999);
     o["MeanInitPly"]                   << Option(15, 0, 99999);
-#ifdef LICHESS_MODE
+#ifdef MODE_LICHESS
     o["Model_Directory_Contender"]     << Option((string("model_contender/" + engineName + "/") + get_first_variant_with_model()).c_str());
 #else
     o["Model_Directory_Contender"]     << Option(string("model_contender/" + engineName + "/" + availableVariants.front()).c_str());
@@ -246,7 +246,7 @@ void OptionsUCI::setoption(istringstream &is, Variant& variant, StateObj& state)
             state.init(variant, is960);
 
             string suffix_960 = (is960) ? "960" : "";
-#ifdef LICHESS_MODE
+#ifdef MODE_LICHESS
             Options["Model_Directory"] << Option(("model/" + engineName + "/" + (string)Options["UCI_Variant"] + suffix_960).c_str());
             Options["Model_Directory_Contender"] << Option(("model_contender/" + engineName + "/" + (string)Options["UCI_Variant"] + suffix_960).c_str());
 #endif

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -154,17 +154,11 @@ void OptionsUCI::init(OptionsMap &o)
 #endif
     o["Threads"]                       << Option(2, 1, 512);
     o["Timeout_MS"]                    << Option(0, 0, 99999999);
-#ifdef MODE_CRAZYHOUSE
-      // we repeat "crazyhouse" in the list because of problem in XBoard/Winboard #23
-    o["UCI_Variant"]                   << Option("crazyhouse", {"crazyhouse", "crazyhouse"});
-#elif defined MODE_LICHESS
+#ifdef MODE_LICHESS
     o["UCI_Variant"]                   << Option(get_first_variant_with_model().c_str(), availableVariants);
-#elif defined MODE_XIANGQI
-    o["UCI_Variant"]                   << Option("xiangqi", {"xiangqi", "xiangqi"});
-#elif defined MODE_STRATEGO
-    o["UCI_Variant"]                   << Option("stratego", {"stratego", "stratego"});
-#else  // MODE = MODE_CHESS
-    o["UCI_Variant"]                   << Option("chess", {"chess", "chess"});
+#else
+    // we repeat e.g. "crazyhouse" in the list because of problem in XBoard/Winboard CrazyAra#23
+    o["UCI_Variant"]                   << Option(availableVariants.front().c_str(), {availableVariants.front().c_str(), availableVariants.front().c_str()});
 #endif
     o["Use_Raw_Network"]               << Option(false);
     // additional UCI-Options for RL only

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -103,16 +103,10 @@ void OptionsUCI::init(OptionsMap &o)
     o["Last_Device_ID"]                << Option(0, 0, 99999);
     o["Log_File"]                      << Option("", on_logger);
     o["MCTS_Solver"]                   << Option(true);
-#ifdef MODE_CRAZYHOUSE
-    o["Model_Directory"]               << Option("model/crazyhouse");
-#elif defined MODE_LICHESS
-    o["Model_Directory"]               << Option((string("model/") + get_first_variant_with_model()).c_str());
-#elif defined MODE_CHESS
-    o["Model_Directory"]               << Option("model/chess");
-#elif defined MODE_XIANGQI
-    o["Model_Directory"]               << Option("model/xiangqi");
+#ifdef MODE_LICHESS
+    o["Model_Directory"]               << Option((string("model/") + engineName + "/" + get_first_variant_with_model()).c_str());
 #else
-    o["Model_Directory"]               << Option("model");
+    o["Model_Directory"]               << Option(string("model/" + engineName + "/" + availableVariants.front()).c_str());
 #endif
     o["Move_Overhead"]                 << Option(20, 0, 5000);
     o["MultiPV"]                       << Option(1, 1, 99999);
@@ -125,7 +119,7 @@ void OptionsUCI::init(OptionsMap &o)
 #ifdef TENSORRT
     o["Precision"]                     << Option("float16", {"float32", "float16", "int8"});
 #else
-    o["Precision"]                     << Option("int8", {"float32", "int8"});
+    o["Precision"]                     << Option("float32", {"float32", "int8"});
 #endif
 #ifdef USE_RL
     o["Reuse_Tree"]                    << Option(false);
@@ -185,13 +179,9 @@ void OptionsUCI::init(OptionsMap &o)
     o["MaxInitPly"]                    << Option(30, 0, 99999);
     o["MeanInitPly"]                   << Option(15, 0, 99999);
 #ifdef LICHESS_MODE
-    o["Model_Directory_Contender"]     << Option((string("model_contender/") + get_first_variant_with_model()).c_str());
-#elif defined MODE_CHESS
-    o["Model_Directory_Contender"]     << Option("model_contender/chess");
-#elif defined MODE_XIANGQI
-    o["Model_Directory_Contender"]     << Option("model_contender/xiangqi");
+    o["Model_Directory_Contender"]     << Option((string("model_contender/" + engineName + "/") + get_first_variant_with_model()).c_str());
 #else
-    o["Model_Directory_Contender"]     << Option("model_contender/");
+    o["Model_Directory_Contender"]     << Option(string("model_contender/" + engineName + "/" + availableVariants.front()).c_str());
 #endif
     o["Selfplay_Number_Chunks"]        << Option(640, 1, 99999);
     o["Selfplay_Chunk_Size"]           << Option(128, 1, 99999);
@@ -256,8 +246,10 @@ void OptionsUCI::setoption(istringstream &is, Variant& variant, StateObj& state)
             state.init(variant, is960);
 
             string suffix_960 = (is960) ? "960" : "";
-            Options["Model_Directory"] << Option(("model/" + (string)Options["UCI_Variant"] + suffix_960).c_str());
-            Options["Model_Directory_Contender"] << Option(("model_contender/" + (string)Options["UCI_Variant"] + suffix_960).c_str());
+#ifdef LICHESS_MODE
+            Options["Model_Directory"] << Option(("model/" + engineName + "/" + (string)Options["UCI_Variant"] + suffix_960).c_str());
+            Options["Model_Directory_Contender"] << Option(("model_contender/" + engineName + "/" + (string)Options["UCI_Variant"] + suffix_960).c_str());
+#endif
             info_string_important("variant", (string)Options["UCI_Variant"] + suffix_960, "startpos", state.fen());
 #endif // not XIANGQI
         }
@@ -291,11 +283,11 @@ string OptionsUCI::check_uci_variant_input(const string &value, bool *is960) {
 
 const string OptionsUCI::get_first_variant_with_model()
 {
-    vector<string> dirs = get_directory_files("model/");
+    vector<string> dirs = get_directory_files("model/" + engineName + "/");
     for(string dir : dirs) {
         if (std::find(availableVariants.begin(), availableVariants.end(), dir) != availableVariants.end()) {
-            const vector <string> files = get_directory_files("model/" + dir);
-            if ("" != get_string_ending_with(files, "-bsize-1.onnx")) {
+            const vector <string> files = get_directory_files("model/" + engineName + "/" + dir);
+            if ("" != get_string_ending_with(files, ".onnx")) {
                 return dir;
             }
         }

--- a/engine/src/uci/variants.h
+++ b/engine/src/uci/variants.h
@@ -53,6 +53,15 @@ const static vector<string> availableVariants = {
     "3check",
     "threecheck", // 3check
 #endif
+#ifdef MODE_XIANGQI
+    "xiangqi",
+#endif
+#ifdef MODE_STRATEGO
+    "stratego",
+#endif
+#ifdef MODE_OPEN_SPIEL
+    "hex",
+#endif
 };
 
 // FEN strings of the initial positions


### PR DESCRIPTION
Added binary name as sub-directory in `Model_Directory` and `Model_Directory_Contender`
* this avoids conflicts between different binaries which both support the
same variant (e.g. crazyhouse and chess is supported by MultiAra, and
was already supported by CrazyAra and ClassicAra respectively)

## Miscellaneous
* fixed potential segfault when running "quit"
* set default batch-size in SearchSettings to 8
* increased engine version to 0.9.5
* set default precision for CPU back to float32
* specified engine authors in more detail
* updated `availableVariants` for `MODE_STRATEGO`, `MODE_OPENSPIEL`, `MODE_XIANGQI`
