### PR TITLE
Fix python input representation for 960

### DIFF
--- a/DeepCrazyhouse/src/domain/variants/classical_chess/v2/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/classical_chess/v2/input_representation.py
@@ -170,7 +170,7 @@ def board_to_planes(board: chess.Board, normalize=True, last_moves=None):
     # Chess960
     assert (channel == CHANNEL_IS_960)
     if board.chess960:
-        planes[channel + 1, :, :] = 1
+        planes[channel, :, :] = 1
     channel += 1
 
     # Channel: 20 - 21

--- a/DeepCrazyhouse/src/domain/variants/classical_chess/v3/input_representation.py
+++ b/DeepCrazyhouse/src/domain/variants/classical_chess/v3/input_representation.py
@@ -196,7 +196,7 @@ def board_to_planes(board: chess.Board, board_occ, normalize=True, last_moves=No
     # Chess960
     assert channel == CHANNEL_IS_960
     if board.chess960:
-        planes[channel + 1, :, :] = 1
+        planes[channel, :, :] = 1
     channel += 1
 
     channel = set_additional_custom_features(planes, board, channel, mirror, normalize, include_king=False)

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -62,7 +62,6 @@ CrazyAra::CrazyAra():
     useRawNetwork(false),      // will be initialized in init_search_settings()
     networkLoaded(false),
     ongoingSearch(false),
-    is960(false),
     changedUCIoption(false)
 {
 }
@@ -82,7 +81,7 @@ void CrazyAra::uci_loop(int argc, char *argv[])
     string token, cmd;
     EvalInfo evalInfo;
     variant = StateConstants::variant_to_int(Options["UCI_Variant"]);
-    state->set(StateConstants::start_fen(variant), is960, variant);
+    state->set(StateConstants::start_fen(variant), Options["UCI_Chess960"], variant);
 
     for (int i = 1; i < argc; ++i)
         cmd += string(argv[i]) + " ";
@@ -224,7 +223,7 @@ void CrazyAra::go(const string& fen, string goCommand, EvalInfo& evalInfo)
     string token, cmd;
 
     variant = StateConstants::variant_to_int(Options["UCI_Variant"]);
-    state->set(StateConstants::start_fen(variant), is960, variant);
+    state->set(StateConstants::start_fen(variant), Options["UCI_Chess960"], variant);
 
     istringstream is("fen " + fen);
 
@@ -271,7 +270,7 @@ void CrazyAra::position(StateObj* state, istringstream& is)
     else
         return;
 
-    state->set(fen, is960, variant);
+    state->set(fen, Options["UCI_Chess960"], variant);
     Action lastMove = ACTION_NONE;
 
     // Parse move list (if any)
@@ -573,7 +572,7 @@ bool CrazyAra::is_ready()
         netBatches.front()->validate_neural_network();
         mctsAgent = create_new_mcts_agent(netSingle.get(), netBatches, &searchSettings);
         rawAgent = make_unique<RawNetAgent>(netSingle.get(), &playSettings, false);
-        StateConstants::init(mctsAgent->is_policy_map(), is960);
+        StateConstants::init(mctsAgent->is_policy_map(), Options["UCI_Chess960"]);
         timeoutThread.kill();
         if (timeoutMS != 0) {
             tTimeoutThread.join();
@@ -652,14 +651,14 @@ void CrazyAra::set_uci_option(istringstream &is, StateObj& state)
 #ifdef SUPPORT960
     const bool prevIs960 = Options["UCI_Chess960"];
 #else
-    const bool prevIs960 = is960;
+    const bool prevIs960 = false;
 #endif
 
     OptionsUCI::setoption(is, variant, state);
 #ifdef SUPPORT960
     const bool curIs960 = Options["UCI_Chess960"];
 #else
-    const bool curIs960 = is960;
+    const bool curIs960 = false;
 #endif
     changedUCIoption = true;
     if (networkLoaded) {
@@ -732,9 +731,6 @@ void CrazyAra::init_search_settings()
     searchSettings.randomMoveFactor = Options["Centi_Random_Move_Factor"]  / 100.0f;
     searchSettings.allowEarlyStopping = Options["Allow_Early_Stopping"];
     useRawNetwork = Options["Use_Raw_Network"];
-#ifdef SUPPORT960
-    is960 = Options["UCI_Chess960"];
-#endif
     searchSettings.useNPSTimemanager = Options["Use_NPS_Time_Manager"];
     if (string(Options["SyzygyPath"]).empty() || string(Options["SyzygyPath"]) == "<empty>") {
         searchSettings.useTablebase = false;

--- a/engine/src/uci/crazyara.h
+++ b/engine/src/uci/crazyara.h
@@ -97,7 +97,6 @@ private:
     bool useRawNetwork;
     bool networkLoaded;
     bool ongoingSearch;
-    bool is960;
     bool changedUCIoption;
 
 public:

--- a/engine/tests/tests.cpp
+++ b/engine/tests/tests.cpp
@@ -1639,5 +1639,31 @@ TEST_CASE("Atomic Input Planes V3") {
 }
 #endif
 
+TEST_CASE("Chess960 Input Planes V3") {
+    init();
+    int variant = StateConstants::variant_to_int("chess");
+    BoardState state;
+    state.set("b1qnrnkr/p2ppppp/1p6/2p1b3/2P5/4N1P1/PP1PPP1P/BBQNRK1R b he - 1 4", true, variant);
+    const uint nbValuesTotal = 52 * StateConstants::NB_SQUARES();
+
+    vector<float> planes(nbValuesTotal);
+    state.get_state_planes(false, planes.data(), make_version<3,0,0>());
+
+    // starting position test
+    PlaneStatistics stats = get_planes_statistics(state, false, make_version<3,0,0>(), nbValuesTotal);
+    REQUIRE(stats.sum == 1312);
+    REQUIRE(stats.maxNum == 8);
+    REQUIRE(stats.key == 3512322);
+    REQUIRE(stats.argMax == 3008);
+    REQUIRE(state.fen() == string("b1qnrnkr/p2ppppp/1p6/2p1b3/2P5/4N1P1/PP1PPP1P/BBQNRK1R b he - 1 4"));
+
+    stats = get_planes_statistics(state, true, make_version<3,0,0>(), nbValuesTotal);
+    REQUIRE_THAT(stats.sum, Catch::Matchers::WithinRel(409.28, 0.001));
+    REQUIRE(stats.maxNum == 1);
+    REQUIRE_THAT(stats.key, Catch::Matchers::WithinRel(823554.8, 0.001));
+    REQUIRE(stats.argMax == 8);
+    REQUIRE(state.fen() == string("b1qnrnkr/p2ppppp/1p6/2p1b3/2P5/4N1P1/PP1PPP1P/BBQNRK1R b he - 1 4"));
+}
+
 #endif
 


### PR DESCRIPTION
+ Fixes python input representation for 960 variants.
+ Adds unit test for input planes
+ Removes is960 from CrazyAra class
