### PR TITLE
Dynamic single player search

### DIFF
--- a/engine/src/agents/config/searchsettings.cpp
+++ b/engine/src/agents/config/searchsettings.cpp
@@ -48,7 +48,8 @@ SearchSettings::SearchSettings():
         useTablebase(false),
         epsilonGreedyCounter(20),
         reuseTree(true),
-        mctsSolver(false)
+        mctsSolver(false),
+        searchPlayerMode(MODE_TWO_PLAYER)
 {
 
 }

--- a/engine/src/agents/config/searchsettings.h
+++ b/engine/src/agents/config/searchsettings.h
@@ -31,6 +31,11 @@
 #include <cstdlib>
 #include <cstdint>
 
+enum SearchPlayerMode {
+    MODE_SINGLE_PLAYER,
+    MODE_TWO_PLAYER
+};
+
 struct SearchSettings
 {
     uint16_t multiPV;
@@ -68,6 +73,8 @@ struct SearchSettings
     bool reuseTree;
     // If true, then the MCTS solver for terminals and tablebases will be active
     bool mctsSolver;
+    // Defines the nubmer of players within the MCTS search. Available are MODE_SINGLE_PLAYER and MODE_TWO_PLAYER
+    SearchPlayerMode searchPlayerMode;
     SearchSettings();
 
 };

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -208,6 +208,8 @@ public:
      * @param curNPS New NPS measurement
      */
     void update_nps_measurement(float curNPS);
+private:
+    void set_root_node_predictions();
 };
 
 /**

--- a/engine/src/agents/mctsagentbatch.cpp
+++ b/engine/src/agents/mctsagentbatch.cpp
@@ -114,7 +114,7 @@ void MCTSAgentBatch::evaluate_board_state()
         }
         else {
             ChildIdx bestMoveIdx;
-            rootNode->get_mcts_policy(eval.policyProbSmall, bestMoveIdx, searchSettings->qValueWeight, searchSettings->qVetoDelta);
+            rootNode->get_mcts_policy(eval.policyProbSmall, bestMoveIdx, searchSettings);
         }
        
         eval.legalMoves = rootNode->get_legal_actions();

--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -148,7 +148,7 @@ void set_eval_for_single_pv(EvalInfo& evalInfo, const Node* rootNode, size_t idx
                 switch (searchSettings->searchPlayerMode) {
                 case MODE_SINGLE_PLAYER:
                     evalInfo.movesToMate[idx] = -evalInfo.movesToMate[idx];
-                default: ;
+                case MODE_TWO_PLAYER: ;
                 }
                 return;
             }
@@ -158,7 +158,7 @@ void set_eval_for_single_pv(EvalInfo& evalInfo, const Node* rootNode, size_t idx
                 switch (searchSettings->searchPlayerMode) {
                 case MODE_SINGLE_PLAYER:
                     evalInfo.movesToMate[idx] = -evalInfo.movesToMate[idx];
-                default: ;
+                case MODE_TWO_PLAYER: ;
                 }
                 return;
             }

--- a/engine/src/evalinfo.h
+++ b/engine/src/evalinfo.h
@@ -88,11 +88,11 @@ void update_eval_info(EvalInfo& evalInfo, const Node* rootNode, size_t tbHits, s
  * @brief get_best_move_q Return the value evaluation for the given next node.
  * If it is a drawn tablebase position, 0.0 is returned.
  * Warning: Must be called with d != nullptr
- * @param searchSettings Search settings
  * @param nextNode Node object
+ * @param searchSettings Search settings
  * @return value evaluation
  */
