### PR TITLE
Update OpenSpiel dependency

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -330,6 +330,14 @@ if (MODE_OPEN_SPIEL OR MODE_STRATEGO)
         "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/container/*.h"
         "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/container/internal/*.cc"
         "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/container/internal/*.h"
+        "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/crc/*.cc"
+        "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/crc/*.h"
+        "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/crc/internal/*.cc"
+        "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/crc/internal/*.h"
+        "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/profiling/*.cc"
+        "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/profiling/*.h"
+        "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/profiling/internal/*.cc"
+        "3rdparty/open_spiel/open_spiel/abseil-cpp/absl/profiling/internal/*.h"
         )
 
     if(MODE_OPEN_SPIEL)


### PR DESCRIPTION
Updates the OpenSpiel dependency which updates abseil-cpp to (hopefully) fix the continuous integration test for Stratego. For the newer abseil-cpp version new files are added to  `open_spiel_abseil_files` in CMakeLists.txt.

