### PR TITLE
Lichess inputs v3 with tests, cpp and python implementation

### DIFF
--- a/DeepCrazyhouse/configs/main_config.py
+++ b/DeepCrazyhouse/configs/main_config.py
@@ -69,7 +69,7 @@ main_config = {
     # Active mode for different input & output representations.
     # Each mode is only compatible with a certain network input-/output representation:
     # Available modes:  0: MODE_CRAZYHOUSE    (crazyhouse only mode, no 960) available versions [1, 2, 3]
-    #                   1: MODE_LICHESS       (all available lichess variants) available versions [1, 2 (last_moves)]
+    #                   1: MODE_LICHESS       (all available lichess variants) available versions [1, 2 (last_moves), 3 (last_moves+fx-features)]
     #                   2: MODE_CHESS         (chess only mode, with 960) available versions [1, 2, 3]
     "mode": 0,
     "version": 1,

--- a/DeepCrazyhouse/src/domain/variants/constants.py
+++ b/DeepCrazyhouse/src/domain/variants/constants.py
@@ -138,12 +138,16 @@ elif MODE == MODE_LICHESS:
     NB_POLICY_MAP_CHANNELS = 84
     if VERSION == 1:
         NB_LAST_MOVES = 0
-    else:
+    else:  # VERSION == 2 or VERSION == 3
         NB_LAST_MOVES = 8
     if VERSION == 1:
         NB_CHANNELS_PER_HISTORY_ITEM = 0
-    else:
+    else:  # VERSION == 2 or VERSION == 3
         NB_CHANNELS_PER_HISTORY_ITEM = 2
+    if VERSION == 3:
+        NB_CHANNELS_FX = 17
+    else:
+        NB_CHANNELS_FX = 0
 elif MODE == MODE_XIANGQI:
     NB_CHANNELS_POS = 26
     NB_CHANNELS_CONST = 2
@@ -183,6 +187,8 @@ else:
     NB_LABELS_POLICY_MAP = NB_POLICY_MAP_CHANNELS * BOARD_HEIGHT * BOARD_WIDTH
 NB_CHANNELS_HISTORY = NB_LAST_MOVES * NB_CHANNELS_PER_HISTORY_ITEM
 NB_CHANNELS_TOTAL = NB_CHANNELS_POS + NB_CHANNELS_CONST + NB_CHANNELS_VARIANTS + NB_CHANNELS_HISTORY
+if MODE == MODE_LICHESS:
+    NB_CHANNELS_TOTAL += NB_CHANNELS_FX
 
 # define the number of different pieces one can have in his pocket (the king/general is excluded)
 if MODE == MODE_XIANGQI:

--- a/DeepCrazyhouse/src/domain/variants/crazyhouse/v3/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/crazyhouse/v3/input_representation.py
@@ -66,7 +66,7 @@ def planes_to_board(planes, normalized_input):
     """
     Converts a board in plane representation to the python chess board representation
     see get_planes_of_board() for input encoding description
-    ! Board is always returned with WHITE to move and move number and no progress counter = 0 !
+    ! Board is always returned with WHITE to move and move number = 0 !
 
     :param planes: Input plane representation
     :param normalized_input: Defines if the inputs are normalized to [0,1]

--- a/DeepCrazyhouse/src/domain/variants/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/input_representation.py
@@ -13,6 +13,7 @@ import DeepCrazyhouse.src.domain.variants.classical_chess.v2.input_representatio
 import DeepCrazyhouse.src.domain.variants.classical_chess.v3.input_representation as chess_v3
 import DeepCrazyhouse.src.domain.variants.crazyhouse.v2.input_representation as crazyhouse_v2
 import DeepCrazyhouse.src.domain.variants.crazyhouse.v3.input_representation as crazyhouse_v3
+import DeepCrazyhouse.src.domain.variants.lichess.v3.input_representation as lichess_v3
 from DeepCrazyhouse.src.domain.variants.default_input_representation import default_board_to_planes,\
     default_normalize_input_planes, default_planes_to_board
 from DeepCrazyhouse.src.domain.variants.constants import (
@@ -20,6 +21,7 @@ from DeepCrazyhouse.src.domain.variants.constants import (
     VERSION,
     MODE_CRAZYHOUSE,
     MODE_CHESS,
+    MODE_LICHESS,
     NB_LAST_MOVES,
     chess, NB_CHANNELS_TOTAL, BOARD_HEIGHT, BOARD_WIDTH)
 from DeepCrazyhouse.configs.main_config import main_config
@@ -51,6 +53,8 @@ def board_to_planes(board, board_occ=0, normalize=True, mode=MODE_CRAZYHOUSE, la
         return crazyhouse_v2.board_to_planes(board, board_occ, normalize, last_moves)
     if mode == MODE_CRAZYHOUSE and VERSION == 3:
         return crazyhouse_v3.board_to_planes(board, board_occ, normalize, last_moves)
+    if mode == MODE_LICHESS and VERSION == 3:
+        return lichess_v3.board_to_planes(board, board_occ, normalize, last_moves)
 
     return default_board_to_planes(board, board_occ, last_moves, mode, normalize)
 
@@ -81,6 +85,8 @@ def planes_to_board(planes, normalized_input=False, mode=MODE_CRAZYHOUSE):
         return crazyhouse_v2.planes_to_board(planes, normalized_input)
     if mode == MODE_CRAZYHOUSE and VERSION == 3:
         return crazyhouse_v3.planes_to_board(planes, normalized_input)
+    if mode == MODE_LICHESS and VERSION == 3:
+        return lichess_v3.planes_to_board(planes, normalized_input)
 
     return default_planes_to_board(planes, normalized_input, mode)
 
@@ -104,6 +110,8 @@ def normalize_input_planes(x):
         return crazyhouse_v2.normalize_input_planes(x)
     if MODE == MODE_CRAZYHOUSE and VERSION == 3:
         return crazyhouse_v3.normalize_input_planes(x)
+    if MODE == MODE_LICHESS and VERSION == 3:
+        return lichess_v3.normalize_input_planes(x)
 
     return default_normalize_input_planes(x)
 
@@ -128,7 +136,6 @@ def get_planes_statistics(board: chess.Board, normalize: bool, last_moves_uci: l
 
     planes = board_to_planes(board, board_occ=board_occ, normalize=normalize, mode=main_config['mode'],
                              last_moves=last_moves)
-    planes = normalize_input_planes(planes)
     planes = planes.flatten()
     stats = {}
     stats['sum'] = planes.sum()

--- a/DeepCrazyhouse/src/domain/variants/lichess/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/lichess/input_representation.py
@@ -107,4 +107,4 @@ def board_to_planes(board, board_occ=0, normalize=True):
     """
 
     # return the plane representation of the given board
-    return variants.board_to_planes(board, board_occ, normalize, mode=MODE_LICHESS)
+    return variants.board_to_planes(board, board_occ, normalize, mode=MODE_LICHESS, last_moves=None)

--- a/DeepCrazyhouse/src/domain/variants/lichess/v3/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/lichess/v3/input_representation.py
@@ -1,0 +1,130 @@
+"""
+@file: input_representation.py
+Created on 17.08.23
+@project: CrazyAra
+@author: queensgambit
+
+Input representation v3 which is compatible to all available lichess variants and passed to the neural network.
+"""
+import numpy as np
+import chess
+from DeepCrazyhouse.src.domain.variants.default_input_representation import default_board_to_planes, default_planes_to_board
+from DeepCrazyhouse.src.domain.variants.constants import MODE_LICHESS, NB_CHANNELS_FX, BOARD_HEIGHT, BOARD_WIDTH
+from DeepCrazyhouse.src.domain.variants.classical_chess.v3.input_representation import set_additional_custom_features
+
+NORMALIZE_POCKETS = 16
+NORMALIZE_PIECE_NUMBER = 8
+NORMALIZE_50_MOVE_RULE = 50
+
+NB_PLAYERS = 2
+CHANNEL_POCKETS = 14
+CHANNEL_COLOR_INFO = 27
+CHANNEL_TOTAL_MOVE_COUNTER = 28
+CHANNEL_NO_PROGRESS = 33
+CHANNEL_CUSTOM_FEATURES = 63
+#CHANNEL_MATERIAL_DIFF = 66
+#CHANNEL_MATERIAL_COUNT = 74
+
+CHANNEL_PIECE_MASK = 37 + 26
+CHANNEL_CHECKERBOARD = 39 + 26
+CHANNEL_MATERIAL_DIFF = 40 + 26
+CHANNEL_OPP_BISHOPS = 46 + 26
+CHANNEL_CHECKERS = 47 + 26
+CHANNEL_MATERIAL_COUNT = 48 + 26
+
+
+def board_to_planes(board, board_occ=0, normalize=True, last_moves=None):
+    """
+    Gets the plane representation of a given board state.
+    (No history of past board positions is used.)
+
+    ## Chess Variants:
+
+    Feature | Planes
+
+    Chess variant input planes features as in lichess v2.0 | 63
+    ---
+    63 planes
+
+    (but set color info and total move counter planes to 0)
+
+    ###
+
+    Additional features as in chess inputs v3.0
+
+    P1 pieces | 1 | A grouped mask of all WHITE pieces |
+    P2 pieces | 1 | A grouped mask of all BLACK pieces |
+    Checkerboard | 1 | A chess board pattern |
+    P1 Material Diff | 6 | (pieces are ordered: PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING), normalized with 8
+    Opposite Color Bishops | 1 | Indicates if they are only two bishops and the bishops are opposite color |
+    Checkers | 1 | Indicates all pieces giving check |
+    P1 Material Count | 6 | (pieces are ordered: PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING), normalized with 8 |
+    ---
+    17 planes
+
+    Total : 63 + 17 = 80 planes
+
+    :param board: Board handle (Python-chess object)
+    :param board_occ: Sets how often the board state has occurred before (by default 0)
+    :param normalize: True if the inputs shall be normalized to the range [0.-1.]
+    ;param last_moves: List of last moves played
+    :return: planes - the plane representation of the current board state
+    """
+
+    # return the plane representation of the given board
+    planes = default_board_to_planes(board, board_occ, normalize=False, mode=MODE_LICHESS, last_moves=last_moves)
+    # set color info and total move counter to 0
+    planes[CHANNEL_COLOR_INFO, :, :] = 0
+    planes[CHANNEL_TOTAL_MOVE_COUNTER, :, :] = 0
+
+    # mirror all bitboard entries for the black player
+    mirror = board.turn == chess.BLACK and board.uci_variant != "racingkings"
+
+    planes_fx = np.zeros((NB_CHANNELS_FX, BOARD_HEIGHT, BOARD_WIDTH))
+    planes = np.concatenate((planes, planes_fx), axis=0)
+
+    set_additional_custom_features(planes, board, CHANNEL_CUSTOM_FEATURES, mirror, normalize=False, include_king=True,
+                                   channel_piece_mask=CHANNEL_PIECE_MASK, channel_checkerboard=CHANNEL_CHECKERBOARD,
+                                   channel_material_diff=CHANNEL_MATERIAL_DIFF, channel_opp_bishops=CHANNEL_OPP_BISHOPS,
+                                   channel_checkers=CHANNEL_CHECKERS, channel_material_count=CHANNEL_MATERIAL_COUNT)
+    if normalize:
+        normalize_input_planes(planes)
+
+    return planes
+
+
+def normalize_input_planes(planes):
+    """
+    Normalizes input planes to range [0,1]. Works in place / meaning the input parameter x is manipulated
+    :param planes: Input planes representation
+    :return: The normalized planes
+    """
+    channel = CHANNEL_POCKETS
+    for _ in range(NB_PLAYERS):
+        for _ in chess.PIECE_TYPES[:-1]:  # exclude the king for the pocket pieces
+            planes[channel, :, :] /= NORMALIZE_POCKETS
+            channel += 1
+    channel = CHANNEL_MATERIAL_DIFF
+    for _ in chess.PIECE_TYPES:
+        planes[channel, :, :] /= NORMALIZE_PIECE_NUMBER
+        channel += 1
+    planes[CHANNEL_NO_PROGRESS, :, :] /= NORMALIZE_50_MOVE_RULE
+    channel = CHANNEL_MATERIAL_COUNT
+    for _ in chess.PIECE_TYPES:
+        planes[channel, :, :] /= NORMALIZE_PIECE_NUMBER
+        channel += 1
+
+    return planes
+
+
+def planes_to_board(planes, normalized_input):
+    """
+    Converts a board in plane representation to the python chess board representation
+    see get_planes_of_board() for input encoding description
+    ! Board is always returned with WHITE to move and move number = 0 !
+
+    :param planes: Input plane representation
+    :param normalized_input: Defines if the inputs are normalized to [0,1]
+    :return: python chess board object
+    """
+    return default_planes_to_board(planes, normalized_input)

--- a/engine/src/environments/chess_related/inputrepresentation.cpp
+++ b/engine/src/environments/chess_related/inputrepresentation.cpp
@@ -313,14 +313,30 @@ inline void set_checkerboard(PlaneData& p)
     }
 }
 
