### PR TITLE
Fix terminal solver for MCTS_SINGLE_PLAYER

### DIFF
--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -144,23 +144,18 @@ bool Node::at_least_one_drawn_child() const
 
 bool Node::only_won_child_nodes() const
 {
-    for (auto it = d->childNodes.begin(); it != d->childNodes.end(); ++it) {
-        const Node* childNode = it->get();
-        if (childNode->d->nodeType != WIN) {
-            return false;
-        }
-    }
-    return true;
+    return only_child_nodes_of_one_kind<WIN>();
 }
 
 bool Node::solved_loss(const Node* childNode) const
 {
 #ifndef MCTS_SINGLE_PLAYER
     if (d->numberUnsolvedChildNodes == 0 && childNode->d->nodeType == WIN) {
+        return only_won_child_nodes();
 #else
     if (d->numberUnsolvedChildNodes == 0 && childNode->d->nodeType == LOSS) {
+        return only_child_nodes_of_one_kind<LOSS>();
 #endif
-        return only_won_child_nodes();
     }
     return false;
 }
@@ -210,23 +205,18 @@ bool Node::solved_tb_loss(const Node* childNode) const
 {
 #ifndef MCTS_SINGLE_PLAYER
     if (d->numberUnsolvedChildNodes == 0 && childNode->d->nodeType == TB_WIN) {
+        return only_won_tb_child_nodes();
 #else
     if (d->numberUnsolvedChildNodes == 0 && childNode->d->nodeType == TB_LOSS) {
+        return only_child_nodes_of_one_kind<TB_LOSS>();
 #endif
-        return only_won_tb_child_nodes();
     }
     return false;
 }
 
 bool Node::only_won_tb_child_nodes() const
 {
-    for (auto it = d->childNodes.begin(); it != d->childNodes.end(); ++it) {
-        const Node* childNode = it->get();
-        if (childNode->d->nodeType != TB_WIN) {
-            return false;
-        }
-    }
-    return true;
+    return only_child_nodes_of_one_kind<TB_WIN>();
 }
 
 void Node::mark_as_tb_loss()

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -584,6 +584,22 @@ private:
     bool only_won_child_nodes() const;
 
     /**
+     * @brief only_child_nodes_of_one_kind Check if all expanded child nodes are of the same kind.
+     * @return true if only child nodes of type <nodeType> exist else false
+     */
+    template <NodeType nodeType>
+    bool only_child_nodes_of_one_kind() const
+    {
+        for (auto it = d->childNodes.begin(); it != d->childNodes.end(); ++it) {
+            const Node* childNode = it->get();
+            if (childNode->d->nodeType != nodeType) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * @brief solved_loss Checks if the current node is a solved loss based on the given child node
      * @param childNode Child nodes which backpropagates the value
      * @return true for LOSS else false


### PR DESCRIPTION
Fixes terminal solver for mode `MCTS_SINGLE_PLAYER`.
Also adds `only_child_nodes_of_one_kind()` to reduce duplicated code.
