### PR TITLE
Check for is_terminal() directly after creating a new node

### DIFF
--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -91,6 +91,10 @@ Node* SearchThread::add_new_node_to_tree(StateObj* newState, Node* parentNode, C
 {
     bool transposition;
     Node* newNode = parentNode->add_new_node_to_tree(mapWithMutex, newState, childIdx, searchSettings, transposition);
+    if (newNode->is_terminal()) {
+        nodeBackup = NODE_TERMINAL;
+        return newNode;
+    }
     if (transposition) {
         const float qValue =  parentNode->get_child_node(childIdx)->get_value();
         transpositionValues->add_element(qValue);
@@ -294,11 +298,9 @@ void SearchThread::set_nn_results_to_child_nodes()
 {
     size_t batchIdx = 0;
     for (auto node: *newNodes) {
-        if (!node->is_terminal()) {
-            fill_nn_results(batchIdx, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, node,
-                            tbHits, rootState->mirror_policy(newNodeSideToMove->get_element(batchIdx)),
-                            searchSettings, rootNode->is_tablebase());
-        }
+        fill_nn_results(batchIdx, net->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, node,
+                        tbHits, rootState->mirror_policy(newNodeSideToMove->get_element(batchIdx)),
+                        searchSettings, rootNode->is_tablebase());
         ++batchIdx;
     }
 }


### PR DESCRIPTION
This PR now checks for is_terminal() directly after creating a new node and sets the nodeBackup type accordingly.

```
./cutechess-cli -variant standard -openings file=chess.epd format=epd -pgnout fix_terminal_30ms.pgn -resign movecount=5 score=600 -draw movenumber=30 movecount=4 score=20 -concurrency 1 -engine name=ClassicAra-fixed-terminal cmd=./ClassicAra_fixed_terminal dir=/data/SL proto=uci -engine name=ClassicAra-master cmd=./ClassicAra_master dir=/data/SL proto=uci -each option.Fixed_Movetime=30 option.First_Device_ID=7 tc=40/6000+21 -games 2 -rounds 500 -repeat
```

```python
Score of ClassicAra-fixed-terminal vs ClassicAra-master: 403 - 307 - 166  [0.555] 876
Elo difference: 38.2 +/- 20.8, LOS: 100.0 %, DrawRatio: 18.9 %
Finished match
```