### PR TITLE
Dynamic ONNX shape support

### DIFF
--- a/engine/src/nn/neuralnetapi.cpp
+++ b/engine/src/nn/neuralnetapi.cpp
@@ -52,10 +52,25 @@ vector<string> get_items_by_elment(const vector<string> &stringVector, const str
 string get_file_ending_with(const string& dir, const string& suffix) {
     const vector<string> files = get_directory_files(dir);
     const string retString = get_string_ending_with(files, suffix);
-    if (retString == "") {
-        throw invalid_argument( "The given directory at " + dir + " doesn't contain a file ending with " + suffix);
-    }
     return retString;
+}
+
+string get_onnx_model_name(const string& modelDir, int batchSize)
+{
+    string modelName = get_file_ending_with(modelDir, "-bsize-" + to_string(batchSize) + ".onnx");
+
+    if (modelName  == "") {
+        // check for onnx with dynamic shape
+        modelName = get_file_ending_with(modelDir, ".onnx");
+        if (modelName == "") {
+            throw invalid_argument( "The given directory at " + modelDir + " doesn't contain a file ending with " + ".onnx");
+        }
+        if (modelName.find("-bsize-") != string::npos) {
+            throw invalid_argument( "The given directory at " + modelDir + " should either contain an onnx file supporting the current batch size"
+                                                                           " or an onnx file with dynamic shape support.");
+        }
+    }
+    return modelName;
 }
 
 

--- a/engine/src/nn/neuralnetapi.h
+++ b/engine/src/nn/neuralnetapi.h
@@ -123,6 +123,17 @@ bool check_condition(const T& value, const T& target, const string& valueStr, co
 
 
 /**
+ * @brief get_onnx_model_name Returns the model name in the given model directory based on the given batch size.
+ * If no file is found, it looks for an onnx file with dynamic shape support.
+ * If this is satisfied neither, an exception is thrown.
+ * @param modelDir Model directory
+ * @param batchSize Batch size
+ * @return model directory as string
+ */
+string get_onnx_model_name(const string& modelDir, int batchSize);
+
+
+/**
  * @brief The NeuralNetAPI class is an abstract class for accessing a neural network back-end and to run inference
  */
 class NeuralNetAPI

--- a/engine/src/nn/openvinoapi.h
+++ b/engine/src/nn/openvinoapi.h
@@ -35,6 +35,7 @@
 #include "neuralnetapi.h"
 
 #include <ie_core.hpp>
+#include "openvino/openvino.hpp"
 
 
 /**
@@ -43,17 +44,13 @@
 class OpenVinoAPI : public NeuralNetAPI
 {
 private:
-    InferenceEngine::Core core;
-    InferenceEngine::CNNNetwork network;
-    InferenceEngine::ExecutableNetwork executableNetwork;
-    InferenceEngine::InputsDataMap inputInfo;
-    InferenceEngine::OutputsDataMap outputInfo;
-    InferenceEngine::InferRequest inferRequest;
-    InferenceEngine::Blob::Ptr inputBlob;
-    float* rawInputData;
+    ov::Core core;
+    std::shared_ptr<ov::Model> model;
+    ov::CompiledModel compiledModel;
+    ov::InferRequest inferRequest;
 
-    InferenceEngine::Blob::Ptr outputBlobValue;
-    InferenceEngine::Blob::Ptr outputBlobPolicy;
+    ov::Tensor inputTensor;
+    float* rawInputData;
     size_t threadsNNInference;
 public:
     OpenVinoAPI(int deviceID, unsigned int batchSize, const string &modelDirectory, size_t threadsNNInference);


### PR DESCRIPTION
This PR allows dynamic shapes of ONNX models. This avoids storing multiple onnx files for each batch size but with the same network parameters. 
* update TensorrtAPI
* update OpenVinoAPI: (now needs to be openvino_2022.1.0 or higher!)

The required onnx files should use **-1**in the batch-size dimension and no longer have batch-size specifier in its file name, e.g. `model-1.20787-0.581-0535-v3.0.onnx` instead of  `model-1.20787-0.581-0535-v3.0-bsize-64.onnx`.