+inline void set_single_relative_count(PlaneData& p, const float relativeCount)
+{
+    if (relativeCount != 0) {
+        p.set_plane_to_value<false>(p.normalize ? relativeCount / StateConstants::NORMALIZE_PIECE_NUMBER() : relativeCount);
+    }
+    p.increment_channel();
+}
+
+inline void set_single_piece_material_diff(PlaneData& p, PieceType piece)
+{
+    set_single_relative_count(p, p.pos->get_board_piece_count(p.me(), piece) - p.pos->get_board_piece_count(p.you(), piece));
+}
+
 inline void set_material_diff(PlaneData& p)
 {
     for (PieceType piece: {PAWN, KNIGHT, BISHOP, ROOK, QUEEN}) {
-        float relativeCount = p.pos->get_board_piece_count(p.me(), piece) - p.pos->get_board_piece_count(p.you(), piece);
-        if (relativeCount != 0) {
-            p.set_plane_to_value<false>(p.normalize ? relativeCount / StateConstants::NORMALIZE_PIECE_NUMBER() : relativeCount);
-        }
-        p.increment_channel();
+        set_single_piece_material_diff(p, piece);
+    }
+}
+
+inline void set_material_diff_with_king(PlaneData& p)
+{
+    for (PieceType piece: {PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING}) {
+        set_single_piece_material_diff(p, piece);
     }
 }
 
