### PR TITLE
Spinlock instead of Mutex

### DIFF
--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -30,7 +30,6 @@
 #include "../util/communication.h"
 #include "evalinfo.h"
 
-
 bool Node::is_sorted() const
 {
     return sorted;

--- a/engine/src/node.cpp
+++ b/engine/src/node.cpp
@@ -939,12 +939,12 @@ void Node::make_to_root()
 
 void Node::lock()
 {
-    mtx.lock();
+    spinlock.lock();
 }
 
 void Node::unlock()
 {
-    mtx.unlock();
+    spinlock.unlock();
 }
 
 void Node::apply_dirichlet_noise_to_prior_policy(const SearchSettings* searchSettings)

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -97,7 +97,7 @@ inline VirtualStyle get_virtual_style(const SearchSettings* searchSettings, uint
 class Node
 {
 private:
-    mutex mtx;
+    Spinlock spinlock;
 
     DynamicVector<float> policyProbSmall;
     vector<Action> legalActions;

--- a/engine/src/node.h
+++ b/engine/src/node.h
@@ -37,6 +37,7 @@
 
 #include "agents/config/searchsettings.h"
 #include "nodedata.h"
+#include "spinlock.h"
 
 
 using blaze::HybridVector;

--- a/engine/src/nodedata.h
+++ b/engine/src/nodedata.h
@@ -33,6 +33,7 @@
 #include <unordered_map>
 #include <blaze/Math.h>
 #include "agents/config/searchsettings.h"
+#include <atomic>
 
 using blaze::HybridVector;
 using blaze::DynamicVector;
@@ -120,5 +121,35 @@ public:
     void reserve_initial_space();
 };
 
+
+struct Spinlock
+{
+    // A std::atomic_flag is the only guaranteed lock-free atomic primitive in C++11
+    std::atomic_flag flag = ATOMIC_FLAG_INIT;
+
+    void lock()
+    {
+        // Waits in a loop (spins) until the flag is cleared, and then sets it atomically.
+        // memory_order_acquire: Ensures that all memory accesses before the unlock
+        // are visible to this thread.
+        while (flag.test_and_set(std::memory_order_acquire))
+        {
+            // Optional: Here, _mm_pause() (x86/64) could be inserted to save power
+            // and relieve bus bandwidth during busy-waiting.
+        }
+    }
+
+    void unlock()
+    {
+        // memory_order_release: Ensures that all changes become visible
+        // before the lock is released.
+        flag.clear(std::memory_order_release);
+    }
+
+    // Adds try_lock, in case std::lock_guard requires it for metadata
+    bool try_lock() {
+        return !flag.test_and_set(std::memory_order_acquire);
+    }
+};
 
 #endif // NODEDATA_H

--- a/engine/src/nodedata.h
+++ b/engine/src/nodedata.h
@@ -33,7 +33,6 @@
 #include <unordered_map>
 #include <blaze/Math.h>
 #include "agents/config/searchsettings.h"
-#include <atomic>
 
 using blaze::HybridVector;
 using blaze::DynamicVector;
@@ -121,35 +120,5 @@ public:
     void reserve_initial_space();
 };
 
-
-struct Spinlock
-{
-    // A std::atomic_flag is the only guaranteed lock-free atomic primitive in C++11
-    std::atomic_flag flag = ATOMIC_FLAG_INIT;
-
-    void lock()
-    {
-        // Waits in a loop (spins) until the flag is cleared, and then sets it atomically.
-        // memory_order_acquire: Ensures that all memory accesses before the unlock
-        // are visible to this thread.
-        while (flag.test_and_set(std::memory_order_acquire))
-        {
-            // Optional: Here, _mm_pause() (x86/64) could be inserted to save power
-            // and relieve bus bandwidth during busy-waiting.
-        }
-    }
-
-    void unlock()
-    {
-        // memory_order_release: Ensures that all changes become visible
-        // before the lock is released.
-        flag.clear(std::memory_order_release);
-    }
-
-    // Adds try_lock, in case std::lock_guard requires it for metadata
-    bool try_lock() {
-        return !flag.test_and_set(std::memory_order_acquire);
-    }
-};
 
 #endif // NODEDATA_H

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -227,8 +227,10 @@ Node* SearchThread::get_new_child_to_evaluate(NodeDescription& description)
                 // fill a new board in the input_planes vector
                 // we shift the index by nbNNInputValues each time
                 newState->get_state_planes(true, inputPlanes + newNodes->size() * nets.front()->get_nb_input_values_total(), nets.front()->get_version());
-                GamePhase currPhase = newState->get_phase(numPhases, searchSettings->gamePhaseDefinition);
-                phaseCountMap[currPhase]++;
+                if (numPhases > 1) {
+                    GamePhase currPhase = newState->get_phase(numPhases, searchSettings->gamePhaseDefinition);
+                    phaseCountMap[currPhase]++;
+                }
                 // save a reference newly created list in the temporary list for node creation
                 // it will later be updated with the evaluation of the NN
                 newNodeSideToMove->add_element(newState->side_to_move());

--- a/engine/src/spinlock.h
+++ b/engine/src/spinlock.h
@@ -29,7 +29,7 @@ struct Spinlock
 
     void lock()
     {
-        uint8_t spin_count = 0;
+        uint_fast8_t spin_count = 0;
 
         // Waits in a loop (spins) until the flag is cleared, and then sets it atomically.
         while (flag.test_and_set(std::memory_order_acquire))

--- a/engine/src/spinlock.h
+++ b/engine/src/spinlock.h
@@ -1,0 +1,64 @@
+#ifndef SPINLOCK_H
+#define SPINLOCK_H
+
+// Required for the Spinlock definition
+#include <atomic>
+#include <thread>
+
+// Include for _mm_pause() on x86/x64 systems
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif defined(__GNUC__) || defined(__clang__)
+#include <immintrin.h>
+#endif
+
+
+// Macro to abstract the CPU pause instruction (x86/64)
+#if defined(__GNUC__) || defined(__clang__)
+#define CPU_PAUSE() __builtin_ia32_pause()
+#elif defined(_MSC_VER)
+#define CPU_PAUSE() _mm_pause()
+#else
+#define CPU_PAUSE()
+#endif
+
+struct Spinlock
+{
+    // A std::atomic_flag is the only guaranteed lock-free atomic primitive in C++11
+    std::atomic_flag flag = ATOMIC_FLAG_INIT;
+
+    void lock()
+    {
+        uint8_t spin_count = 0;
+
+        // Waits in a loop (spins) until the flag is cleared, and then sets it atomically.
+        while (flag.test_and_set(std::memory_order_acquire))
+        {
+            // OPTIMIZATION: Hybrid Backoff Strategy
+            if (spin_count < 10) { // Fast spinning threshold (e.g., 10 iterations)
+                // CPU Pause Instruction: Reduces power consumption and improves bus contention
+                // during short busy-waits.
+                CPU_PAUSE();
+                spin_count++;
+            } else {
+                // If contention is high, yield the thread to the OS scheduler.
+                // This releases the CPU core, preventing resource waste and improving overall system throughput.
+                std::this_thread::yield();
+            }
+        }
+    }
+
+    void unlock()
+    {
+        // memory_order_release: Ensures that all changes become visible
+        // before the lock is released.
+        flag.clear(std::memory_order_release);
+    }
+
+    // Adds try_lock, for compatibility with std::lock_guard and other standard utilities
+    bool try_lock() {
+        return !flag.test_and_set(std::memory_order_acquire);
+    }
+};
+
+#endif // SPINLOCK_H


### PR DESCRIPTION
This PR integrates a spinlock as a replacement of mutex for Node.h
The memory consumption is almost identical.
Leads to 17.73 +/-  17.05  Elo improvement in chess.

Also adds `if (numPhases > 1) {` check in searchthread.cpp

```
File: /data/SL/spinlock_optimized_v3.pgn

Name                        :  Games                 Elo    Pts   Pts%   Win  Loss  Draw  Tf  Sc
ClassicAra_master           :   1000   -17.73 +/-  17.05  474.5   47.5   288   339   373   0   0
ClassicAra_spinlock         :   1000    17.73 +/-  17.05  525.5   52.5   339   288   373   0   0

Name                        :  W_win  B_win   Draw
ClassicAra_master           :    126    162    373
ClassicAra_spinlock         :    153    186    373


Name                        :   Wapc     Sd
ClassicAra_master           :     94     35
ClassicAra_spinlock         :     99     40

Finished games   : 1000
White wins       : 279 (27.9%)
Black wins       : 348 (34.8%)
Draws            : 746 (74.6%)
Unfinished games : 0 (0.0%)

Tf = time forfeit
Sc = stalled connection
Wapc = win average ply count, lower is better
Sd = standard deviation
```
