### PR TITLE
MCTS solver bug fix

### DIFF
--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -187,7 +187,7 @@ public:
      * @param solveForTerminal Decides if the terminal solver will be used
      */
     template<bool freeBackup>
-    void revert_virtual_loss_and_update(ChildIdx childIdx, float value, float virtualLoss, bool& solveForTerminal)
+    void revert_virtual_loss_and_update(ChildIdx childIdx, float value, float virtualLoss, bool solveForTerminal)
     {
         lock();
         // decrement virtual loss counter
@@ -216,7 +216,7 @@ public:
             ++d->freeVisits;
         }
         if (solveForTerminal) {
-            solveForTerminal = solve_for_terminal(childIdx);
+            solve_for_terminal(childIdx);
         }
         unlock();
     }


### PR DESCRIPTION
This PR aims to fix a bug when losing on time in forced mating sequences.
Example game:
* https://tcec-chess.com/#div=ql&game=102&season=23

Now `solveForTerminal` is kept on `true` when descending from a terminal node.