### PR TITLE
OpenVino Backend

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -7,6 +7,7 @@ option(USE_RL                    "Build with reinforcement learning support"  OF
 option(BACKEND_TENSORRT          "Build with TensorRT support"  ON)
 option(BACKEND_MXNET             "Build with MXNet backend (Blas/IntelMKL/CUDA/TensorRT) support"  OFF)
 option(BACKEND_TORCH             "Build with Torch backend (CPU/GPU) support" OFF)
+option(BACKEND_OPENVINO          "Build with OpenVino backend (CPU/GPU) support" OFF)
 option(USE_960                   "Build with 960 variant support"  OFF)
 option(BUILD_TESTS               "Build and run tests"  OFF)
 option(USE_DYNAMIC_NN_ARCH       "Build with dynamic neural network architektur support"  ON)
@@ -381,6 +382,12 @@ if (BACKEND_TORCH)
     add_definitions(-DTORCH)
 endif()
 
+if (BACKEND_OPENVINO)
+    add_definitions(-DOPENVINO)
+    find_package(ngraph REQUIRED OPTIONAL_COMPONENTS onnx_importer)
+    find_package(InferenceEngine REQUIRED)
+endif()
+
 if (USE_RL)
     message(STATUS "Enabled Reinforcement Learning functionality")
     if(DEFINED ENV{Z5_PATH})
@@ -424,6 +431,16 @@ add_executable(${PROJECT_NAME} ${source_files})
 
 if (BACKEND_TENSORRT)
     target_link_libraries(${PROJECT_NAME} nvonnxparser nvinfer cudart ${CUDART_LIB} ${CUBLAS_LIB} ${CUDNN_LIB})
+endif()
+
+if (BACKEND_OPENVINO)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE IMPLEMENT_INFERENCE_EXTENSION_API)
+    target_link_libraries(${PROJECT_NAME} PRIVATE IE::inference_engine
+                                                 ${${OPEN_VINO_PATH}/deployment_tools/inference_engine/shareNGRAPH_LIBRARIES})
+    if (ngraph_onnx_importer_FOUND)
+        target_link_libraries(${PROJECT_NAME} PRIVATE ${ONNX_IMPORTER_LIBRARIES})
+        target_compile_definitions(${PROJECT_NAME} PRIVATE NGRAPH_ONNX_IMPORT_ENABLED)
+    endif()
 endif()
 
 if (USE_RL)

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -181,7 +181,7 @@ void MCTSAgent::create_new_root_node(StateObj* state)
     state->get_state_planes(true, inputPlanes, net->get_version());
     net->predict(inputPlanes, valueOutputs, probOutputs, auxiliaryOutputs);
     size_t tbHits = 0;
