### PR TITLE
Dockerfile Pytorch Support

### DIFF
--- a/DeepCrazyhouse/src/training/requirements.txt
+++ b/DeepCrazyhouse/src/training/requirements.txt
@@ -13,5 +13,8 @@ ipytree
 setproctitle
 rtpt
 dataclasses
+mxnet
+torch
 torchsummary
+onnxruntime
 onnxsim

--- a/engine/src/rl/Dockerfile
+++ b/engine/src/rl/Dockerfile
@@ -24,7 +24,13 @@
 # Base this Dockerfile from the official NVIDIA-MXNet docker contaienr
 # see release page for  all current available releases:
 # https://docs.nvidia.com/deeplearning/frameworks/mxnet-release-notes/running.html
-FROM nvcr.io/nvidia/mxnet:20.09-py3
+ARG FRAMEWORK="pytorch"
+ARG ID=22.05
+
+FROM nvcr.io/nvidia/${FRAMEWORK}:${ID}-py3
+# alternative arguments
+# ARG FRAMEWORK="mxnet"
+# ARG ID=20.09
 
 MAINTAINER QueensGambit
 
@@ -39,11 +45,18 @@ RUN cd /root \
     && make install
 
 # Clone TensorRT repository for TensorRT backend
-# checkout commit for tag 20.09 ("git checkout tags/20.09" is currently not working)
 RUN cd /root \
     && git clone https://github.com/NVIDIA/TensorRT \
-    && cd TensorRT \
-    && git checkout f693a6d723ef2766be36deb5e7987cd50159973a
+    && cd TensorRT
+
+RUN if [ ${FRAMEWORK} = "pytorch" ]; then
+# checkout commit for tag 22.05
+git checkout 99a11a5fcdd1f184739bb20a8c4a473262c8ecc8
+else
+# checkout commit for tag 20.09 ("git checkout tags/20.09" is currently not working)
+git checkout f693a6d723ef2766be36deb5e7987cd50159973a
+fi
+
 ENV TENSORRT_PATH /root/TensorRT/
 ENV CUDA_PATH /usr/local/cuda/
 
@@ -87,6 +100,12 @@ RUN cd /root \
     && cd /root/CrazyAra/DeepCrazyhouse/src/training/ \
     && pip install -r requirements.txt
 
+# prepare setup for pytorch
+RUN if [ ${FRAMEWORK} = "pytorch" ]; then
+    pip uninstall mxboard \
+    && pip install --upgrade onnx
+fi
+
 # Install graphviz for plotting NN architectures
 RUN apt-get update -y \
     && apt-get install -y graphviz \
@@ -98,8 +117,13 @@ RUN apt-get update -y \
 RUN cd /root/CrazyAra/engine \
     && mkdir build \
     && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_RL=ON -DBACKEND_TENSORRT_7=ON .. \
+RUN if [ ${FRAMEWORK} = "pytorch" ]; then
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_RL=ON -DMODE_CRAZYHOUSE=0 -DMODE_CHESS=1 -DMODE_LICHESS=0 .. \
     && make -j8
+else
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_RL=ON -DMODE_CRAZYHOUSE=0 -DMODE_CHESS=1 -DMODE_LICHESS=0 -DBACKEND_TENSORRT_7=ON .. \
+    && make -j8
+fi
 
 # Rename the config files
 RUN mv /root/CrazyAra/DeepCrazyhouse/configs/main_config_template.py /root/CrazyAra/DeepCrazyhouse/configs/main_config.py \
@@ -114,5 +138,3 @@ RUN apt-get update -y \
 
 CMD cd /root/CrazyAra/engine/src/rl/ \
     && /bin/bash
-
-

--- a/engine/src/rl/README.md
+++ b/engine/src/rl/README.md
@@ -14,18 +14,22 @@ installs all additional libraries for reinforcement learning.
 Lastly, it compiles the CrazyAra executable from the C++ source code using the current repository state.
 :warning: NVIDIA Docker [does not work on Windows](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#is-microsoft-windows-supported).
 
-In order to build the docker container, use the following command:
+In order to build the docker container with pytorch support, use the following command:
  
 ```shell script
- docker build -t crazyara_docker .
+ docker build -t crazyara_docker . -build-arg FRAMEWORK=pytorch ID=22.05
+```
+if you want to use mxnet instead, use the following:
+```shell script
+ docker build -t crazyara_docker . -build-arg FRAMEWORK=mxnet ID=20.09
 ```
 
 Afterwards you can start the container using a specified list of GPUs:
 ```shell script
-docker run --gpus all -it \
- --rm -v local_dir:/data/RL --name crazyara_rl crazyara_docker:latest
+docker run --gpus all --shm-size 16G -it \
+ --rm -v ~/mnt:/data/RL --name crazyara_rl crazyara_docker:latest
 ```
-If you want to launch the docker using only a subset of availabe you can specify them by e.g. `--gpus '"device=10,11,12"'` instead.
+If you want to launch the docker using only a subset of available you can specify them by e.g. `--gpus '"device=10,11,12"'` instead.
 
 The parameter `-v` describes the mount directory, where the selfplay data will be stored.
 

--- a/engine/src/rl/rl_training.py
+++ b/engine/src/rl/rl_training.py
@@ -130,12 +130,6 @@ def _export_net(convert_to_onnx, input_shape, k_steps_final, net, nn_update_idx,
                                Path(model_contender_dir), model_prefix,
                                train_config.use_wdl and train_config.use_plys_to_end,
                                True)
-                for batch_size in [1, 8, 16]:
-                    dummy_input = torch.zeros(batch_size, input_shape[0], input_shape[1], input_shape[2]).to(ctx)
-                    export_to_onnx(net, batch_size,
-                                   dummy_input,
-                                   Path(model_contender_dir), model_prefix,
-                                   train_config.use_wdl and train_config.use_plys_to_end, False)
 
 
 def _get_net(ctx, input_shape, main_config, params_filename, symbol_filename, tar_filename, train_config):


### PR DESCRIPTION
This PR add Dockerfile support for pytorch.
Before building the container, the framework can be chosen via command line arguments.
