### PR TITLE
Stoppable search thread

### DIFF
--- a/engine/src/agents/config/searchlimits.cpp
+++ b/engine/src/agents/config/searchlimits.cpp
@@ -23,6 +23,7 @@
  * @author: queensgambit
  */
 
+#include <algorithm>
 #include "searchlimits.h"
 #include "state.h"
 #include "constants.h"
@@ -64,7 +65,7 @@ void SearchLimits::reset()
 
 int SearchLimits::get_safe_remaining_time(SideToMove sideToMove) const
 {
-    return max(time[sideToMove] - moveOverhead * TIME_BUFFER_FACTOR, 1);
+    return std::max(time[sideToMove] - moveOverhead * TIME_BUFFER_FACTOR, 1);
 }
 
 bool is_game_sceneario(const SearchLimits* searchLimits)

--- a/engine/src/agents/mctsagentbatch.cpp
+++ b/engine/src/agents/mctsagentbatch.cpp
@@ -80,9 +80,11 @@ void MCTSAgentBatch::evaluate_board_state()
         
         if (rootNode->get_number_child_nodes() == 1) {
             info_string("Only single move available -> early stopping");
+            unlock_and_notify();
         }
         else if (rootNode->get_number_child_nodes() == 0) {
             info_string("The given position has no legal moves");
+            unlock_and_notify();
         }
         else {
             if (searchSettings->dirichletEpsilon > 0.009f) {

--- a/engine/src/agents/rawnetagent.cpp
+++ b/engine/src/agents/rawnetagent.cpp
@@ -71,7 +71,7 @@ void RawNetAgent::evaluate_board_state()
     evalInfo->nodes = 1;
     evalInfo->isChess960 = state->is_chess960();
     evalInfo->pv[0] = { bestmove };
-    runnerMutex.unlock();
+    unlock_and_notify();
 }
 
 void RawNetAgent::stop()

--- a/engine/src/manager/timemanager.cpp
+++ b/engine/src/manager/timemanager.cpp
@@ -23,6 +23,7 @@
  * @author: queensgambit
  */
 
+#include <algorithm>
 #include "timemanager.h"
 #include "../util/communication.h"
 #include <cassert>
@@ -91,7 +92,7 @@ int TimeManager::get_time_for_move(const SearchLimits* searchLimits, SideToMove 
 
     if (searchLimits->time[me] != 0) {
         // make sure the returned movetime is within bounds
-        return min(searchLimits->get_safe_remaining_time(me), curMovetime);
+        return std::min(searchLimits->get_safe_remaining_time(me), curMovetime);
     }
     return curMovetime;
 }

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -183,10 +183,12 @@ void CrazyAra::go(StateObj* state, istringstream &is,  EvalInfo& evalInfo)
     if (useRawNetwork) {
         rawAgent->set_search_settings(state, &searchLimits, &evalInfo);
         mainSearchThread = thread(run_agent_thread, rawAgent.get());
+        rawAgent->lock_and_wait();  // wait for the agent to be initalized to allow then stopping it.
     }
     else {
         mctsAgent->set_search_settings(state, &searchLimits, &evalInfo);
         mainSearchThread = thread(run_agent_thread, mctsAgent.get());
+        mctsAgent->lock_and_wait();  // wait for the agent to be initalized to allow then stopping it.
     }
 }
 


### PR DESCRIPTION
Allows a safe stopping of the search thread.

Locking a mutex from the main thread and releasing it in a different thread causes problems in Windows ("Unlock of unowned mutex"). Therefore, we need to use a condition variable and a mutex here.

Reference: https://github.com/dmfrodrigues/GraphViewerCpp/issues/16

Related:
* https://github.com/QueensGambit/CrazyAra/pull/167
* #81