-    fill_nn_results(0, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, rootNode.get(), tbHits,
+    fill_nn_results(0, net->is_policy_map(), net->apply_softmax(), valueOutputs, probOutputs, auxiliaryOutputs, rootNode.get(), tbHits,
                     rootState->mirror_policy(state->side_to_move()), searchSettings, rootNode->is_tablebase());
 #endif
     rootNode->prepare_node_for_visits();

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -181,7 +181,7 @@ void MCTSAgent::create_new_root_node(StateObj* state)
     state->get_state_planes(true, inputPlanes, net->get_version());
     net->predict(inputPlanes, valueOutputs, probOutputs, auxiliaryOutputs);
     size_t tbHits = 0;
-    fill_nn_results(0, net->is_policy_map(), net->apply_softmax(), valueOutputs, probOutputs, auxiliaryOutputs, rootNode.get(), tbHits,
+    fill_nn_results(0, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, rootNode.get(), tbHits,
                     rootState->mirror_policy(state->side_to_move()), searchSettings, rootNode->is_tablebase());
 #endif
     rootNode->prepare_node_for_visits();

--- a/engine/src/constants.h
+++ b/engine/src/constants.h
@@ -59,7 +59,7 @@ const string engineName = "OpenSpielAra";
 const string engineName = "ClassicAra";
 #endif
 
-const string engineVersion = "0.9.5";
+const string engineVersion = "0.9.5.post0";
 #ifdef MODE_CRAZYHOUSE
 const string engineAuthors = "Johannes Czech, Moritz Willig, Alena Beyer and CrazyAra developers (see AUTHORS file)";
 #elif defined MODE_LICHESS

--- a/engine/src/nn/neuralnetapi.cpp
+++ b/engine/src/nn/neuralnetapi.cpp
@@ -205,7 +205,7 @@ Version read_version_from_string(const string &modelFileName)
 
 void apply_softmax(float* input, size_t size) {
 
-    assert(0 <= size <= sizeof(input) / sizeof(double));
+    assert(size <= sizeof(input) / sizeof(double));
 
     size_t idx;
     double maximum = -INFINITY;

--- a/engine/src/nn/neuralnetapi.cpp
+++ b/engine/src/nn/neuralnetapi.cpp
@@ -207,3 +207,26 @@ Version read_version_from_string(const string &modelFileName)
     // unsuccessfull
     return make_version<0,0,0>();
 }
+
+void softmax(float* input, size_t size) {
+
+    assert(0 <= size <= sizeof(input) / sizeof(double));
+
+    size_t idx;
+    double maximum = -INFINITY;
+    for (idx = 0; idx < size; ++idx) {
+        if (maximum < input[idx]) {
+            maximum = input[idx];
+        }
+    }
+
+    double sum = 0.0;
+    for (idx = 0; idx < size; ++idx) {
+        sum += exp(input[idx] - maximum);
+    }
+
+    double constant = maximum + log(sum);
+    for (idx = 0; idx < size; ++idx) {
+        input[idx] = exp(input[idx] - constant);
+    }
+}

--- a/engine/src/nn/neuralnetapi.cpp
+++ b/engine/src/nn/neuralnetapi.cpp
@@ -101,11 +101,6 @@ bool NeuralNetAPI::is_policy_map() const
     return nnDesign.isPolicyMap;
 }
 
-bool NeuralNetAPI::apply_softmax() const
-{
-    return nnDesign.applySoftmax;
-}
-
 string NeuralNetAPI::get_model_name() const
 {
     return modelName;
@@ -208,7 +203,7 @@ Version read_version_from_string(const string &modelFileName)
     return make_version<0,0,0>();
 }
 
-void softmax(float* input, size_t size) {
+void apply_softmax(float* input, size_t size) {
 
     assert(0 <= size <= sizeof(input) / sizeof(double));
 

--- a/engine/src/nn/neuralnetapi.cpp
+++ b/engine/src/nn/neuralnetapi.cpp
@@ -101,6 +101,11 @@ bool NeuralNetAPI::is_policy_map() const
     return nnDesign.isPolicyMap;
 }
 
+bool NeuralNetAPI::apply_softmax() const
+{
+    return nnDesign.applySoftmax;
+}
+
 string NeuralNetAPI::get_model_name() const
 {
     return modelName;

--- a/engine/src/nn/neuralnetapi.h
+++ b/engine/src/nn/neuralnetapi.h
@@ -287,4 +287,14 @@ protected:
  */
 string parse_directory(const string& directory);
 
+/**
+ * @brief softmax Applies the softmax activation on a given data array.
+ * This method is based on an implementation by "SlayStudy":
+ * https://slaystudy.com/implementation-of-softmax-activation-function-in-c-c/
+ * @param input Data array
+ * @param size Length on how many values to apply softmax
+ */
+void softmax(float* input, size_t size);
+
+
 #endif // NEURALNETAPI_H

--- a/engine/src/nn/neuralnetapi.h
+++ b/engine/src/nn/neuralnetapi.h
@@ -188,12 +188,6 @@ public:
     bool is_policy_map() const;
 
     /**
-     * @brief apply_softmax Decides if the softmax activation function should be applied to the policy output.
-     * @return bool
-     */
-    bool apply_softmax() const;
-
-    /**
      * @brief get_model_name Returns the name of the model based on the loaded parameter/weight file
      * @return string
      */
@@ -288,13 +282,13 @@ protected:
 string parse_directory(const string& directory);
 
 /**
- * @brief softmax Applies the softmax activation on a given data array.
+ * @brief apply_softmax Applies the softmax activation on a given data array.
  * This method is based on an implementation by "SlayStudy":
  * https://slaystudy.com/implementation-of-softmax-activation-function-in-c-c/
  * @param input Data array
  * @param size Length on how many values to apply softmax
  */
-void softmax(float* input, size_t size);
+void apply_softmax(float* input, size_t size);
 
 
 #endif // NEURALNETAPI_H

--- a/engine/src/nn/neuralnetapi.h
+++ b/engine/src/nn/neuralnetapi.h
@@ -46,8 +46,7 @@ vector<string> get_directory_files(const string& dir) {
     shared_ptr<DIR> directory_ptr(opendir(dir.c_str()), [](DIR* dir){ dir && closedir(dir); });
     struct dirent *dirent_ptr;
     if (!directory_ptr) {
-        info_string("Error opening :", strerror(errno));
-        info_string(dir);
+        info_string_important("Error opening :", dir, "(" + string(strerror(errno)) + ")");
         return files;
     }
 
@@ -187,6 +186,12 @@ public:
      * @return bool
      */
     bool is_policy_map() const;
+
+    /**
+     * @brief apply_softmax Decides if the softmax activation function should be applied to the policy output.
+     * @return bool
+     */
+    bool apply_softmax() const;
 
     /**
      * @brief get_model_name Returns the name of the model based on the loaded parameter/weight file

--- a/engine/src/nn/neuralnetdesign.h
+++ b/engine/src/nn/neuralnetdesign.h
@@ -56,12 +56,13 @@ std::ostream& operator<<(std::ostream& os, const Shape& shape);
  */
 struct NeuralNetDesign {
     bool isPolicyMap = false;
+    bool applySoftmax = false;
     bool hasAuxiliaryOutputs = false;
     const int nbInputs = 1;
     const string inputLayerName = "data";
-    const string policyOutputName = "policy_out";
+    string policyOutputName = "policy_out";  // may be adjusted using "policyOutputIdx" if not found
     const string policySoftmaxOutputName = "policy_softmax";
-    const string valueOutputName = "value_out";
+    string valueOutputName = "value_out";  // may be adjusted using "valueOutputIdx" if not found
     const string auxiliaryOutputName = "auxiliary_out";
     const int inputIdx = 0;
     const int valueOutputIdx = 0;

--- a/engine/src/nn/neuralnetdesign.h
+++ b/engine/src/nn/neuralnetdesign.h
@@ -56,7 +56,6 @@ std::ostream& operator<<(std::ostream& os, const Shape& shape);
  */
 struct NeuralNetDesign {
     bool isPolicyMap = false;
-    bool applySoftmax = false;
     bool hasAuxiliaryOutputs = false;
     const int nbInputs = 1;
     const string inputLayerName = "data";

--- a/engine/src/nn/openvinoapi.cpp
+++ b/engine/src/nn/openvinoapi.cpp
@@ -27,8 +27,10 @@
 #include "openvinoapi.h"
 #include "stateobj.h"
 
-OpenVinoAPI::OpenVinoAPI(int deviceID, unsigned int batchSize, const string &modelDirectory, const string& strPrecision):
-    NeuralNetAPI("gpu", deviceID, batchSize, modelDirectory, true)
+OpenVinoAPI::OpenVinoAPI(int deviceID, unsigned int batchSize, const string &modelDirectory, size_t threadsNNInference):
+    NeuralNetAPI("gpu", deviceID, batchSize, modelDirectory, true),
+    rawInputData(nullptr),
+    threadsNNInference(threadsNNInference)
 {
     modelName = get_file_ending_with(modelDir, "-bsize-" + to_string(batchSize) + ".onnx");
     modelFilePath = modelDir + "/" + modelName;
@@ -83,7 +85,10 @@ void OpenVinoAPI::load_model()
 void OpenVinoAPI::load_parameters()
 {
     // load the model to the device
-    executableNetwork = core.LoadNetwork(network, "CPU");
+    std::map<std::string, std::string> config = {
+        { InferenceEngine::PluginConfigParams::KEY_CPU_THREADS_NUM, std::to_string(threadsNNInference).c_str() }
+    };
+    executableNetwork = core.LoadNetwork(network, "CPU", config);
 }
 
 void OpenVinoAPI::bind_executor()

--- a/engine/src/nn/openvinoapi.cpp
+++ b/engine/src/nn/openvinoapi.cpp
@@ -23,6 +23,7 @@
  * @author: queensgambit
  */
 
+#ifdef OPENVINO
 #include "openvinoapi.h"
 #include "stateobj.h"
 
@@ -134,3 +135,4 @@ void set_shape(nn_api::Shape& shape, const InferenceEngine::SizeVector& sizeVect
         shape.v[idx] = sizeVector[idx];
     }
 }
+#endif

--- a/engine/src/nn/openvinoapi.cpp
+++ b/engine/src/nn/openvinoapi.cpp
@@ -1,0 +1,136 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: openvinoapi.cpp
+ * Created on 29.08.2021
+ * @author: queensgambit
+ */
+
+#include "openvinoapi.h"
+#include "stateobj.h"
+
+OpenVinoAPI::OpenVinoAPI(int deviceID, unsigned int batchSize, const string &modelDirectory, const string& strPrecision):
+    NeuralNetAPI("gpu", deviceID, batchSize, modelDirectory, true)
+{
+    modelName = get_file_ending_with(modelDir, "-bsize-" + to_string(batchSize) + ".onnx");
+    modelFilePath = modelDir + "/" + modelName;
+    initialize();
+}
+
+void OpenVinoAPI::set_nn_value_policy_shape()
+{
+    if (outputInfo.find(nnDesign.policyOutputName) == outputInfo.end() || outputInfo.find(nnDesign.valueOutputName) == outputInfo.end()) {
+        info_string_important(nnDesign.policyOutputName, " or ", nnDesign.valueOutputName, "not found. Fallback to default indices.");
+        nnDesign.valueOutputName = outputInfo.begin()->first;
+        nnDesign.policyOutputName = outputInfo.rbegin()->first;
+    }
+    set_shape(nnDesign.valueOutputShape, outputInfo.begin()->second.get()->getDims());
+    set_shape(nnDesign.policyOutputShape, outputInfo.rbegin()->second.get()->getDims());
+
+    set_shape(nnDesign.policyOutputShape, outputInfo.at(nnDesign.policyOutputName).get()->getDims());
+    set_shape(nnDesign.valueOutputShape, outputInfo.at(nnDesign.valueOutputName).get()->getDims());
+}
+
+void OpenVinoAPI::init_nn_design()
+{
+    set_shape(nnDesign.inputShape, network.getInputShapes().at("data"));
+    set_nn_value_policy_shape();
+
+    nnDesign.hasAuxiliaryOutputs = outputInfo.size() > 2;
+    if (nnDesign.hasAuxiliaryOutputs) {
+        set_shape(nnDesign.auxiliaryOutputShape, outputInfo.at(nnDesign.auxiliaryOutputName).get()->getDims());
+    }
+    nnDesign.isPolicyMap = uint(nnDesign.policyOutputShape.v[1]) != (StateConstants::NB_LABELS());
+    policyOutputLength = nnDesign.policyOutputShape.v[1] * batchSize;
+    nnDesign.applySoftmax = true;
+
+    nbNNInputValues = nnDesign.inputShape.flatten();
+}
+
+void OpenVinoAPI::load_model()
+{
+    // load the model architecture
+    network = core.ReadNetwork(modelFilePath);
+
+    // get information about all topology inputs
+    inputInfo = network.getInputsInfo();
+    // get information about all topology outputs
+    outputInfo = network.getOutputsInfo();
+
+    // set precision and layout for input data
+    inputInfo.at(nnDesign.inputLayerName)->setLayout(InferenceEngine::Layout::NCHW);
+    inputInfo.at(nnDesign.inputLayerName)->setPrecision(InferenceEngine::Precision::FP32);
+
+    // set precision for outputs
+    for (auto output : outputInfo) {
+        output.second->setPrecision(InferenceEngine::Precision::FP32);
+    }
+}
+
+void OpenVinoAPI::load_parameters()
+{
+    // load the model to the device
+    executableNetwork = core.LoadNetwork(network, "CPU");
+}
+
+void OpenVinoAPI::bind_executor()
+{
+    // create an infer request
+    inferRequest = executableNetwork.CreateInferRequest();
+
+    // allocate required objects before the actual inference
+    inputBlob = inferRequest.GetBlob(nnDesign.inputLayerName);
+    inputBlob->allocate();
+    rawInputData = inputBlob->buffer().as<InferenceEngine::PrecisionTrait<InferenceEngine::Precision::FP32>::value_type *>();
+
+    inferRequest.SetBlob(nnDesign.inputLayerName, inputBlob);
+}
+
+
+void OpenVinoAPI::predict(float *inputPlanes, float *valueOutput, float *probOutputs, float *auxiliaryOutputs)
+{
+    // copy over the input planes into the raw data cotainer
+    std::copy(inputPlanes, inputPlanes + batchSize * get_nb_input_values_total(), rawInputData);
+
+    // run the request synchronously
+    inferRequest.Infer();
+
+    // process outputs
+    outputBlobValue = inferRequest.GetBlob(nnDesign.valueOutputName);
+    outputBlobPolicy = inferRequest.GetBlob(nnDesign.policyOutputName);
+
+    auto const memLockerValue = outputBlobValue->cbuffer(); // use const memory locker
+    auto const memLockerPolicy = outputBlobPolicy->cbuffer(); // use const memory locker
+
+    const float* outputBufferValue = memLockerValue.as<const float *>();
+    const float* outputBufferPolicy = memLockerPolicy.as<const float *>();
+
+    // copy the outputs to the given pointers
+    std::copy(outputBufferValue, outputBufferValue + batchSize, valueOutput);
+    std::copy(outputBufferPolicy, outputBufferPolicy + get_policy_output_length(), probOutputs);
+}
+
+void set_shape(nn_api::Shape& shape, const InferenceEngine::SizeVector& sizeVector)
+{
+    shape.nbDims = sizeVector.size();
+    for (int idx = 0; idx < shape.nbDims; ++idx) {
+        shape.v[idx] = sizeVector[idx];
+    }
+}

--- a/engine/src/nn/openvinoapi.cpp
+++ b/engine/src/nn/openvinoapi.cpp
@@ -42,9 +42,6 @@ void OpenVinoAPI::set_nn_value_policy_shape()
         nnDesign.valueOutputName = outputInfo.begin()->first;
         nnDesign.policyOutputName = outputInfo.rbegin()->first;
     }
-    set_shape(nnDesign.valueOutputShape, outputInfo.begin()->second.get()->getDims());
-    set_shape(nnDesign.policyOutputShape, outputInfo.rbegin()->second.get()->getDims());
-
     set_shape(nnDesign.policyOutputShape, outputInfo.at(nnDesign.policyOutputName).get()->getDims());
     set_shape(nnDesign.valueOutputShape, outputInfo.at(nnDesign.valueOutputName).get()->getDims());
 }

--- a/engine/src/nn/openvinoapi.cpp
+++ b/engine/src/nn/openvinoapi.cpp
@@ -122,7 +122,7 @@ void OpenVinoAPI::predict(float *inputPlanes, float *valueOutput, float *probOut
     std::copy(outputBufferPolicy, outputBufferPolicy + get_policy_output_length(), probOutputs);
 
     for (unsigned int batchIdx = 0; batchIdx < batchSize; ++batchIdx) {
-        softmax(probOutputs + batchIdx * nnDesign.policyOutputShape.v[1], nnDesign.policyOutputShape.v[1]);
+        apply_softmax(probOutputs + batchIdx * nnDesign.policyOutputShape.v[1], nnDesign.policyOutputShape.v[1]);
     }
 }
 

--- a/engine/src/nn/openvinoapi.h
+++ b/engine/src/nn/openvinoapi.h
@@ -31,6 +31,7 @@
 #ifndef OPENVINOAPI_H
 #define OPENVINOAPI_H
 
+#ifdef OPENVINO
 #include "neuralnetapi.h"
 
 #include <ie_core.hpp>
@@ -75,5 +76,7 @@ public:
  * @param dims Target object
  */
 void set_shape(nn_api::Shape& shape, const InferenceEngine::SizeVector& sizeVector);
+
+#endif
 
 #endif // OPENVINOAPI_H

--- a/engine/src/nn/openvinoapi.h
+++ b/engine/src/nn/openvinoapi.h
@@ -54,8 +54,9 @@ private:
 
     InferenceEngine::Blob::Ptr outputBlobValue;
     InferenceEngine::Blob::Ptr outputBlobPolicy;
+    size_t threadsNNInference;
 public:
-    OpenVinoAPI(int deviceID, unsigned int batchSize, const string &modelDirectory, const string& strPrecision);
+    OpenVinoAPI(int deviceID, unsigned int batchSize, const string &modelDirectory, size_t threadsNNInference);
 
     // NeuralNetAPI interface
 private:

--- a/engine/src/nn/openvinoapi.h
+++ b/engine/src/nn/openvinoapi.h
@@ -1,0 +1,79 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: openvinoapi.h
+ * Created on 29.08.2021
+ * @author: queensgambit
+ *
+ * This file describes the Intel OpenVino interface for CrazyAra networks.
+ * More information about OpenVino can be found at:
+ * https://github.com/openvinotoolkit/openvino
+ * https://docs.openvinotoolkit.org/latest/openvino_docs_IE_DG_Integrate_with_customer_application_new_API.html
+ */
+
+#ifndef OPENVINOAPI_H
+#define OPENVINOAPI_H
+
+#include "neuralnetapi.h"
+
+#include <ie_core.hpp>
+
+
+/**
+ * @brief The OpenVinoAPI class provides a compatible interface to use CrazyAra networks in the ONNX format using the OpenVino API.
+ */
+class OpenVinoAPI : public NeuralNetAPI
+{
+private:
+    InferenceEngine::Core core;
+    InferenceEngine::CNNNetwork network;
+    InferenceEngine::ExecutableNetwork executableNetwork;
+    InferenceEngine::InputsDataMap inputInfo;
+    InferenceEngine::OutputsDataMap outputInfo;
+    InferenceEngine::InferRequest inferRequest;
+    InferenceEngine::Blob::Ptr inputBlob;
+    float* rawInputData;
+
+    InferenceEngine::Blob::Ptr outputBlobValue;
+    InferenceEngine::Blob::Ptr outputBlobPolicy;
+public:
+    OpenVinoAPI(int deviceID, unsigned int batchSize, const string &modelDirectory, const string& strPrecision);
+
+    // NeuralNetAPI interface
+private:
+    void init_nn_design() override;
+    void load_model() override;
+    void load_parameters() override;
+    void bind_executor() override;
+
+    // helper methods
+    void set_nn_value_policy_shape();
+public:
+    void predict(float *inputPlanes, float *valueOutput, float *probOutputs, float *auxiliaryOutputs) override;
+};
+
+/**
+ * @brief set_shape Converter function from InferenceEngine::SizeVector to nn_api::Shape
+ * @param shape Shape object to be set
+ * @param dims Target object
+ */
+void set_shape(nn_api::Shape& shape, const InferenceEngine::SizeVector& sizeVector);
+
+#endif // OPENVINOAPI_H

--- a/engine/src/nn/tensorrtapi.cpp
+++ b/engine/src/nn/tensorrtapi.cpp
@@ -125,7 +125,6 @@ bool TensorrtAPI::retrieve_indices_by_name(bool verbose)
 void TensorrtAPI::init_nn_design()
 {
     nnDesign.hasAuxiliaryOutputs = engine->getNbBindings() > 3;
-
     if (!retrieve_indices_by_name(generatedTrtFromONNX)) {
         info_string_important("Fallback to default indices.");
         idxInput = nnDesign.inputIdx;
@@ -305,7 +304,7 @@ void TensorrtAPI::configure_network(SampleUniquePtr<nvinfer1::INetworkDefinition
         }
     }
     if (policyOutputIdx == -1) {
-        info_string("Did not find policy output with name '", nnDesign.policyOutputName, "'");
+        info_string("Did not find policy output with name '" + nnDesign.policyOutputName + "'");
         info_string("Setting policyOutputIdx to:", nnDesign.policyOutputIdx);
         policyOutputIdx = nnDesign.policyOutputIdx;
     }

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -282,10 +282,10 @@ void SearchThread::reset_stats()
     depthSum = 0;
 }
 
-void fill_nn_results(size_t batchIdx, bool isPolicyMap, bool applySoftmax, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, bool mirrorPolicy, const SearchSettings* searchSettings, bool isRootNodeTB)
+void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, bool mirrorPolicy, const SearchSettings* searchSettings, bool isRootNodeTB)
 {
     node->set_probabilities_for_moves(get_policy_data_batch(batchIdx, probOutputs, isPolicyMap), mirrorPolicy);
-    node_post_process_policy(node, searchSettings->nodePolicyTemperature, applySoftmax, searchSettings);
+    node_post_process_policy(node, searchSettings->nodePolicyTemperature, searchSettings);
     node_assign_value(node, valueOutputs, tbHits, batchIdx, isRootNodeTB);
 #ifdef MCTS_STORE_STATES
     node->set_auxiliary_outputs(get_auxiliary_data_batch(batchIdx, auxiliaryOutputs));
@@ -298,7 +298,7 @@ void SearchThread::set_nn_results_to_child_nodes()
     size_t batchIdx = 0;
     for (auto node: *newNodes) {
         if (!node->is_terminal()) {
-            fill_nn_results(batchIdx, net->is_policy_map(), net->apply_softmax(), valueOutputs, probOutputs, auxiliaryOutputs, node,
+            fill_nn_results(batchIdx, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, node,
                             tbHits, rootState->mirror_policy(newNodeSideToMove->get_element(batchIdx)),
                             searchSettings, rootNode->is_tablebase());
         }
@@ -462,11 +462,8 @@ void node_assign_value(Node *node, const float* valueOutputs, size_t& tbHits, si
     node->set_value(valueOutputs[batchIdx]);
 }
 
-void node_post_process_policy(Node *node, float temperature, bool applySoftmax, const SearchSettings* searchSettings)
+void node_post_process_policy(Node *node, float temperature, const SearchSettings* searchSettings)
 {
-    if (applySoftmax) {
-        node->apply_softmax_to_policy();
-    }
     node->enhance_moves(searchSettings);
     node->apply_temperature_to_prior_policy(temperature);
 }

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -190,8 +190,8 @@ private:
 
 void run_search_thread(SearchThread *t);
 
-void fill_nn_results(size_t batchIdx, bool isPolicyMap, bool applySoftmax, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, bool mirrorPolicy, const SearchSettings* searchSettings, bool isRootNodeTB);
-void node_post_process_policy(Node *node, float temperature, bool applySoftmax, const SearchSettings* searchSettings);
+void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, bool mirrorPolicy, const SearchSettings* searchSettings, bool isRootNodeTB);
+void node_post_process_policy(Node *node, float temperature, const SearchSettings* searchSettings);
 void node_assign_value(Node *node, const float* valueOutputs, size_t& tbHits, size_t batchIdx, bool isRootNodeTB);
 
 /**

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -190,8 +190,8 @@ private:
 
 void run_search_thread(SearchThread *t);
 
-void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, bool mirrorPolicy, const SearchSettings* searchSettings, bool isRootNodeTB);
-void node_post_process_policy(Node *node, float temperature, bool isPolicyMap, const SearchSettings* searchSettings);
+void fill_nn_results(size_t batchIdx, bool isPolicyMap, bool applySoftmax, const float* valueOutputs, const float* probOutputs, const float* auxiliaryOutputs, Node *node, size_t& tbHits, bool mirrorPolicy, const SearchSettings* searchSettings, bool isRootNodeTB);
+void node_post_process_policy(Node *node, float temperature, bool applySoftmax, const SearchSettings* searchSettings);
 void node_assign_value(Node *node, const float* valueOutputs, size_t& tbHits, size_t batchIdx, bool isRootNodeTB);
 
 /**

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -602,7 +602,7 @@ unique_ptr<NeuralNetAPI> CrazyAra::create_new_net_single(const string& modelDire
 #elif defined TENSORRT
     return make_unique<TensorrtAPI>(int(Options["First_Device_ID"]), 1, modelDirectory, Options["Precision"]);
 #elif defined OPENVINO
-    return make_unique<OpenVinoAPI>(int(Options["First_Device_ID"]), 1, modelDirectory, Options["Precision"]);
+    return make_unique<OpenVinoAPI>(int(Options["First_Device_ID"]), 1, modelDirectory, Options["Threads_NN_Inference"]);
 #endif
     return nullptr;
 }
@@ -624,7 +624,7 @@ vector<unique_ptr<NeuralNetAPI>> CrazyAra::create_new_net_batches(const string& 
     #elif defined TENSORRT
             netBatches.push_back(make_unique<TensorrtAPI>(deviceId, searchSettings.batchSize, modelDirectory, Options["Precision"]));
     #elif defined OPENVINO
-            netBatches.push_back(make_unique<OpenVinoAPI>(deviceId, searchSettings.batchSize, modelDirectory, Options["Precision"]));
+            netBatches.push_back(make_unique<OpenVinoAPI>(deviceId, searchSettings.batchSize, modelDirectory, Options["Threads_NN_Inference"]));
     #endif
         }
     }

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -50,6 +50,8 @@
 #include "nn/mxnetapi.h"
 #elif defined TENSORRT
 #include "nn/tensorrtapi.h"
+#elif defined OPENVINO
+#include "nn/openvinoapi.h"
 #endif
 
 
@@ -599,6 +601,8 @@ unique_ptr<NeuralNetAPI> CrazyAra::create_new_net_single(const string& modelDire
     return make_unique<MXNetAPI>(Options["Context"], int(Options["First_Device_ID"]), 1, modelDirectory, Options["Precision"], false);
 #elif defined TENSORRT
     return make_unique<TensorrtAPI>(int(Options["First_Device_ID"]), 1, modelDirectory, Options["Precision"]);
+#elif defined OPENVINO
+    return make_unique<OpenVinoAPI>(int(Options["First_Device_ID"]), 1, modelDirectory, Options["Precision"]);
 #endif
     return nullptr;
 }
@@ -619,6 +623,8 @@ vector<unique_ptr<NeuralNetAPI>> CrazyAra::create_new_net_batches(const string& 
             netBatches.push_back(make_unique<MXNetAPI>(Options["Context"], deviceId, searchSettings.batchSize, modelDirectory, Options["Precision"], useTensorRT));
     #elif defined TENSORRT
             netBatches.push_back(make_unique<TensorrtAPI>(deviceId, searchSettings.batchSize, modelDirectory, Options["Precision"]));
+    #elif defined OPENVINO
+            netBatches.push_back(make_unique<OpenVinoAPI>(deviceId, searchSettings.batchSize, modelDirectory, Options["Precision"]));
     #endif
         }
     }


### PR DESCRIPTION
This PR provides a compatible interface to use _CrazyAra_ networks in the ONNX format using the [**OpenVino**](https://docs.openvinotoolkit.org) API.
The OpenVino API can be used with CPUs, Intel Neural Compute Sticks and Intel GPUs.
For now only CPUs are supported.

The following environment variable must be set to build using `BACKEND_OPENVINO`:
```bash
OPEN_VINO_PATH=/opt/intel/openvino_2021/
ngraph_DIR=/opt/intel/openvino_2021/deployment_tools/ngraph/cmake/
InferenceEngine_DIR=/opt/intel/openvino_2021/deployment_tools/inference_engine/share
```

:warning: This PR also fixes a bug of applying softmax twice for `isPolicyMap==false`.