@@ -388,14 +404,22 @@ inline void set_opposite_bishops(PlaneData& p)
     p.increment_channel();
 }
 
+inline void set_single_piece_material_count(PlaneData& p, PieceType piece)
+{
+    set_single_relative_count(p, p.pos->get_board_piece_count(p.me(), piece));
+}
+
 inline void set_material_count(PlaneData& p)
 {
     for (PieceType piece: {PAWN, KNIGHT, BISHOP, ROOK, QUEEN}) {
-        float relativeCount = p.pos->get_board_piece_count(p.me(), piece);
-        if (relativeCount != 0) {
-            p.set_plane_to_value<false>(p.normalize ? relativeCount / StateConstants::NORMALIZE_PIECE_NUMBER() : relativeCount);
-        }
-        p.increment_channel();
+        set_single_piece_material_count(p, piece);
+    }
+}
+
+inline void set_material_count_with_king(PlaneData& p)
+{
+    for (PieceType piece: {PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING}) {
+        set_single_piece_material_count(p, piece);
     }
 }
 
@@ -570,6 +594,36 @@ inline void board_to_planes_crazyhouse_v2(PlaneData& planeData, size_t boardRepe
 }
 #endif
 
+#ifdef MODE_LICHESS
+inline void board_to_planes_lichess_v3(PlaneData& planeData, size_t boardRepetition)
+{
+    const uint_fast32_t nbChannelsTotal = 80;
+    // default features
+    planeData.set_all_planes_to_zero(nbChannelsTotal);
+    set_plane_pieces(planeData);
+    set_plane_repetition(planeData, boardRepetition);
+    set_plane_pockets(planeData);
+    set_plane_promoted_pieces(planeData);
+    set_plane_ep_square(planeData);
+    planeData.increment_channel();  // skip color info
+    planeData.increment_channel();  // skip total move count
+    set_plane_castling_rights(planeData);
+    set_no_progress_counter(planeData);
+    set_remaining_checks(planeData);
+    set_variant_and_960(planeData);
+    set_last_moves(planeData);
+    // fx features
+    set_piece_masks(planeData);
+    set_checkerboard(planeData);
+    set_material_diff_with_king(planeData);
+    set_opposite_bishops(planeData);
+    set_checkers(planeData);
+    set_material_count_with_king(planeData);
+    assert(planeData.current_channel() == nbChannelsTotal);
+}
+#endif
+
+
 void board_to_planes(const Board *pos, size_t boardRepetition, bool normalize, float* inputPlanes, Version version)
 {
     // Fill in the piece positions
@@ -609,6 +663,16 @@ void board_to_planes(const Board *pos, size_t boardRepetition, bool normalize, f
         default:
             std::cerr << "The given version '" << version_to_string(version) << "' was unexpected and could not be handled" << endl;
             throw false;
+    }
+#endif
+#ifdef MODE_LICHESS
+    switch (version) {
+    case make_version<0,0,0>():
+    case make_version<1,0,0>():
+    case make_version<2,0,0>():
+            break;
+    case make_version<3,0,0>():
+            return board_to_planes_lichess_v3(planeData, boardRepetition);
     }
 #endif
     default_board_to_planes(planeData, boardRepetition);

--- a/engine/tests/tests.cpp
+++ b/engine/tests/tests.cpp
@@ -1602,5 +1602,22 @@ TEST_CASE("Crazyhouse Input Planes V3") {
 }
 #endif
 
+#ifdef MODE_LICHESS
+TEST_CASE("Atomic Input Planes V3") {
+    init();
+    int variant = StateConstants::variant_to_int("atomic");
+    BoardState state;
+    const uint nbValuesTotal = 80 * StateConstants::NB_SQUARES();
+    state.init(variant, false);
+    // starting position test
+    PlaneStatistics stats = get_planes_statistics(state, false, make_version<3,0,0>(), nbValuesTotal);
+    REQUIRE(stats.sum == 1440);
+    REQUIRE(stats.maxNum == 8);
+    REQUIRE(stats.key == 5932976);
+    REQUIRE(stats.argMax == 4736);
+    REQUIRE(state.fen() == string("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"));
+}
+#endif
+
 #endif
 


### PR DESCRIPTION
This PR adds the Lichess input representation v3 for MultiAra
This can be used as an ablation study to other paper: "Representation Matters: The Game of Chess Poses a Challenge to Vision Transformers".
It was tested so far only for the chess variant atomic and showed superior performance.