### PR TITLE
Replace deprecated Approx() by Catch::Matchers::WithinRel()

### DIFF
--- a/engine/tests/tests.cpp
+++ b/engine/tests/tests.cpp
@@ -717,7 +717,6 @@ TEST_CASE("State: clone()"){
     REQUIRE(state2->fen() == state.fen());
 }
 #elif defined(MODE_XIANGQI) || defined(MODE_BOARDGAMES)
-#include "catch.hpp"
 #include "piece.h"
 #include "thread.h"
 #include "uci.h"

--- a/engine/tests/tests.cpp
+++ b/engine/tests/tests.cpp
@@ -540,10 +540,10 @@ TEST_CASE("Chess_Input_Planes Version 2.7, 2.8, 3.0"){
 #endif
 #endif
 #if VERSION == 3
-    REQUIRE(stats.sum == Approx(179.12));
+    REQUIRE_THAT(stats.sum, Catch::Matchers::WithinRel(179.12, 0.001));
     REQUIRE(stats.argMax == 8);
     REQUIRE(stats.maxNum == 1);
-    REQUIRE(stats.key == Approx(442487.2));
+    REQUIRE_THAT(stats.key, Catch::Matchers::WithinRel(442487.2, 0.001));
 #endif
 }
 #endif


### PR DESCRIPTION
This PR replaces the deprecated Approx() floating point comparison by Catch::Matchers::WithinRel().
* https://github.com/catchorg/Catch2/blob/devel/docs/comparing-floating-point-numbers.md#comparing-floating-point-numbers-with-catch2