-float get_best_move_q(const Node* nextNode);
+float get_best_move_q(const Node* nextNode, const SearchSettings* searchSettings);
 
 /**
  * @brief set_eval_for_single_pv Sets the eval struct pv line and score for a single pv

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -48,13 +48,14 @@ SearchThread::SearchThread(NeuralNetAPI *netBatch, const SearchSettings* searchS
     transpositionValues(make_unique<FixedVector<float>>(searchSettings->batchSize*2)),
     isRunning(true), mapWithMutex(mapWithMutex), searchSettings(searchSettings),
     tbHits(0), depthSum(0), depthMax(0), visitsPreSearch(0),
-#ifdef MCTS_SINGLE_PLAYER
-    terminalNodeCache(1),
-#else
     terminalNodeCache(searchSettings->batchSize*2),
-#endif
     reachedTablebases(false)
 {
+    switch (searchSettings->searchPlayerMode) {
+    case MODE_SINGLE_PLAYER:
+        terminalNodeCache = 1;  // TODO: Check if this is really needed
+    case MODE_TWO_PLAYER: ;
+    }
     searchLimits = nullptr;  // will be set by set_search_limits() every time before go()
     trajectoryBuffer.reserve(DEPTH_INIT);
     actionsBuffer.reserve(DEPTH_INIT);
@@ -141,7 +142,7 @@ Node* SearchThread::get_starting_node(Node* currentNode, NodeDescription& descri
     size_t depth = get_random_depth();
     for (uint curDepth = 0; curDepth < depth; ++curDepth) {
         currentNode->lock();
-        childIdx = get_best_action_index(currentNode, true, 0, 0);
+        childIdx = get_best_action_index(currentNode, true, searchSettings);
         Node* nextNode = currentNode->get_child_node(childIdx);
         if (nextNode == nullptr || !nextNode->is_playout_node() || nextNode->get_visits() < searchSettings->epsilonGreedyCounter || nextNode->get_node_type() != UNSOLVED) {
             currentNode->unlock();
@@ -356,7 +357,7 @@ void SearchThread::create_mini_batch()
 
         if(description.type == NODE_TERMINAL) {
             ++numTerminalNodes;
-            backup_value<true>(newNode->get_value(), searchSettings->virtualLoss, trajectoryBuffer, searchSettings->mctsSolver);
+            backup_value<true>(newNode->get_value(), searchSettings, trajectoryBuffer, searchSettings->mctsSolver);
         }
         else if (description.type == NODE_COLLISION) {
             // store a pointer to the collision node in order to revert the virtual loss of the forward propagation
@@ -400,9 +401,9 @@ void SearchThread::backup_values(FixedVector<Node*>& nodes, vector<Trajectory>& 
         Node* node = nodes.get_element(idx);
 #ifdef MCTS_TB_SUPPORT
         const bool solveForTerminal = searchSettings->mctsSolver && node->is_tablebase();
-        backup_value<false>(node->get_value(), searchSettings->virtualLoss, trajectories[idx], solveForTerminal);
+        backup_value<false>(node->get_value(), searchSettings, trajectories[idx], solveForTerminal);
 #else
-        backup_value<false>(node->get_value(), searchSettings->virtualLoss, trajectories[idx], false);
+        backup_value<false>(node->get_value(), searchSettings, trajectories[idx], false);
 #endif
     }
     nodes.reset_idx();
@@ -412,7 +413,7 @@ void SearchThread::backup_values(FixedVector<Node*>& nodes, vector<Trajectory>& 
 void SearchThread::backup_values(FixedVector<float>* values, vector<Trajectory>& trajectories) {
     for (size_t idx = 0; idx < values->size(); ++idx) {
         const float value = values->get_element(idx);
-        backup_value<true>(value, searchSettings->virtualLoss, trajectories[idx], false);
+        backup_value<true>(value, searchSettings, trajectories[idx], false);
     }
     values->reset_idx();
     trajectories.clear();

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -79,7 +79,7 @@ private:
     size_t depthSum;
     size_t depthMax;
     size_t visitsPreSearch;
-    const uint_fast32_t terminalNodeCache;
+    uint_fast32_t terminalNodeCache;  // TODO: better add "const" classifier here is possible
     bool reachedTablebases;
 public:
     /**

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -674,6 +674,12 @@ void CrazyAra::init_search_settings()
     searchSettings.threads = Options["Threads"] * get_num_gpus(Options);
     searchSettings.batchSize = Options["Batch_Size"];
     searchSettings.useMCGS = Options["Search_Type"] == "mcgs";
+    if (Options["Search_Player_Mode"] == "two_player") {
+        searchSettings.searchPlayerMode = MODE_TWO_PLAYER;
+    }
+    else if (Options["Search_Player_Mode"] == "single_player") {
+        searchSettings.searchPlayerMode = MODE_SINGLE_PLAYER;
+    }
 //    searchSettings.uInit = float(Options["Centi_U_Init_Divisor"]) / 100.0f;     currently disabled
 //    searchSettings.uMin = Options["Centi_U_Min"] / 100.0f;                      currently disabled
 //    searchSettings.uBase = Options["U_Base"];                                   currently disabled

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -164,6 +164,7 @@ void OptionsUCI::init(OptionsMap &o)
     o["UCI_Chess960"]                  << Option(false);
 #endif
     o["Search_Type"]                   << Option("mcgs", {"mcgs", "mcts"});
+    o["Search_Player_Mode"]            << Option("two_player", {"two_player", "single_player"});
 #ifdef USE_RL
     o["Simulations"]                   << Option(3200, 0, 99999999);
 #else


### PR DESCRIPTION
This PR replaces the `#ifdef` flag `MCTS_SINGLE_PLAYER_MODE` with a dynamic search setting called `searchPlayerMode`.
This allows changing the `searchPlayerMode` between two different search runs, i.e. for Pommerman.
The variable can also be set via the UCI-Option `Search_Player_Mode`.
For chess and other two player zero sum games, only `Search_Player_Mode == two_player`, makes sense.
