### PR TITLE
Generate random pytorch models

### DIFF
--- a/DeepCrazyhouse/src/domain/neural_net/architectures/pytorch/a0_resnet.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/pytorch/a0_resnet.py
@@ -165,3 +165,19 @@ class AlphaZeroResnet(torch.nn.Module):
         out = self.body(x)
 
         return process_value_policy_head(out, self.value_head, self.policy_head, self.use_plys_to_end, self.use_wdl)
+
+
+def get_alpha_zero_model(args):
+    """
+    Wrapper definition for AlphaVile models
+    :param args: Argument dictionary
+    :return: pytorch model object
+    """
+
+    model = AlphaZeroResnet(channels=256, channels_value_head=4,
+                            channels_policy_head=args.channels_policy_head,
+                            value_fc_size=256, num_res_blocks=19, act_type='relu',
+                            n_labels=args.n_labels, select_policy_from_plane=args.select_policy_from_plane,
+                            use_wdl=args.use_wdl, use_plys_to_end=args.use_plys_to_end,
+                            use_mlp_wdl_ply=args.use_mlp_wdl_ply)
+    return model

--- a/DeepCrazyhouse/src/training/trainer_agent_pytorch.py
+++ b/DeepCrazyhouse/src/training/trainer_agent_pytorch.py
@@ -534,7 +534,7 @@ def export_model(model, batch_sizes, input_shape, dir=Path('.'), torch_cpu=True,
 
 
 def export_to_onnx(model, batch_size: int, dummy_input: torch.Tensor, dir: Path, model_prefix: str,
-                   has_auxiliary_output: bool, dynamic_batch_size: bool) -> None:
+                   has_auxiliary_output: bool, dynamic_batch_size: bool, input_version=None) -> None:
     """
     Exports the model to ONNX format to allow later import in TensorRT.
 
@@ -545,6 +545,8 @@ def export_to_onnx(model, batch_size: int, dummy_input: torch.Tensor, dir: Path,
     :param model_prefix: Model prefix name
     :param has_auxiliary_output: Determines if the model has an auxiliary output
     :param dynamic_batch_size: Whether to export model with dynamic batch size
+    :param input_version: Can be used to specify the input representation version e.g. "3.0" for chess models.
+    If none, the version will be read from the main_config file instead. It is used for labelling the onnx file.
     :return:
     """
     if has_auxiliary_output:
@@ -562,7 +564,10 @@ def export_to_onnx(model, batch_size: int, dummy_input: torch.Tensor, dir: Path,
     else:
         dynamic_axes = None
 
-    onnx_name = f"{model_prefix}-v{main_config['version']}.0"
+    if input_version is None:
+        input_version = f"{main_config['version']}.0"
+
+    onnx_name = f"{model_prefix}-v{input_version}"
     if not dynamic_batch_size:
         onnx_name += f"-bsize-{batch_size}"
     onnx_name += ".onnx"


### PR DESCRIPTION
This PR allows generating random pytorch model using the command line script `generate_random_nn()`.