### PR TITLE
Fen position from epd file

### DIFF
--- a/DeepCrazyhouse/configs/rl_config.py
+++ b/DeepCrazyhouse/configs/rl_config.py
@@ -16,7 +16,7 @@ class RLConfig:
     arena_games: int = 100
     # Directory where the executable is located and where the selfplay data will be stored
     binary_dir: str = f'/data/RL/'
-    binary_name: str = f'MultiAra'
+    binary_name: str = f'ClassicAra'
     # How many times to train the NN, create a model contender or generate nn_update_files games
     nb_nn_updates: int = 10
     # How many new generated training files are needed to apply an update to the NN
@@ -27,7 +27,7 @@ class RLConfig:
     rm_fraction_for_selection: float = 0.05  # which percentage of the most recent memory shall be taken into account
     # The UCI_Variant. Must be in ["3check", "atomic", "chess", "crazyhouse",
     # "giveaway" (= antichess), "horde", "kingofthehill", "racingkings"]
-    uci_variant: str = f'atomic'
+    uci_variant: str = f'chess'
 
 
 @dataclass
@@ -47,8 +47,9 @@ class UCIConfig:
     Centi_Q_Value_Weight: int = 0
     Centi_Quick_Probability: int = 0
     Centi_Temperature: int = 80
+    EPD_File_Path: str = "<empty>"
     MaxInitPly: int = 0  # default: 30
-    MCTS_Solver: bool = False
+    MCTS_Solver: bool = True
     MeanInitPly: int = 0  # default: 15
     Milli_Policy_Clip_Thresh: int = 10
     Nodes: int = 800
@@ -60,6 +61,7 @@ class UCIConfig:
     SyzygyPath: str = f''
     Temperature_Moves: int = 15  # CZ: 500
     Timeout_MS: int = 0
+    UCI_Chess960: bool = False
 
 
 @dataclass

--- a/engine/src/agents/config/rlsettings.h
+++ b/engine/src/agents/config/rlsettings.h
@@ -29,6 +29,7 @@
 #define RLSETTINGS_H
 
 #include <stddef.h>
+#include <string>
 
 struct RLSettings
 {
@@ -60,6 +61,8 @@ struct RLSettings
     float resignThreshold;
     // boolean indicating if the search tree is reused during selfplay game generation
     bool reuseTreeForSelpay;
+    // string indicating the file path to an epd file which is used to initialize the rl games
+    std::string epdFilePath;
 };
 
 #endif // RLSETTINGS_H

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -54,6 +54,15 @@ using namespace CUSTOM_UCI;
 void play_move_and_update(const EvalInfo& evalInfo, StateObj* state, GamePGN& gamePGN, Result& gameResult);
 
 
+/**
+ * @brief load_random_fen Returns a random fen string from a epd file defined by its file path.
+ * If the filepath is "" or "<empty>" an empty string will be returned.
+ * @param filepath Points to the location of the epd file.
+ * @return fen string
+ */
+string load_random_fen(string filepath);
+
+
 class SelfPlay
 {
 private:
@@ -209,9 +218,10 @@ void clean_up(GamePGN& gamePGN, MCTSAgent* mctsAgent);
  * @param variant Game variant
  * @param is960 If we are in a 960 game or not
  * @param rawPolicyProbTemp Probability for which a temperature scaling > 1.0f is applied
+ * @param fen Starting fen. If "" then standard starting position will be used.
  * @return New state object
  */
-unique_ptr<StateObj> init_starting_state_from_raw_policy(RawNetAgent& rawAgent, size_t plys, GamePGN& gamePGN, int variant, bool is960, float rawPolicyProbTemp);
+unique_ptr<StateObj> init_starting_state_from_raw_policy(RawNetAgent& rawAgent, size_t plys, GamePGN& gamePGN, int variant, bool is960, float rawPolicyProbTemp, const string& fen);
 
 /**
  * @brief init_starting_state_from_fixed_move Initializes a starting position using a vector of actions

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -469,6 +469,13 @@ void CrazyAra::init_rl_settings()
     rlSettings.resignProbability = Options["Centi_Resign_Probability"] / 100.0f;
     rlSettings.resignThreshold = Options["Centi_Resign_Threshold"] / 100.0f;
     rlSettings.reuseTreeForSelpay = Options["Reuse_Tree"];
+    rlSettings.epdFilePath = string(Options["EPD_File_Path"]);
+    if (rlSettings.epdFilePath != "<empty>" and rlSettings.epdFilePath != "") {
+        std::ifstream epdFile (rlSettings.epdFilePath);
+        if (!epdFile.is_open()) {
+            throw invalid_argument("Given epd file: " + rlSettings.epdFilePath + " could not be opened.");
+        }
+    }
 }
 #endif
 

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -91,7 +91,11 @@ void OptionsUCI::init(OptionsMap &o)
 //    o["Centi_U_Init"]                  << Option(100, 0, 100);         currently disabled
 //    o["Centi_U_Min"]                   << Option(100, 0, 100);         currently disabled
 //    o["U_Base"]                        << Option(1965, 0, 99999);      currently disabled
+#ifdef USE_RL
+    o["Centi_Node_Temperature"]        << Option(100, 1, 99999);
+#else
     o["Centi_Node_Temperature"]        << Option(170, 1, 99999);
+#endif
     o["Centi_Q_Value_Weight"]          << Option(100, 0, 99999);
     o["Centi_Q_Veto_Delta"]            << Option(40, 0, 99999);
 #ifdef USE_RL
@@ -196,6 +200,7 @@ void OptionsUCI::init(OptionsMap &o)
     o["Centi_Raw_Prob_Temperature"]    << Option(25, 0, 100);
     o["Centi_Resign_Probability"]      << Option(90, 0, 100);
     o["Centi_Resign_Threshold"]        << Option(-90, -100, 100);
+    o["EPD_File_Path"]                 << Option("<empty>");
     o["MaxInitPly"]                    << Option(30, 0, 99999);
     o["MeanInitPly"]                   << Option(15, 0, 99999);
 #ifdef MODE_LICHESS


### PR DESCRIPTION
This PR adds the possibility to set the starting fen position in RL using an epd file.

The file path to the epd file which is by default `<empty>` is set via the uci-option `EPD_File_Path`.
