### PR TITLE
Parallel RL

### DIFF
--- a/DeepCrazyhouse/configs/rl_config.py
+++ b/DeepCrazyhouse/configs/rl_config.py
@@ -37,7 +37,7 @@ class UCIConfig:
     The options will be passed to the binary before game generation starts.
     """
     Allow_Early_Stopping: bool = False
-    Batch_Size: int = 64
+    Batch_Size: int = 8
     Centi_Dirichlet_Alpha: int = 30  # default: 20
     Centi_Dirichlet_Epsilon: int = 25
     Centi_Epsilon_Checks: int = 0

--- a/DeepCrazyhouse/configs/rl_config.py
+++ b/DeepCrazyhouse/configs/rl_config.py
@@ -37,7 +37,7 @@ class UCIConfig:
     The options will be passed to the binary before game generation starts.
     """
     Allow_Early_Stopping: bool = False
-    Batch_Size: int = 8
+    Batch_Size: int = 64
     Centi_Dirichlet_Alpha: int = 30  # default: 20
     Centi_Dirichlet_Epsilon: int = 25
     Centi_Epsilon_Checks: int = 0
@@ -53,6 +53,7 @@ class UCIConfig:
     MeanInitPly: int = 0  # default: 15
     Milli_Policy_Clip_Thresh: int = 10
     Nodes: int = 800
+    Number_Parallel_Games: int = 8
     Reuse_Tree: str = False
     Search_Type: str = f'mcts'
     Selfplay_Chunk_Size: int = 128  # default: 128

--- a/DeepCrazyhouse/configs/train_config.py
+++ b/DeepCrazyhouse/configs/train_config.py
@@ -68,9 +68,9 @@ class TrainConfig:
                                            "tensorboard."
     log_metrics_to_tensorboard: bool = True
 
-    info_model_type: str = "model_type defines the Model type that used during training (e.g. resnet, vit, risev2," \
-                           " risev3, risev3-large, alphavile, alphavile-tiny, alphavile-small, alphavile-normal," \
-                           " alphavile-large, NextViT)"
+    info_model_type: str = "model_type defines the Model type that used during training (e.g. resnet, resnet-small," \
+                           " vit, risev2, risev3, risev3-large, alphavile, alphavile-tiny, alphavile-small," \
+                           " alphavile-normal, alphavile-large, NextViT)"
     model_type: str = "risev3-large"
 
     info_k_steps_initial: str = "k_steps_initial defines how many steps have been trained before (k_steps_initial != 0 if" \

--- a/DeepCrazyhouse/configs/train_config.py
+++ b/DeepCrazyhouse/configs/train_config.py
@@ -69,9 +69,9 @@ class TrainConfig:
     log_metrics_to_tensorboard: bool = True
 
     info_model_type: str = "model_type defines the Model type that used during training (e.g. resnet, vit, risev2," \
-                           " risev3, alphavile, alphavile-tiny, alphavile-small, alphavile-normal, alphavile-large," \
-                           " NextViT)"
-    model_type: str = "risev3"
+                           " risev3, risev3-large, alphavile, alphavile-tiny, alphavile-small, alphavile-normal," \
+                           " alphavile-large, NextViT)"
+    model_type: str = "risev3-large"
 
     info_k_steps_initial: str = "k_steps_initial defines how many steps have been trained before (k_steps_initial != 0 if" \
                            " you continue training from a checkpoint)" \

--- a/DeepCrazyhouse/src/domain/neural_net/architectures/pytorch/a0_resnet.py
+++ b/DeepCrazyhouse/src/domain/neural_net/architectures/pytorch/a0_resnet.py
@@ -181,3 +181,19 @@ def get_alpha_zero_model(args):
                             use_wdl=args.use_wdl, use_plys_to_end=args.use_plys_to_end,
                             use_mlp_wdl_ply=args.use_mlp_wdl_ply)
     return model
+
+
+def get_alpha_zero_model_small(args):
+    """
+    Wrapper definition for the AlphaZero model (small version)
+    :param args: Argument dictionary
+    :return: pytorch model object
+    """
+
+    model = AlphaZeroResnet(channels=128, channels_value_head=4,
+                            channels_policy_head=args.channels_policy_head,
+                            value_fc_size=128, num_res_blocks=10, act_type='relu',
+                            n_labels=args.n_labels, select_policy_from_plane=args.select_policy_from_plane,
+                            use_wdl=args.use_wdl, use_plys_to_end=args.use_plys_to_end,
+                            use_mlp_wdl_ply=args.use_mlp_wdl_ply)
+    return model

--- a/DeepCrazyhouse/src/domain/neural_net/generate_random_nn.py
+++ b/DeepCrazyhouse/src/domain/neural_net/generate_random_nn.py
@@ -8,22 +8,13 @@ Command-line tool to generate a random initialized neural network and export ONN
 """
 import os
 import argparse
-import mxnet as mx
 import torch
 from pathlib import Path
 import logging
-import numpy as np
 import sys
 sys.path.insert(0, '../../../../')
-from DeepCrazyhouse.src.domain.neural_net.architectures.mxnet_alpha_zero import get_alpha_zero_symbol
-from DeepCrazyhouse.src.domain.neural_net.architectures.rise_mobile_v3 import get_rise_v33_symbol
-from DeepCrazyhouse.src.domain.neural_net.architectures.rise_mobile_v2 import get_rise_v2_symbol
-from DeepCrazyhouse.src.domain.neural_net.onnx.convert_to_onnx import convert_mxnet_model_to_onnx
 from DeepCrazyhouse.src.domain.variants.constants import NB_LABELS, NB_POLICY_MAP_CHANNELS, NB_CHANNELS_TOTAL,\
     BOARD_WIDTH, BOARD_HEIGHT
-from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.rise_mobile_v3 import get_rise_v33_model, get_rise_v2_model
-from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.a0_resnet import get_alpha_zero_model
-from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.alpha_vile import get_alpha_vile_model
 from DeepCrazyhouse.src.runtime.color_logger import enable_color_logging
 from DeepCrazyhouse.configs.train_config import TrainConfig
 from DeepCrazyhouse.src.training.trainer_agent_pytorch import save_torch_state, export_to_onnx, get_context
@@ -93,45 +84,6 @@ def parse_args(cmd_args: list):
     # convert list to tuple
     args.input_shape = tuple(args.input_shape)
     return args
-
-
-def generate_random_nn_mnxet(args):
-    """
-    Generates a new neural network model with random parameter initialization and exports it to ONNX.
-    """
-    if args.model_type == "alpha_zero":
-        symbol = get_alpha_zero_symbol(args)
-    elif args.model_type == "risev2":
-        symbol = get_rise_v2_symbol(args)
-    elif args.model_type == "risev3.3":
-        symbol = get_rise_v33_symbol(args)
-    else:
-        raise NotImplementedError
-
-    x_dummy = np.zeros(shape=(1, args.input_shape[0], args.input_shape[1], args.input_shape[2]))
-    y_value_dummy = np.zeros(shape=(1, 1))
-    if args.select_policy_from_plane:
-        y_policy_dummy = np.zeros(shape=(1, args.channels_policy_head + args.input_shape[1] * args.input_shape[2]))
-    else:
-        y_policy_dummy = np.zeros(shape=(1, args.n_labels))
-    data_iter = mx.io.NDArrayIter({'data': x_dummy}, {'value_label': y_value_dummy,
-                                                      'policy_label': y_policy_dummy.argmax(axis=1)}, 1)
-
-    model = mx.mod.Module(symbol=symbol, context=mx.cpu(), label_names=['value_label', 'policy_label'])
-    model.bind(for_training=True, data_shapes=[('data', x_dummy.shape)],
-               label_shapes=data_iter.provide_label)
-    model.init_params(mx.initializer.Xavier(rnd_type='uniform', factor_type='avg', magnitude=2.24))
-
-    prefix = args.export_dir + args.model_type
-    sym_file = prefix + "-symbol.json"
-    params_file = prefix + "-" + "%04d.params" % 0
-
-    # the export function saves both the architecture and the weights
-    model.save_checkpoint(prefix, epoch=0)
-
-    # if convert_to_onnx:
-    convert_mxnet_model_to_onnx(sym_file, params_file, ["value_out_output", "policy_out_output"], args.input_shape,
-                                [1, 8, 16], False)
 
 
 def generate_random_nn_pytorch(args, train_config: TrainConfig):

--- a/DeepCrazyhouse/src/domain/neural_net/generate_random_nn.py
+++ b/DeepCrazyhouse/src/domain/neural_net/generate_random_nn.py
@@ -27,6 +27,7 @@ from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.alpha_vile impor
 from DeepCrazyhouse.src.runtime.color_logger import enable_color_logging
 from DeepCrazyhouse.configs.train_config import TrainConfig
 from DeepCrazyhouse.src.training.trainer_agent_pytorch import save_torch_state, export_to_onnx, get_context
+from DeepCrazyhouse.src.training.train_cli_util import get_default_model
 
 enable_color_logging()
 
@@ -40,7 +41,7 @@ def parse_args(cmd_args: list):
     parser = argparse.ArgumentParser(description='Command-line tool to generate a random initialized neural network'
                                                  ' and export MXNet and ONNX weights.')
     parser.add_argument("--model-type", type=str, default="risev2",
-                        help="available model types [alpha_zero, risev2, risev3.3, alpha_vile] (default: risev2)")
+                        help="available model types [alpha_zero, risev2, risev3.3, alpha_vile, ... (see train_config.py: model_type)] (default: risev2)")
     parser.add_argument("--channels-policy-head", type=int, default=None,
                         help=" (default: None)")
     parser.add_argument("--n-labels", type=int, default=None,
@@ -137,16 +138,7 @@ def generate_random_nn_pytorch(args, train_config: TrainConfig):
     """
     Generates a new neural network model with random parameter initialization and exports it to ONNX.
     """
-    if args.model_type == "alpha_zero":
-        model = get_alpha_zero_model(args)
-    elif args.model_type == "risev2":
-        model = get_rise_v2_model(args)
-    elif args.model_type == "risev3.3":
-        model = get_rise_v33_model(args)
-    elif args.model_type == "alpha_vil":
-        model = get_alpha_vile_model(args)
-    else:
-        raise NotImplementedError
+    model = get_default_model(args.model_type, args)
 
     if args.context == "gpu" and torch.cuda.is_available():
         model.cuda(torch.device(f"cuda:{args.device_id}"))

--- a/DeepCrazyhouse/src/training/train_cli_util.py
+++ b/DeepCrazyhouse/src/training/train_cli_util.py
@@ -24,7 +24,7 @@ from DeepCrazyhouse.src.domain.variants.constants import NB_POLICY_MAP_CHANNELS,
 from DeepCrazyhouse.configs.main_config import main_config
 # architectures
 from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.rise_mobile_v3 import RiseV3, \
-    get_rise_v2_model, get_rise_v33_model
+    get_rise_v2_model, get_rise_v33_model, get_rise_v33_large_model
 from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.vision_transformer import VisionTransformer,\
     get_vision_transformer_model
 from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.vit_configs import get_b8_config
@@ -147,6 +147,8 @@ def get_default_model(model_type: str, args: Args):
         return get_rise_v2_model(args)
     elif model_type == 'risev3':
         return get_rise_v33_model(args)
+    elif model_type == 'risev3-large':
+        return get_rise_v33_large_model(args)
     elif model_type == 'alphavile':
         return get_alpha_vile_model(args)
     elif model_type == 'alphavile-tiny':

--- a/DeepCrazyhouse/src/training/train_cli_util.py
+++ b/DeepCrazyhouse/src/training/train_cli_util.py
@@ -29,7 +29,8 @@ from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.vision_transform
     get_vision_transformer_model
 from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.vit_configs import get_b8_config
 from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.next_vit_official import NextVit, get_next_vit_model
-from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.a0_resnet import AlphaZeroResnet, get_alpha_zero_model
+from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.a0_resnet import AlphaZeroResnet, get_alpha_zero_model,\
+    get_alpha_zero_model_small
 from DeepCrazyhouse.src.domain.neural_net.architectures.pytorch.alpha_vile import get_alpha_vile_model
 from DeepCrazyhouse.configs.train_config import TrainConfig, TrainObjects
 from DeepCrazyhouse.configs.model_config import ModelConfig
@@ -141,6 +142,8 @@ def get_default_model(model_type: str, args: Args):
     """Returns a pytorch object based on the given model_type."""
     if model_type == 'resnet':
         return get_alpha_zero_model(args)
+    elif model_type == 'resnet-small':
+        return get_alpha_zero_model_small(args)
     elif model_type == 'vit':
         return get_vision_transformer_model(args)
     elif model_type == 'risev2':

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-set (CMAKE_CXX_STANDARD 20)
+set (CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(USE_PROFILING             "Build with profiling"   OFF)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
-set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(USE_PROFILING             "Build with profiling"   OFF)
 option(USE_RL                    "Build with reinforcement learning support"  OFF)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -147,6 +147,8 @@ file(GLOB source_files
     "src/agents/util/*.h"
     "src/nn/*.cpp"
     "src/nn/*.h"
+    "src/inference/*.cpp"
+    "src/inference/*.h"
     "src/nn/util/*.cpp"
     "src/nn/util/*.h"
     "src/manager/*.cpp"

--- a/engine/src/agents/agent.cpp
+++ b/engine/src/agents/agent.cpp
@@ -57,10 +57,25 @@ void Agent::set_must_wait(bool value)
     mustWait = value;
 }
 
-Agent::Agent(const vector<unique_ptr<NeuralNetAPI>>& nets, const PlaySettings* playSettings, bool verbose):
-    NeuralNetAPIUser(nets),
-    playSettings(playSettings), mustWait(true), verbose(verbose), isRunning(false)
+void Agent::set_id(size_t value)
 {
+    id = value;
+}
+
+Agent::Agent(const vector<unique_ptr<NeuralNetAPI>>& nets, const PlaySettings* playSettings, bool verbose):
+    playSettings(playSettings), mustWait(true), verbose(verbose), isRunning(false), id(0)
+{
+    nnUser = make_shared<NeuralNetAPIUser>(nets);
+}
+
+Agent::Agent(const Agent& other)
+{
+    nnUser = other.nnUser;
+    playSettings = other.playSettings;
+    mustWait = other.mustWait;
+    verbose = other.verbose;
+    isRunning = other.isRunning;
+    id = other.id;
 }
 
 void Agent::set_search_settings(StateObj *pos, SearchLimits *searchLimits, EvalInfo* evalInfo)
@@ -106,6 +121,11 @@ void Agent::perform_action()
         info_bestmove(StateConstants::action_to_uci(evalInfo->bestMove, state->is_chess960()));
     #endif
     isRunning = false;
+}
+
+NeuralNetAPIUser* Agent::get_nn_user() const
+{
+    return nnUser.get();
 }
 
 void run_agent_thread(Agent* agent)

--- a/engine/src/agents/agent.cpp
+++ b/engine/src/agents/agent.cpp
@@ -57,13 +57,13 @@ void Agent::set_must_wait(bool value)
     mustWait = value;
 }
 
-void Agent::set_id(size_t value)
+void Agent::set_agent_id(size_t value)
 {
-    id = value;
+    agentID = value;
 }
 
 Agent::Agent(const vector<unique_ptr<NeuralNetAPI>>& nets, const PlaySettings* playSettings, bool verbose):
-    playSettings(playSettings), mustWait(true), verbose(verbose), isRunning(false), id(0)
+    playSettings(playSettings), mustWait(true), verbose(verbose), isRunning(false), agentID(0)
 {
     nnUser = make_shared<NeuralNetAPIUser>(nets);
 }
@@ -75,7 +75,7 @@ Agent::Agent(const Agent& other)
     mustWait = other.mustWait;
     verbose = other.verbose;
     isRunning = other.isRunning;
-    id = other.id;
+    agentID = other.agentID;
 }
 
 void Agent::set_search_settings(StateObj *pos, SearchLimits *searchLimits, EvalInfo* evalInfo)

--- a/engine/src/agents/agent.cpp
+++ b/engine/src/agents/agent.cpp
@@ -70,7 +70,7 @@ Agent::Agent(const vector<unique_ptr<NeuralNetAPI>>& nets, const PlaySettings* p
 
 Agent::Agent(const Agent& other)
 {
-    nnUser = other.nnUser;
+    nnUser = make_shared<NeuralNetAPIUser>(other.nnUser->nets);
     playSettings = other.playSettings;
     mustWait = other.mustWait;
     verbose = other.verbose;

--- a/engine/src/agents/agent.cpp
+++ b/engine/src/agents/agent.cpp
@@ -70,7 +70,7 @@ Agent::Agent(const vector<unique_ptr<NeuralNetAPI>>& nets, const PlaySettings* p
 
 Agent::Agent(const Agent& other)
 {
-    nnUser = make_shared<NeuralNetAPIUser>(other.nnUser->nets);
+    nnUser = other.nnUser;
     playSettings = other.playSettings;
     mustWait = other.mustWait;
     verbose = other.verbose;

--- a/engine/src/agents/agent.h
+++ b/engine/src/agents/agent.h
@@ -44,7 +44,7 @@ namespace crazyara {
  * It is assumed that the agent uses a neural network in some way,
  * therefore it inherits from NeuralNetAPIUser.
  */
-class Agent : public NeuralNetAPIUser
+class Agent
 {
 private:
     /**
@@ -71,8 +71,19 @@ protected:
     // boolean which can be triggered by "stop" from std-in to stop the current search
     bool isRunning;
 
+    // the ID is used to schedule multiple agents on a single gpu
+    size_t id;
+
+    // neural net API user, agent with id 0 is the nnUser owner
+    shared_ptr<NeuralNetAPIUser> nnUser;
 public:
     Agent(const vector<unique_ptr<NeuralNetAPI>>& nets, const PlaySettings* playSettings, bool verbose);
+
+    /**
+     * @brief Agent Copy constructor
+     * @param other Agent to copy
+     */
+    Agent(const Agent& other);
 
     /**
      * @brief perform_action Selects an action based on the evaluation result
@@ -122,6 +133,17 @@ public:
      */
     void unlock_and_notify();
     void set_must_wait(bool value);
+
+    /**
+     * @brief set_id Sets the ID of the agent. This is used to schedule multiple GPU requests
+     */
+    void set_id(size_t value);
+
+    /**
+     * @brief get_nn_user Getter method for nn user
+     * @return NeuralNetAPIUser* reference
+     */
+    NeuralNetAPIUser* get_nn_user() const;
 };
 }
 

--- a/engine/src/agents/agent.h
+++ b/engine/src/agents/agent.h
@@ -72,7 +72,7 @@ protected:
     bool isRunning;
 
     // the ID is used to schedule multiple agents on a single gpu
-    size_t id;
+    size_t agentID;
 
     // neural net API user, agent with id 0 is the nnUser owner
     shared_ptr<NeuralNetAPIUser> nnUser;
@@ -137,7 +137,7 @@ public:
     /**
      * @brief set_id Sets the ID of the agent. This is used to schedule multiple GPU requests
      */
-    void set_id(size_t value);
+    void set_agent_id(size_t value);
 
     /**
      * @brief get_nn_user Getter method for nn user

--- a/engine/src/agents/config/searchsettings.h
+++ b/engine/src/agents/config/searchsettings.h
@@ -50,9 +50,9 @@ enum GamePhaseDefinition {
 
 struct SearchSettings
 {
-    uint16_t multiPV;
+    uint_fast16_t multiPV;
     size_t threads;
-    unsigned int batchSize;
+    uint_fast32_t batchSize;
     float dirichletEpsilon;
     float dirichletAlpha;
     // policy temperature which can be applied on the every nodes' policy
@@ -94,8 +94,13 @@ struct SearchSettings
     double virtualOffsetStrenght;
     // Defines the type of game phase definition to be used
     GamePhaseDefinition gamePhaseDefinition;
+    // Number of games to generate in parallel
+    uint_fast32_t numberParallelGames;
     SearchSettings();
 
+    uint_fast32_t get_local_batch_size() const {
+        return batchSize / numberParallelGames;
+    }
 };
 
 #endif // SEARCHSETTINGS_H

--- a/engine/src/agents/config/searchsettings.h
+++ b/engine/src/agents/config/searchsettings.h
@@ -98,8 +98,8 @@ struct SearchSettings
     uint_fast32_t numberParallelGames;
     SearchSettings();
 
-    uint_fast32_t get_local_batch_size() const {
-        return batchSize / numberParallelGames;
+    uint_fast32_t get_main_batch_size() const {
+        return batchSize * numberParallelGames;
     }
 };
 

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -286,7 +286,7 @@ bool MCTSAgent::is_policy_map()
 
 string MCTSAgent::get_name() const
 {
-    return engineName + "-" + engineVersion + "-" + nnUser->nets.front()->get_model_name();
+    return engineName + "-" + engineVersion + "-" + nnUser->nets.front()->get_model_name() + "-" + to_string(agentID);
 }
 
 void MCTSAgent::update_stats()

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -206,7 +206,7 @@ void MCTSAgent::set_root_node_predictions()
         nnUser->nets[netIdx]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
     }
     else {
-        fwd_pass_queue(inferenceQueue.get(), nnUser.get(), 1, agentID, searchSettings);
+        fwd_pass_queue(inferenceQueue.get(), nnUser.get(), 1, 0, searchSettings);
     }
 
     size_t tbHits = 0;

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -65,6 +65,13 @@ MCTSAgent::~MCTSAgent()
     }
 }
 
+MCTSAgent::MCTSAgent(const MCTSAgent& other):
+    Agent(other)
+{
+    this->searchSettings = other.searchSettings;
+    this->playSettings = other.playSettings;
+}
+
 Node* MCTSAgent::get_opponents_next_root() const
 {
     return opponentsNextRoot.get();
@@ -77,7 +84,7 @@ Node* MCTSAgent::get_root_node() const
 
 string MCTSAgent::get_device_name() const
 {
-    return nets.front()->get_device_name();
+    return nnUser->nets.front()->get_device_name();
 }
 
 float MCTSAgent::get_dirichlet_noise() const
@@ -165,15 +172,15 @@ shared_ptr<Node> MCTSAgent::get_root_node_from_tree(StateObj *state)
 
 void MCTSAgent::set_root_node_predictions()
 {
-    state->get_state_planes(true, inputPlanes, nets.front()->get_version());
+    state->get_state_planes(true, nnUser->inputPlanes, nnUser->nets.front()->get_version());
     size_t netIdx = 0;
-    if (nets.size() > 1) {
-        GamePhase currentPhase = state->get_phase(numPhases, searchSettings->gamePhaseDefinition);
-        netIdx = phaseToNetsIndex.at(currentPhase);
+    if (nnUser->nets.size() > 1) {
+        GamePhase currentPhase = state->get_phase(nnUser->numPhases, searchSettings->gamePhaseDefinition);
+        netIdx = nnUser->phaseToNetsIndex.at(currentPhase);
     }
-    nets[netIdx]->predict(inputPlanes, valueOutputs, probOutputs, auxiliaryOutputs);
+    nnUser->nets[netIdx]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
     size_t tbHits = 0;
-    fill_nn_results(0, nets[netIdx]->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, rootNode.get(), tbHits,
+    fill_nn_results(0, nnUser->nets[netIdx]->is_policy_map(), nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs, rootNode.get(), tbHits,
                     rootState->mirror_policy(state->side_to_move()), searchSettings, rootNode->is_tablebase());
 }
 
@@ -260,12 +267,12 @@ void MCTSAgent::clear_game_history()
 
 bool MCTSAgent::is_policy_map()
 {
-    return nets.front()->is_policy_map();
+    return nnUser->nets.front()->is_policy_map();
 }
 
 string MCTSAgent::get_name() const
 {
-    return engineName + "-" + engineVersion + "-" + nets.front()->get_model_name();
+    return engineName + "-" + engineVersion + "-" + nnUser->nets.front()->get_model_name();
 }
 
 void MCTSAgent::update_stats()

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -50,14 +50,22 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
     reachedTablebases(false)
 {
     mapWithMutex.hashTable.reserve(1e6);
+    inferenceQueue = std::make_shared<InferenceQueue>();
 
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
         shared_ptr<NeuralNetAPIUser> nnUserThread = make_shared<NeuralNetAPIUser>(netBatchesVector[idx]);
         batchBarriers.emplace_back(make_shared<ReusableBarrier>(searchSettings->numberParallelGames));
-        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchBarriers[idx].get()));
+        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchBarriers[idx].get(), inferenceQueue.get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
     generator = default_random_engine(r());
+
+    auto nnUser = make_shared<NeuralNetAPIUser>(netBatchesVector[0]);
+    size_t maxBatchSize = searchSettings->get_local_batch_size() * searchSettings->numberParallelGames; // or tuned
+    size_t policySize = StateConstants::NB_LABELS();
+    size_t auxSize = StateConstants::NB_AUXILIARY_OUTPUTS();
+    inferenceWorker = std::make_unique<InferenceWorker>(inferenceQueue, nnUser, maxBatchSize, policySize, auxSize);
+    inferenceWorker->start();
 }
 
 MCTSAgent::~MCTSAgent()
@@ -76,7 +84,7 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
     this->batchBarriers = other.batchBarriers;
     this->agentID = other.agentID;
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
-        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchBarriers[idx].get()));
+        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchBarriers[idx].get(), other.inferenceQueue.get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
 }

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -52,7 +52,8 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
     mapWithMutex.hashTable.reserve(1e6);
 
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
-        searchThreads.emplace_back(new SearchThread(agentID, netBatchesVector[idx], searchSettings, &mapWithMutex));
+        shared_ptr<NeuralNetAPIUser> nnUserThread = make_shared<NeuralNetAPIUser>(netBatchesVector[idx]);
+        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
     generator = default_random_engine(r());
@@ -70,6 +71,10 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
 {
     this->searchSettings = other.searchSettings;
     this->playSettings = other.playSettings;
+    for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
+        other.searchThreads.emplace_back(new SearchThread(agentID, searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex));
+    }
+
 }
 
 Node* MCTSAgent::get_opponents_next_root() const

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -53,7 +53,9 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
 
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
         shared_ptr<NeuralNetAPIUser> nnUserThread = make_shared<NeuralNetAPIUser>(netBatchesVector[idx]);
-        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex));
+        batchCounters.emplace_back(0);
+        batchMutexes.emplace_back();
+        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, &batchCounters[idx], batchMutexes[idx].get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
     generator = default_random_engine(r());
@@ -69,12 +71,12 @@ MCTSAgent::~MCTSAgent()
 MCTSAgent::MCTSAgent(const MCTSAgent& other):
     Agent(other)
 {
+    this->mapWithMutex.hashTable.reserve(1e6);
     this->searchSettings = other.searchSettings;
     this->playSettings = other.playSettings;
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
-        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex));
+        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, &batchCounters[idx], batchMutexes[idx].get()));
     }
-
 }
 
 Node* MCTSAgent::get_opponents_next_root() const

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -62,7 +62,13 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
 
     auto nnUser = make_shared<NeuralNetAPIUser>(netBatchesVector[0]);
     size_t maxBatchSize = searchSettings->get_local_batch_size() * searchSettings->numberParallelGames; // or tuned
-    size_t policySize = StateConstants::NB_LABELS();
+    size_t policySize;
+    if (nnUser->nets.front()->is_policy_map()) {
+        policySize = StateConstants::NB_LABELS_POLICY_MAP();
+    }
+    else {
+        policySize = StateConstants::NB_LABELS();
+    }
     size_t auxSize = StateConstants::NB_AUXILIARY_OUTPUTS();
     inferenceWorker = std::make_unique<InferenceWorker>(inferenceQueue, nnUser, maxBatchSize, policySize, auxSize);
     inferenceWorker->start();

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -52,7 +52,7 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
     mapWithMutex.hashTable.reserve(1e6);
 
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
-        searchThreads.emplace_back(new SearchThread(netBatchesVector[idx], searchSettings, &mapWithMutex));
+        searchThreads.emplace_back(new SearchThread(agentID, netBatchesVector[idx], searchSettings, &mapWithMutex));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
     generator = default_random_engine(r());

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -79,6 +79,7 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
         this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchCounters[idx].get(), other.batchMutexes[idx].get()));
     }
+    timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
 }
 
 Node* MCTSAgent::get_opponents_next_root() const

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -53,9 +53,9 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
 
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
         shared_ptr<NeuralNetAPIUser> nnUserThread = make_shared<NeuralNetAPIUser>(netBatchesVector[idx]);
-        batchCounters.emplace_back(0);
+        batchCounters.emplace_back(make_shared<size_t>(0));
         batchMutexes.emplace_back();
-        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, &batchCounters[idx], batchMutexes[idx].get()));
+        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchCounters[idx].get(), batchMutexes[idx].get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
     generator = default_random_engine(r());
@@ -74,8 +74,10 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
     this->mapWithMutex.hashTable.reserve(1e6);
     this->searchSettings = other.searchSettings;
     this->playSettings = other.playSettings;
+    this->batchCounters = other.batchCounters;
+    this->batchMutexes = other.batchMutexes;
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
-        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, &batchCounters[idx], batchMutexes[idx].get()));
+        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchCounters[idx].get(), other.batchMutexes[idx].get()));
     }
 }
 

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -234,6 +234,11 @@ void MCTSAgent::update_nps_measurement(float curNPS)
     }
 }
 
+unsigned int MCTSAgent::get_num_phases()
+{
+    return nnUser->get_num_phases();
+}
+
 void MCTSAgent::apply_move_to_tree(Action move, bool ownMove)
 {
     if (!reusedFullTree && rootNode != nullptr && rootNode->is_playout_node()) {

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -72,7 +72,7 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
     this->searchSettings = other.searchSettings;
     this->playSettings = other.playSettings;
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
-        other.searchThreads.emplace_back(new SearchThread(agentID, searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex));
+        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex));
     }
 
 }

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -56,6 +56,7 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
         batchCounters.emplace_back(make_shared<size_t>(0));
         batchMutexes.emplace_back();
         batchConditions.emplace_back();
+        batchBarriers.emplace_back(make_shared<barrier<>>(searchSettings->numberParallelGames));
         searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchCounters[idx].get(), batchMutexes[idx].get(), batchConditions[idx].get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
@@ -78,8 +79,9 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
     this->batchCounters = other.batchCounters;
     this->batchMutexes = other.batchMutexes;
     this->batchConditions = other.batchConditions;
+    this->batchBarriers = other.batchBarriers;
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
-        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchCounters[idx].get(), other.batchMutexes[idx].get(), other.batchConditions[idx].get()));
+        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchCounters[idx].get(), other.batchMutexes[idx].get(), other.batchConditions[idx].get(), other.batchBarriers[idx].get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
 }

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -56,8 +56,8 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
         batchCounters.emplace_back(make_shared<size_t>(0));
         batchMutexes.emplace_back();
         batchConditions.emplace_back();
-        batchBarriers.emplace_back(make_shared<barrier<>>(searchSettings->numberParallelGames));
-        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchCounters[idx].get(), batchMutexes[idx].get(), batchConditions[idx].get()));
+        batchBarriers.emplace_back(make_shared<ReusableBarrier>(searchSettings->numberParallelGames));
+        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchCounters[idx].get(), batchMutexes[idx].get(), batchConditions[idx].get(), batchBarriers[idx].get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
     generator = default_random_engine(r());

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -89,6 +89,7 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
     this->playSettings = other.playSettings;
     this->batchBarriers = other.batchBarriers;
     this->agentID = other.agentID;
+    this->inferenceQueue = other.inferenceQueue;
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
         this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchBarriers[idx].get(), other.inferenceQueue.get()));
     }
@@ -201,7 +202,13 @@ void MCTSAgent::set_root_node_predictions()
         GamePhase currentPhase = state->get_phase(nnUser->numPhases, searchSettings->gamePhaseDefinition);
         netIdx = nnUser->phaseToNetsIndex.at(currentPhase);
     }
-    nnUser->nets[netIdx]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+    if (searchSettings->numberParallelGames == 1) {
+        nnUser->nets[netIdx]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+    }
+    else {
+        fwd_pass_queue(inferenceQueue.get(), nnUser.get(), 1, agentID, searchSettings);
+    }
+
     size_t tbHits = 0;
     fill_nn_results(0, nnUser->nets[netIdx]->is_policy_map(), nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs, rootNode.get(), tbHits,
                     rootState->mirror_policy(state->side_to_move()), searchSettings, rootNode->is_tablebase());

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -53,11 +53,8 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
 
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
         shared_ptr<NeuralNetAPIUser> nnUserThread = make_shared<NeuralNetAPIUser>(netBatchesVector[idx]);
-        batchCounters.emplace_back(make_shared<size_t>(0));
-        batchMutexes.emplace_back();
-        batchConditions.emplace_back();
         batchBarriers.emplace_back(make_shared<ReusableBarrier>(searchSettings->numberParallelGames));
-        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchCounters[idx].get(), batchMutexes[idx].get(), batchConditions[idx].get(), batchBarriers[idx].get()));
+        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchBarriers[idx].get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
     generator = default_random_engine(r());
@@ -76,12 +73,9 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
     this->mapWithMutex.hashTable.reserve(1e6);
     this->searchSettings = other.searchSettings;
     this->playSettings = other.playSettings;
-    this->batchCounters = other.batchCounters;
-    this->batchMutexes = other.batchMutexes;
-    this->batchConditions = other.batchConditions;
     this->batchBarriers = other.batchBarriers;
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
-        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchCounters[idx].get(), other.batchMutexes[idx].get(), other.batchConditions[idx].get(), other.batchBarriers[idx].get()));
+        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchBarriers[idx].get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
 }

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -196,22 +196,45 @@ shared_ptr<Node> MCTSAgent::get_root_node_from_tree(StateObj *state)
 
 void MCTSAgent::set_root_node_predictions()
 {
-    state->get_state_planes(true, nnUser->inputPlanes, nnUser->nets.front()->get_version());
-    size_t netIdx = 0;
-    if (nnUser->nets.size() > 1) {
-        GamePhase currentPhase = state->get_phase(nnUser->numPhases, searchSettings->gamePhaseDefinition);
-        netIdx = nnUser->phaseToNetsIndex.at(currentPhase);
-    }
     if (searchSettings->numberParallelGames == 1) {
+        state->get_state_planes(true, nnUser->inputPlanes, nnUser->nets.front()->get_version());
+        size_t netIdx = 0;
+        if (nnUser->nets.size() > 1) {
+            GamePhase currentPhase = state->get_phase(nnUser->numPhases, searchSettings->gamePhaseDefinition);
+            netIdx = nnUser->phaseToNetsIndex.at(currentPhase);
+        }
+
         nnUser->nets[netIdx]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+        size_t tbHits = 0;
+        fill_nn_results(0, nnUser->nets[netIdx]->is_policy_map(), nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs, rootNode.get(), tbHits,
+                        rootState->mirror_policy(state->side_to_move()), searchSettings, rootNode->is_tablebase());
     }
     else {
-        fwd_pass_queue(inferenceQueue.get(), nnUser.get(), 1, 0, searchSettings);
+        InferenceRequest request;
+
+        // --- basic metadata ---
+        request.inputSize  = StateConstants::NB_VALUES_TOTAL();
+        request.batchCount = 1;
+        request.agentID    = agentID;
+
+        // --- OWNED input buffer ---
+        const size_t localBatchSize = searchSettings->get_local_batch_size();
+        const size_t elems = request.inputSize;
+
+        request.inputData.resize(elems);
+
+        state->get_state_planes(true, request.inputData.data(), nnUser->nets.front()->get_version());
+
+        // --- enqueue & wait synchronously ---
+        auto future = request.promise.get_future();
+        inferenceQueue->push(std::move(request));
+
+        InferenceResult result = future.get();
+        size_t tbHits = 0;
+        fill_nn_results(0, nnUser->nets[0]->is_policy_map(), result.valueOutputs.data(), result.probOutputs.data(), result.auxiliaryOutputs.data(), rootNode.get(), tbHits,
+                        rootState->mirror_policy(state->side_to_move()), searchSettings, rootNode->is_tablebase());
     }
 
-    size_t tbHits = 0;
-    fill_nn_results(0, nnUser->nets[netIdx]->is_policy_map(), nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs, rootNode.get(), tbHits,
-                    rootState->mirror_policy(state->side_to_move()), searchSettings, rootNode->is_tablebase());
 }
 
 void MCTSAgent::create_new_root_node(StateObj* state)

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -74,6 +74,7 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
     this->searchSettings = other.searchSettings;
     this->playSettings = other.playSettings;
     this->batchBarriers = other.batchBarriers;
+    this->agentID = other.agentID;
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
         this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchBarriers[idx].get()));
     }
@@ -245,6 +246,14 @@ void MCTSAgent::update_nps_measurement(float curNPS)
 unsigned int MCTSAgent::get_num_phases()
 {
     return nnUser->get_num_phases();
+}
+
+void MCTSAgent::set_agent_id(size_t value)
+{
+    agentID = value;
+    for (auto searchThread : searchThreads) {
+        searchThread->set_agent_id(value);
+    }
 }
 
 void MCTSAgent::apply_move_to_tree(Action move, bool ownMove)

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -292,6 +292,11 @@ unsigned int MCTSAgent::get_num_phases()
     return nnUser->get_num_phases();
 }
 
+size_t MCTSAgent::get_agent_id()
+{
+    return agentID;
+}
+
 void MCTSAgent::set_agent_id(size_t value)
 {
     agentID = value;

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -218,7 +218,7 @@ void MCTSAgent::set_root_node_predictions()
         request.agentID    = agentID;
 
         // --- OWNED input buffer ---
-        const size_t localBatchSize = searchSettings->get_local_batch_size();
+        const size_t localBatchSize = searchSettings->batchSize;
         const size_t elems = request.inputSize;
 
         request.inputData.resize(elems);

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -55,7 +55,8 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
         shared_ptr<NeuralNetAPIUser> nnUserThread = make_shared<NeuralNetAPIUser>(netBatchesVector[idx]);
         batchCounters.emplace_back(make_shared<size_t>(0));
         batchMutexes.emplace_back();
-        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchCounters[idx].get(), batchMutexes[idx].get()));
+        batchConditions.emplace_back();
+        searchThreads.emplace_back(new SearchThread(agentID, nnUserThread, searchSettings, &mapWithMutex, batchCounters[idx].get(), batchMutexes[idx].get(), batchConditions[idx].get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
     generator = default_random_engine(r());
@@ -76,8 +77,9 @@ MCTSAgent::MCTSAgent(const MCTSAgent& other):
     this->playSettings = other.playSettings;
     this->batchCounters = other.batchCounters;
     this->batchMutexes = other.batchMutexes;
+    this->batchConditions = other.batchConditions;
     for (size_t idx = 0; idx < searchSettings->threads; ++idx) {
-        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchCounters[idx].get(), other.batchMutexes[idx].get()));
+        this->searchThreads.emplace_back(new SearchThread(agentID, other.searchThreads[idx]->get_nn_user(), searchSettings, &mapWithMutex, other.batchCounters[idx].get(), other.batchMutexes[idx].get(), other.batchConditions[idx].get()));
     }
     timeManager = make_unique<TimeManager>(searchSettings->randomMoveFactor);
 }

--- a/engine/src/agents/mctsagent.cpp
+++ b/engine/src/agents/mctsagent.cpp
@@ -61,7 +61,7 @@ MCTSAgent::MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector, co
     generator = default_random_engine(r());
 
     auto nnUser = make_shared<NeuralNetAPIUser>(netBatchesVector[0]);
-    size_t maxBatchSize = searchSettings->get_local_batch_size() * searchSettings->numberParallelGames; // or tuned
+    size_t maxBatchSize = searchSettings->numberParallelGames; // or tuned
     size_t policySize;
     if (nnUser->nets.front()->is_policy_map()) {
         policySize = StateConstants::NB_LABELS_POLICY_MAP();

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -216,6 +216,9 @@ public:
      * @return number of phases
      */
     unsigned int get_num_phases();
+
+    void set_agent_id(size_t value);
+
 private:
     void set_root_node_predictions();
 };

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -88,6 +88,8 @@ public:
     vector<shared_ptr<mutex>> batchMutexes;
     // condition variable that manages waiting
     vector<shared_ptr<condition_variable>> batchConditions;
+
+    vector<shared_ptr<barrier<>>> batchBarriers;
 public:
     MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector,
               const vector<vector<unique_ptr<NeuralNetAPI>>>& netBatchesVector,

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -46,7 +46,7 @@
 #include "../manager/threadmanager.h"
 #include "util/gcthread.h"
 #include "../inference/inferencequeue.h"
-#include "../inference/inferenceworker.h".h"
+#include "../inference/inferenceworker.h"
 
 using namespace crazyara;
 

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -221,6 +221,7 @@ public:
      */
     unsigned int get_num_phases();
 
+    size_t get_agent_id();
     void set_agent_id(size_t value);
 
 private:

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -209,6 +209,12 @@ public:
      * @param curNPS New NPS measurement
      */
     void update_nps_measurement(float curNPS);
+
+    /**
+     * @brief get_num_phases Wrapper method for nnUser->get_num_phases()
+     * @return number of phases
+     */
+    unsigned int get_num_phases();
 private:
     void set_root_node_predictions();
 };

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -81,13 +81,14 @@ public:
 
     unique_ptr<ThreadManager> threadManager;
     bool reachedTablebases;
+
 public:
     MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector,
               const vector<vector<unique_ptr<NeuralNetAPI>>>& netBatchesVector,
               SearchSettings* searchSettings,
               PlaySettings* playSettings);
     ~MCTSAgent();
-    MCTSAgent(const MCTSAgent&) = delete;
+    MCTSAgent(const MCTSAgent& other);
     MCTSAgent& operator=(MCTSAgent const&) = delete;
 
     void evaluate_board_state() override;

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -85,7 +85,7 @@ public:
     // batchCounter that coordinates all search threads
     vector<shared_ptr<size_t>> batchCounters;
     // mutex that protects the batchCounter access
-    vector<shared_ptr<mutex>> batchMutexes;
+    vector<shared_ptr<recursive_mutex>> batchMutexes;
 public:
     MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector,
               const vector<vector<unique_ptr<NeuralNetAPI>>>& netBatchesVector,

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -85,7 +85,9 @@ public:
     // batchCounter that coordinates all search threads
     vector<shared_ptr<size_t>> batchCounters;
     // mutex that protects the batchCounter access
-    vector<shared_ptr<recursive_mutex>> batchMutexes;
+    vector<shared_ptr<mutex>> batchMutexes;
+    // condition variable that manages waiting
+    vector<shared_ptr<condition_variable>> batchConditions;
 public:
     MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector,
               const vector<vector<unique_ptr<NeuralNetAPI>>>& netBatchesVector,

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -83,9 +83,9 @@ public:
     bool reachedTablebases;
 
     // batchCounter that coordinates all search threads
-    vector<size_t> batchCounters;
+    vector<shared_ptr<size_t>> batchCounters;
     // mutex that protects the batchCounter access
-    vector<unique_ptr<mutex>> batchMutexes;
+    vector<shared_ptr<mutex>> batchMutexes;
 public:
     MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector,
               const vector<vector<unique_ptr<NeuralNetAPI>>>& netBatchesVector,

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -89,7 +89,7 @@ public:
     // condition variable that manages waiting
     vector<shared_ptr<condition_variable>> batchConditions;
 
-    vector<shared_ptr<barrier<>>> batchBarriers;
+    vector<shared_ptr<ReusableBarrier>> batchBarriers;
 public:
     MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector,
               const vector<vector<unique_ptr<NeuralNetAPI>>>& netBatchesVector,

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -45,6 +45,8 @@
 #include "../manager/timemanager.h"
 #include "../manager/threadmanager.h"
 #include "util/gcthread.h"
+#include "../inference/inferencequeue.h"
+#include "../inference/inferenceworker.h".h"
 
 using namespace crazyara;
 
@@ -83,6 +85,8 @@ public:
     bool reachedTablebases;
 
     vector<shared_ptr<ReusableBarrier>> batchBarriers;
+    shared_ptr<InferenceQueue> inferenceQueue;
+    shared_ptr<InferenceWorker> inferenceWorker;
 public:
     MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector,
               const vector<vector<unique_ptr<NeuralNetAPI>>>& netBatchesVector,

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -82,13 +82,6 @@ public:
     unique_ptr<ThreadManager> threadManager;
     bool reachedTablebases;
 
-    // batchCounter that coordinates all search threads
-    vector<shared_ptr<size_t>> batchCounters;
-    // mutex that protects the batchCounter access
-    vector<shared_ptr<mutex>> batchMutexes;
-    // condition variable that manages waiting
-    vector<shared_ptr<condition_variable>> batchConditions;
-
     vector<shared_ptr<ReusableBarrier>> batchBarriers;
 public:
     MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector,

--- a/engine/src/agents/mctsagent.h
+++ b/engine/src/agents/mctsagent.h
@@ -82,6 +82,10 @@ public:
     unique_ptr<ThreadManager> threadManager;
     bool reachedTablebases;
 
+    // batchCounter that coordinates all search threads
+    vector<size_t> batchCounters;
+    // mutex that protects the batchCounter access
+    vector<unique_ptr<mutex>> batchMutexes;
 public:
     MCTSAgent(const vector<unique_ptr<NeuralNetAPI>>& netSingleVector,
               const vector<vector<unique_ptr<NeuralNetAPI>>>& netBatchesVector,

--- a/engine/src/agents/mctsagentbatch.cpp
+++ b/engine/src/agents/mctsagentbatch.cpp
@@ -54,10 +54,10 @@ MCTSAgentBatch::~MCTSAgentBatch()
 }
 
 string MCTSAgentBatch::get_name() const
-{   
-    string ret = "MCTSBatch-" + std::to_string(numberOfAgents) + "-" + engineVersion + "-" + nets.front()->get_model_name();
+{
+    string ret = "MCTSBatch-" + std::to_string(numberOfAgents) + "-" + engineVersion + "-" + nnUser->nets.front()->get_model_name();
     if(splitNodes){
-        ret = "MCTSBatch-Split-" + std::to_string(numberOfAgents) + "-" + engineVersion + "-" + nets.front()->get_model_name();
+        ret = "MCTSBatch-Split-" + std::to_string(numberOfAgents) + "-" + engineVersion + "-" + nnUser->nets.front()->get_model_name();
     }
     return ret;
 }

--- a/engine/src/agents/mctsagentbatch.cpp
+++ b/engine/src/agents/mctsagentbatch.cpp
@@ -122,7 +122,7 @@ void MCTSAgentBatch::evaluate_board_state()
         eval.legalMoves = rootNode->get_legal_actions();
 
         vector<size_t> indices;
-        uint16_t maxIdx = min(searchSettings->multiPV, rootNode->get_no_visit_idx());
+        uint_fast16_t maxIdx = min(uint_fast16_t(searchSettings->multiPV), uint_fast16_t(rootNode->get_no_visit_idx()));
 
         if (maxIdx > 1) {
             sort_eval_lists(eval, indices);

--- a/engine/src/agents/mctsagenttruesight.cpp
+++ b/engine/src/agents/mctsagenttruesight.cpp
@@ -52,8 +52,8 @@ MCTSAgentTrueSight::~MCTSAgentTrueSight()
 }
 
 string MCTSAgentTrueSight::get_name() const
-{   
-   return "MCTSTrueSight-" + engineVersion + "-" + nets.front()->get_model_name();
+{
+    return "MCTSTrueSight-" + engineVersion + "-" + nnUser->nets.front()->get_model_name();
 }
 
 void MCTSAgentTrueSight::evaluate_board_state()

--- a/engine/src/agents/rawnetagent.cpp
+++ b/engine/src/agents/rawnetagent.cpp
@@ -36,10 +36,10 @@ RawNetAgent::RawNetAgent(const vector<unique_ptr<NeuralNetAPI>>& nets, const Pla
 }
 
 size_t RawNetAgent::select_nn_index() {
-    if (nets.size() == 1) {
+    if (nnUser->nets.size() == 1) {
         return 0;
     }
-    return phaseToNetsIndex.at(state->get_phase(numPhases, searchSettings->gamePhaseDefinition));
+    return nnUser->phaseToNetsIndex.at(state->get_phase(nnUser->numPhases, searchSettings->gamePhaseDefinition));
 }
 
 void RawNetAgent::evaluate_board_state()
@@ -61,17 +61,17 @@ void RawNetAgent::evaluate_board_state()
         evalInfo->pv[0] = {evalInfo->legalMoves[0]};
         return;
     }
-    state->get_state_planes(true, inputPlanes, nets.front()->get_version());
-    nets[select_nn_index()]->predict(inputPlanes, valueOutputs, probOutputs, auxiliaryOutputs);
-    state->set_auxiliary_outputs(auxiliaryOutputs);
+    state->get_state_planes(true, nnUser->inputPlanes, nnUser->nets.front()->get_version());
+    nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+    state->set_auxiliary_outputs(nnUser->auxiliaryOutputs);
 
     evalInfo->policyProbSmall.resize(evalInfo->legalMoves.size());
-    get_probs_of_move_list(0, probOutputs, evalInfo->legalMoves, state->mirror_policy(state->side_to_move()),
-                           !nets.front()->is_policy_map(), evalInfo->policyProbSmall, nets.front()->is_policy_map());
+    get_probs_of_move_list(0, nnUser->probOutputs, evalInfo->legalMoves, state->mirror_policy(state->side_to_move()),
+                           !nnUser->nets.front()->is_policy_map(), evalInfo->policyProbSmall, nnUser->nets.front()->is_policy_map());
     size_t selIdx = argmax(evalInfo->policyProbSmall);
     Action bestmove = evalInfo->legalMoves[selIdx];
 
-    evalInfo->centipawns[0] = value_to_centipawn(valueOutputs[0]);
+    evalInfo->centipawns[0] = value_to_centipawn(nnUser->valueOutputs[0]);
     evalInfo->movesToMate[0] = 0;
     evalInfo->depth = 1;
     evalInfo->selDepth = 1;

--- a/engine/src/agents/rawnetagent.cpp
+++ b/engine/src/agents/rawnetagent.cpp
@@ -35,6 +35,12 @@ RawNetAgent::RawNetAgent(const vector<unique_ptr<NeuralNetAPI>>& nets, const Pla
 {
 }
 
+RawNetAgent::RawNetAgent(const RawNetAgent& other):
+Agent(other)
+{
+
+}
+
 size_t RawNetAgent::select_nn_index() {
     if (nnUser->nets.size() == 1) {
         return 0;

--- a/engine/src/agents/rawnetagent.h
+++ b/engine/src/agents/rawnetagent.h
@@ -53,7 +53,7 @@ public:
     const SearchSettings* searchSettings;
 
     RawNetAgent(const vector<unique_ptr<NeuralNetAPI>>& nets, const PlaySettings* playSettings, bool verbose, const SearchSettings* searchSettings);
-    RawNetAgent(const RawNetAgent&) = delete;
+    RawNetAgent(const RawNetAgent& other);
     RawNetAgent& operator=(RawNetAgent const&) = delete;
 
     void evaluate_board_state() override;

--- a/engine/src/evalinfo.cpp
+++ b/engine/src/evalinfo.cpp
@@ -215,7 +215,7 @@ void update_eval_info(EvalInfo& evalInfo, const Node* rootNode, size_t tbHits, s
     evalInfo.legalMoves = rootNode->get_legal_actions();
 
     vector<size_t> indices;
-    size_t maxIdx = min(searchSettings->multiPV, rootNode->get_no_visit_idx());
+    uint_fast16_t maxIdx = min(uint_fast16_t(searchSettings->multiPV), uint_fast16_t(rootNode->get_no_visit_idx()));
 
     if (maxIdx > 1) {
         sort_eval_lists(evalInfo, indices);

--- a/engine/src/inference/inferencequeue.cpp
+++ b/engine/src/inference/inferencequeue.cpp
@@ -62,16 +62,3 @@ bool InferenceQueue::empty() const {
     return queue.empty();
 }
 
-template<typename Rep, typename Period>
-bool InferenceQueue::pop_with_timeout(InferenceRequest &out, std::chrono::duration<Rep, Period> timeout) {
-    std::unique_lock<std::mutex> lock(mutex);
-    if (!conditionVariable.wait_for(lock, timeout, [&]{ return !queue.empty() || terminated; })) {
-        return false; // timeout
-    }
-    if (terminated && queue.empty()) {
-        return false;
-    }
-    out = std::move(queue.front());
-    queue.pop_front();
-    return true;
-}

--- a/engine/src/inference/inferencequeue.cpp
+++ b/engine/src/inference/inferencequeue.cpp
@@ -1,0 +1,77 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: inferencequeue.cpp
+ * Created on 10.12.2025
+ * @author: queensgambit
+ */
+
+#include "inferencequeue.h"
+
+
+void InferenceQueue::push(InferenceRequest &&req) {
+    std::unique_lock<std::mutex> lock(mutex);
+    queue.push_back(std::move(req));
+    conditionVariable.notify_one();
+}
+
+bool InferenceQueue::pop_blocking(InferenceRequest &out) {
+    std::unique_lock<std::mutex> lock(mutex);
+    conditionVariable.wait(lock, [&]{ return !queue.empty() || terminated; });
+    if (terminated && queue.empty()) {
+        return false;
+    }
+    out = std::move(queue.front()); queue.pop_front();
+    return true;
+}
+
+bool InferenceQueue::try_pop(InferenceRequest &out) {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (queue.empty()) {
+        return false;
+    }
+    out = std::move(queue.front()); queue.pop_front();
+    return true;
+}
+
+void InferenceQueue::terminate() {
+    std::unique_lock<std::mutex> lock(mutex);
+    terminated = true;
+    conditionVariable.notify_all();
+}
+
+bool InferenceQueue::empty() const {
+    std::unique_lock<std::mutex> lock(mutex);
+    return queue.empty();
+}
+
+template<typename Rep, typename Period>
+bool InferenceQueue::pop_with_timeout(InferenceRequest &out, std::chrono::duration<Rep, Period> timeout) {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (!conditionVariable.wait_for(lock, timeout, [&]{ return !queue.empty() || terminated; })) {
+        return false; // timeout
+    }
+    if (terminated && queue.empty()) {
+        return false;
+    }
+    out = std::move(queue.front());
+    queue.pop_front();
+    return true;
+}

--- a/engine/src/inference/inferencequeue.h
+++ b/engine/src/inference/inferencequeue.h
@@ -88,7 +88,18 @@ public:
      * @return
      */
     template<typename Rep, typename Period>
-    bool pop_with_timeout(InferenceRequest& out, std::chrono::duration<Rep, Period> timeout);
+    bool pop_with_timeout(InferenceRequest& out, std::chrono::duration<Rep, Period> timeout) {
+        std::unique_lock<std::mutex> lock(mutex);
+        if (!conditionVariable.wait_for(lock, timeout, [&]{ return !queue.empty() || terminated; })) {
+            return false; // timeout
+        }
+        if (terminated && queue.empty()) {
+            return false;
+        }
+        out = std::move(queue.front());
+        queue.pop_front();
+        return true;
+    }
 
     /**
      * @brief terminate Terminates the queue

--- a/engine/src/inference/inferencequeue.h
+++ b/engine/src/inference/inferencequeue.h
@@ -1,0 +1,111 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: inferencequeue.h
+ * Created on 10.12.2025
+ * @author: queensgambit
+ *
+ * Provides the queue functionality as well as result and request for inference.
+ */
+
+#ifndef INFERENCEQUEUE_H
+#define INFERENCEQUEUE_H
+
+#include <condition_variable>
+#include <deque>
+#include <future>
+#include <mutex>
+#include <vector>
+
+// A minimal InferenceRequest and InferenceResult used by MCTS threads -> worker
+struct InferenceResult {
+    std::vector<float> valueOutputs; // size = 1 (scalar) or batch local
+    std::vector<float> probOutputs; // flattened policy vector
+    std::vector<float> auxiliaryOutputs; // optional
+};
+
+struct InferenceRequest {
+    // The inputPlanes must point to a caller-owned contiguous float buffer of size inputSize
+    // The worker will copy from this pointer into the NN global input buffer.
+    const float* inputPlanes; // pointer to input floats
+    size_t inputSize; // number of floats at inputPlanes
+    size_t batchCount;  // number of local batches
+
+    // metadata (optional): e.g. agent id, node pointer, etc.
+    size_t agentID;
+    size_t outputOffset;
+
+    // result future: worker will set an InferenceResult
+    std::promise<InferenceResult> promise;
+};
+
+
+class InferenceQueue {
+public:
+    InferenceQueue() = default;
+
+    /**
+     * @brief push push a job; mcts thread moves the request
+     * @param req Inference request
+     */
+    void push(InferenceRequest&& req);
+
+    /**
+     * @brief pop_blocking blocking pop of one request; returns false if terminated
+     * @param out Inference request
+     * @return true or conditionVariable.wait()
+     */
+    bool pop_blocking(InferenceRequest& out);
+
+    /**
+     * @brief try_pop non-blocking try-pop
+     * @param out Inference request
+     * @return
+     */
+    bool try_pop(InferenceRequest& out);
+
+    /**
+     * @brief pop_with_timeout wait with timeout (milliseconds)
+     * @param out Inference request
+     * @param timeout true or conditionVariable.wait_for()
+     * @return
+     */
+    template<typename Rep, typename Period>
+    bool pop_with_timeout(InferenceRequest& out, std::chrono::duration<Rep, Period> timeout);
+
+    /**
+     * @brief terminate Terminates the queue
+     */
+    void terminate();
+
+    /**
+     * @brief empty Checks if the queue is empty
+     * @return
+     */
+    bool empty() const;
+
+private:
+    mutable std::mutex mutex;
+    std::condition_variable conditionVariable;
+    std::deque<InferenceRequest> queue;
+    bool terminated = false;
+};
+
+#endif // INFERENCEQUEUE_H

--- a/engine/src/inference/inferencequeue.h
+++ b/engine/src/inference/inferencequeue.h
@@ -44,7 +44,7 @@ struct InferenceResult {
 struct InferenceRequest {
     // The inputPlanes must point to a caller-owned contiguous float buffer of size inputSize
     // The worker will copy from this pointer into the NN global input buffer.
-    const float* inputPlanes; // pointer to input floats
+    std::vector<float> inputData;
     size_t inputSize; // number of floats at inputPlanes
     size_t batchCount;  // number of local batches
 

--- a/engine/src/inference/inferenceworker.cpp
+++ b/engine/src/inference/inferenceworker.cpp
@@ -1,0 +1,155 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: inferenceworker.cpp
+ * Created on 10.12.2025
+ * @author: queensgambit
+ */
+
+#include "inferenceworker.h"
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+
+// Include your neural net API header (TensorRT wrapper)
+// #include "neuralnetapiuser.h"
+
+InferenceWorker::InferenceWorker(std::shared_ptr<InferenceQueue> queue,
+                                 std::shared_ptr<NeuralNetAPIUser> nnUser,
+                                 size_t maxBatchSize,
+                                 size_t policySize,
+                                 size_t auxSize,
+                                 std::chrono::milliseconds gatherTimeout) :
+    queue(std::move(queue)), nnUser(std::move(nnUser)), maxBatchSize(maxBatchSize),
+    policySize(policySize), auxSize(auxSize), gatherTimeout(gatherTimeout) {}
+
+InferenceWorker::~InferenceWorker() {
+    stop();
+}
+
+void InferenceWorker::start() {
+    if (running.exchange(true)) {
+        return;
+    }
+    workerThread = std::thread(&InferenceWorker::run, this);
+}
+
+void InferenceWorker::stop() {
+    if (!running.exchange(false)) {
+        return;
+    }
+    if (queue) {
+        queue->terminate();
+    }
+    if (workerThread.joinable()) {
+        workerThread.join();
+    }
+}
+
+void InferenceWorker::run() {
+    std::vector<InferenceRequest> batch;
+    batch.reserve(maxBatchSize);
+
+    while (running) {
+        batch.clear();
+
+        InferenceRequest firstReq;
+        // block until we get the first job or termination
+        if (!queue->pop_blocking(firstReq)) {
+            break; // terminated
+        }
+        batch.push_back(std::move(firstReq));
+
+        // Gather more requests up to maxBatchSize with short non-blocking loop
+        InferenceRequest req;
+        auto start = std::chrono::steady_clock::now();
+        while (batch.size() < maxBatchSize) {
+            // try immediate pop first
+            if (queue->try_pop(req)) {
+                batch.push_back(std::move(req));
+                continue;
+            }
+            // otherwise wait up to gatherTimeout to accumulate more
+            if (queue->pop_with_timeout(req, gatherTimeout)) {
+                batch.push_back(std::move(req));
+                continue;
+            }
+            break; // no more requests within timeout
+        }
+
+        // Determine per-request inputSize consistency
+        size_t inputSize = batch[0].inputSize;
+        bool allSame = true;
+        for (size_t i = 1; i < batch.size(); ++i) {
+            if (batch[i].inputSize != inputSize) {
+                allSame = false;
+                break;
+            }
+        }
+        if (!allSame) {
+            std::cerr << "[InferenceWorker] warning: varying input sizes in batch; handling individually\n";
+        }
+
+        // Build contiguous host input buffer: batch_count * inputSize
+        size_t writeIndex = 0;
+        for (InferenceRequest& request : batch) {
+            for (size_t i = 0; i < request.batchCount; i++) {
+                memcpy(nnUser->inputPlanes + (writeIndex + i) * request.inputSize,
+                       request.inputPlanes + i * request.inputSize,
+                       request.inputSize * sizeof(float));
+            }
+            request.outputOffset = writeIndex;
+            writeIndex += request.batchCount;
+        }
+        size_t totalBatch = writeIndex;
+
+        // --- Perform NN inference on hostInput ---
+        // TODO: select_nn_index()
+        nnUser->nets[0]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+
+        // -- deliver results to each requester via promise --
+        for (InferenceRequest& request : batch) {
+            InferenceResult res;
+            res.valueOutputs.resize(request.batchCount);
+            res.probOutputs.resize(request.batchCount * policySize);
+            if (auxSize) {
+                res.auxiliaryOutputs.resize(request.batchCount * auxSize);
+            }
+
+
+            for (size_t i = 0; i < request.batchCount; i++) {
+                size_t gi = request.outputOffset + i;
+                res.valueOutputs[i] = nnUser->valueOutputs[gi];
+                memcpy(&res.probOutputs[i * policySize],
+                       &nnUser->probOutputs[gi * policySize],
+                       policySize * sizeof(float));
+                if (auxSize) {
+                    memcpy(&res.auxiliaryOutputs[i * auxSize],
+                           &nnUser->auxiliaryOutputs[gi * auxSize],
+                           auxSize * sizeof(float));
+                }
+            }
+
+            try { request.promise.set_value(std::move(res)); } catch (...) {}
+        }
+
+    } // while running
+}
+

--- a/engine/src/inference/inferenceworker.cpp
+++ b/engine/src/inference/inferenceworker.cpp
@@ -64,41 +64,41 @@ void InferenceWorker::stop() {
 }
 
 void InferenceWorker::run() {
-    std::vector<InferenceRequest> batch;
-    batch.reserve(maxBatchSize);
+    std::vector<InferenceRequest> batches;
+    batches.reserve(maxBatchSize);
 
     while (running) {
-        batch.clear();
+        batches.clear();
 
         InferenceRequest firstReq;
         // block until we get the first job or termination
         if (!queue->pop_blocking(firstReq)) {
             break; // terminated
         }
-        batch.push_back(std::move(firstReq));
+        batches.push_back(std::move(firstReq));
 
         // Gather more requests up to maxBatchSize with short non-blocking loop
         InferenceRequest req;
         auto start = std::chrono::steady_clock::now();
-        while (batch.size() < maxBatchSize) {
+        while (batches.size() < maxBatchSize) {
             // try immediate pop first
             if (queue->try_pop(req)) {
-                batch.push_back(std::move(req));
+                batches.push_back(std::move(req));
                 continue;
             }
             // otherwise wait up to gatherTimeout to accumulate more
             if (queue->pop_with_timeout(req, gatherTimeout)) {
-                batch.push_back(std::move(req));
+                batches.push_back(std::move(req));
                 continue;
             }
             break; // no more requests within timeout
         }
 
         // Determine per-request inputSize consistency
-        size_t inputSize = batch[0].inputSize;
+        size_t inputSize = batches[0].inputSize;
         bool allSame = true;
-        for (size_t i = 1; i < batch.size(); ++i) {
-            if (batch[i].inputSize != inputSize) {
+        for (size_t i = 1; i < batches.size(); ++i) {
+            if (batches[i].inputSize != inputSize) {
                 allSame = false;
                 break;
             }
@@ -109,7 +109,7 @@ void InferenceWorker::run() {
 
         // Build contiguous host input buffer: batch_count * inputSize
         size_t writeIndex = 0;
-        for (InferenceRequest& request : batch) {
+        for (InferenceRequest& request : batches) {
             for (size_t i = 0; i < request.batchCount; i++) {
                 memcpy(nnUser->inputPlanes + (writeIndex + i) * request.inputSize,
                        request.inputPlanes + i * request.inputSize,
@@ -125,7 +125,7 @@ void InferenceWorker::run() {
         nnUser->nets[0]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
 
         // -- deliver results to each requester via promise --
-        for (InferenceRequest& request : batch) {
+        for (InferenceRequest& request : batches) {
             InferenceResult res;
             res.valueOutputs.resize(request.batchCount);
             res.probOutputs.resize(request.batchCount * policySize);

--- a/engine/src/inference/inferenceworker.cpp
+++ b/engine/src/inference/inferenceworker.cpp
@@ -79,7 +79,6 @@ void InferenceWorker::run() {
 
         // Gather more requests up to maxBatchSize with short non-blocking loop
         InferenceRequest req;
-        auto start = std::chrono::steady_clock::now();
         while (batches.size() < maxBatchSize) {
             // try immediate pop first
             if (queue->try_pop(req)) {
@@ -118,7 +117,6 @@ void InferenceWorker::run() {
             request.outputOffset = writeIndex;
             writeIndex += request.batchCount;
         }
-        size_t totalBatch = writeIndex;
 
         // --- Perform NN inference on hostInput ---
         // TODO: select_nn_index()

--- a/engine/src/inference/inferenceworker.cpp
+++ b/engine/src/inference/inferenceworker.cpp
@@ -112,7 +112,7 @@ void InferenceWorker::run() {
         for (InferenceRequest& request : batches) {
             for (size_t i = 0; i < request.batchCount; i++) {
                 memcpy(nnUser->inputPlanes + (writeIndex + i) * request.inputSize,
-                       request.inputPlanes + i * request.inputSize,
+                       request.inputData.data() + i * request.inputSize,
                        request.inputSize * sizeof(float));
             }
             request.outputOffset = writeIndex;

--- a/engine/src/inference/inferenceworker.h
+++ b/engine/src/inference/inferenceworker.h
@@ -1,0 +1,78 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: inferenceworker.h
+ * Created on 10.12.2025
+ * @author: queensgambit
+ *
+ *
+ */
+
+#ifndef INFERENCEWORKER_H
+#define INFERENCEWORKER_H
+
+#include "inferencequeue.h"
+#include "nn/neuralnetapiuser.h"
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+
+class InferenceWorker {
+public:
+    InferenceWorker(std::shared_ptr<InferenceQueue> queue,
+                    std::shared_ptr<NeuralNetAPIUser> nnUser,
+                    size_t maxBatchSize,
+                    size_t policySize,
+                    size_t auxSize = 0,
+                    std::chrono::milliseconds gatherTimeout = std::chrono::milliseconds(2));
+
+
+    ~InferenceWorker();
+
+    /**
+     * @brief start start worker thread
+     */
+    void start();
+
+    /**
+     * @brief stop stop worker and join
+     */
+    void stop();
+
+
+private:
+    /**
+     * @brief run Runs the inference worker
+     */
+    void run();
+
+    std::shared_ptr<InferenceQueue> queue;
+    std::shared_ptr<NeuralNetAPIUser> nnUser;
+    const size_t maxBatchSize;
+    const size_t policySize;
+    const size_t auxSize;
+    const std::chrono::milliseconds gatherTimeout;
+
+    std::thread workerThread;
+    std::atomic<bool> running{false};
+};
+#endif // INFERENCEWORKER_H

--- a/engine/src/nn/neuralnetapiuser.cpp
+++ b/engine/src/nn/neuralnetapiuser.cpp
@@ -37,6 +37,20 @@ NeuralNetAPIUser::NeuralNetAPIUser(const vector<unique_ptr<NeuralNetAPI>>& netsN
     for (size_t idx = 0; idx < netsNew.size(); idx++) {
         nets.push_back(netsNew[idx].get());
     }
+    init_members();
+}
+
+NeuralNetAPIUser::NeuralNetAPIUser(const vector<NeuralNetAPI *> netsNew) :
+    auxiliaryOutputs(nullptr)
+{
+    for (size_t idx = 0; idx < netsNew.size(); idx++) {
+        nets.push_back(netsNew[idx]);
+    }
+    init_members();
+}
+
+void NeuralNetAPIUser::init_members()
+{
     numPhases = nets.size();
     for (unsigned int i = 0; i < numPhases; i++)
     {
@@ -45,7 +59,7 @@ NeuralNetAPIUser::NeuralNetAPIUser(const vector<unique_ptr<NeuralNetAPI>>& netsN
         assert(phaseToNetsIndex.count(phaseOfNetI) == 0); // no net should have the same phase as another net
         phaseToNetsIndex[phaseOfNetI] = i;
     }
-    
+
     // allocate memory for all predictions and results
 #ifdef TENSORRT
 #ifdef DYNAMIC_NN_ARCH

--- a/engine/src/nn/neuralnetapiuser.h
+++ b/engine/src/nn/neuralnetapiuser.h
@@ -36,7 +36,7 @@
  */
 class NeuralNetAPIUser
 {
-protected:
+public:
     vector<NeuralNetAPI*> nets; // vector of net objects
     unsigned int numPhases;
     std::map<GamePhase, int> phaseToNetsIndex;  // maps a GamePhase to the index of the net that should be used

--- a/engine/src/nn/neuralnetapiuser.h
+++ b/engine/src/nn/neuralnetapiuser.h
@@ -51,6 +51,7 @@ public:
 
 public:
     NeuralNetAPIUser(const vector<unique_ptr<NeuralNetAPI>>& netsNew);
+    NeuralNetAPIUser(const vector<NeuralNetAPI*> netsNew);
     ~NeuralNetAPIUser();
     NeuralNetAPIUser(NeuralNetAPIUser&) = delete;
 
@@ -66,6 +67,11 @@ public:
      * @return numPhases
      */
     unsigned int get_num_phases() const;
+
+    /**
+     * @brief init_members Initialize member and allocates memory.
+     */
+    void init_members();
 };
 
 #endif // NEURALNETAPIUSER_H

--- a/engine/src/rl/fileio.py
+++ b/engine/src/rl/fileio.py
@@ -402,7 +402,7 @@ class FileIO:
         nan_detected = False
 
         for key in keys:
-            logging.info(f"Merging key: {key}...")
+            logging.debug(f"Merging key: {key}...")
 
             # Calculate the total number of samples (sum of first dimension)
             total_rows = sum(src[key].shape[0] for src in sources)

--- a/engine/src/rl/fileio.py
+++ b/engine/src/rl/fileio.py
@@ -8,6 +8,7 @@ Contains the main class to handle files and directories during Reinforcement Lea
 Additionally, a function to compress zarr datasets is provided.
 """
 import os
+import shutil
 import glob
 import zarr
 import time
@@ -289,7 +290,7 @@ class FileIO:
     def _retrieve_end_idx(self, data):
         """
         Checks the y_policy sum in the data for is_moe is False and
-        returns the first occurence of only 0s.
+        returns the first occurrence of only 0s.
         An end_idx of 0 means the whole dataset will be used
         :param data: Zarr data object
         :return: end_idx
@@ -302,6 +303,176 @@ class FileIO:
         if sum_y_policy[potential_end_idx] == 0:
             return potential_end_idx
         return 0
+
+    def _merge_pgn_files(self, output_filename: str, input_prefix: str, num_files: int):
+        """
+        Merges the content of all small pgn files to a single file.
+        :param output_filename: File in which all content will be exported
+        :param input_prefix: Input prefix (e.g. "games_gpu0")
+        :param num_files: Number of individual files
+        :return:
+        """
+        with open(self.binary_dir + output_filename, 'wb') as outfile:
+            for i in range(num_files):
+                input_filename = self.binary_dir + f"{input_prefix}_{i}.pgn"
+
+                if os.path.exists(input_filename):
+                    with open(input_filename, 'rb') as infile:
+                        shutil.copyfileobj(infile, outfile)
+                else:
+                    raise FileNotFoundError(f'Error: {input_filename} was not found')
+
+
+    def _merge_game_idx_files(self, output_filename: str, input_prefix: str, num_files: int):
+        """
+        Reads numbers from multiple files, sums them up and exports the result.
+
+        :param output_filename: File in which the sum will be exported to.
+        :param input_prefix: Input prefix (e.g. "gameIdx_gpu0")
+        :param num_files: Number of individual files
+        :return:
+        """
+        total_count = 0
+
+        for i in range(num_files):
+            input_filename = self.binary_dir + f"{input_prefix}_{i}.txt"
+
+            if os.path.exists(input_filename):
+                try:
+                    with open(input_filename, 'r') as infile:
+                        content = infile.read().strip()
+                        if content:
+                            total_count += int(content)
+                except ValueError:
+                    raise ValueError(f"The content of {input_filename} is not a valid number.")
+            else:
+                raise FileNotFoundError(f'Error: {input_filename} was not found')
+
+        # write final result to file
+        with open(self.binary_dir + output_filename, 'w') as outfile:
+            outfile.write(str(total_count))
+
+    def _remove_individual_files(self, file_prefix: str, suffix, num_files):
+        """
+        Removes the individual files.
+        :param file_prefix: File prefix (e.g. "games_gpu0")
+        :param suffix: file type
+        :param num_files: Number of files
+        :return:
+        """
+        for i in range(num_files):
+            filename = self.binary_dir + f"{file_prefix}_{i}.{suffix}"
+            os.remove(filename)
+
+    def _merge_and_compress_zarr_datasets(self, input_prefix, output_path, num_files, compression='lz4', clevel=5):
+        """
+        Combines multiple uncompressed Zarr directories into a single compressed ZipStore.
+
+        :param input_prefix: The prefix before the index (e.g., "data_gpu0")
+        :param output_path: Path for the final compressed file (e.g., "data_gpu0_final.zip")
+        :param num_files: Number of input files to process
+        :param compression: Compression algorithm for Blosc
+        :param clevel: Compression level (1-9)
+        :return: export_dir
+        """
+        # 1. Gather all existing input paths
+        input_paths = [self.binary_dir + f"{input_prefix}_{i}.zarr" for i in range(num_files)]
+        sources = []
+
+        for path in input_paths:
+            if os.path.exists(path):
+                sources.append(zarr.open(path, mode='r'))
+            else:
+                logging.warning(f"Source file not found: {path}")
+
+        if not sources:
+            logging.error("No source files found to merge.")
+            return False
+
+        export_dir, time_stamp = self.create_export_dir(phase, device_name)
+        zarr_path = export_dir + time_stamp + ".zip"
+
+        # 2. Setup compressor and destination store
+        compressor = Blosc(cname=compression, clevel=clevel, shuffle=Blosc.SHUFFLE)
+        store = zarr.ZipStore(zarr_path, mode="w")
+        target_group = zarr.group(store=store)
+
+        # Get keys from the first source (e.g., 'input_planes', 'value_targets', etc.)
+        keys = list(sources[0].keys())
+        nan_detected = False
+
+        for key in keys:
+            logging.info(f"Merging key: {key}...")
+
+            # Calculate the total number of samples (sum of first dimension)
+            total_rows = sum(src[key].shape[0] for src in sources)
+
+            # Determine target shape and chunking
+            # Chunks are set to 128 for the first dimension, as per your requirements
+            original_shape = list(sources[0][key].shape)
+            target_shape = original_shape.copy()
+            target_shape[0] = total_rows
+
+            chunk_shape = original_shape.copy()
+            chunk_shape[0] = 128
+
+            # 3. Create the empty dataset in the target file
+            target_ds = target_group.create_dataset(
+                name=key,
+                shape=tuple(target_shape),
+                chunks=tuple(chunk_shape),
+                dtype=sources[0][key].dtype,
+                compression=compressor,
+                synchronizer=zarr.ThreadSynchronizer()
+            )
+
+            # 4. Copy data from sources into the target slice-by-slice
+            current_offset = 0
+            for src in sources:
+                data_chunk = src[key][:]  # Load source data into memory
+
+                # Check for data integrity
+                if np.isnan(data_chunk).any():
+                    nan_detected = True
+                    logging.warning(f"NaN detected in {key} of a source file!")
+
+                num_rows = data_chunk.shape[0]
+                # Write to the specific pre-calculated slice in the destination
+                target_ds[current_offset: current_offset + num_rows] = data_chunk
+                current_offset += num_rows
+
+        store.close()
+        logging.info(f"Successfully exported compressed dataset to: {output_path}")
+        return export_dir
+
+    def combine_dataset_and_files(self, device_name: str, number_parallel_games: int):
+        """
+        Combines the dataset as well as pgn and txt-files into a single file each.
+        :param device_name: The currently active device name (context_device-id)
+        :param number_parallel_games: How many separate files have been generated
+        :return:
+        """
+
+        self._merge_pgn_files(
+            output_filename=f"games_{device_name}.pgn",
+            input_prefix=f"games_{device_name}",
+            num_files=number_parallel_games
+        )
+
+        self._merge_game_idx_files(
+            output_filename=f"gameIdx_{device_name}.txt",
+            input_prefix=f"gameIdx_{device_name}",
+            num_files=8
+        )
+
+        export_dir = self._merge_and_compress_zarr_datasets(input_prefix=f"data_{device_name}",
+                                                           output_path=f"data_{device_name}.zip",
+                                                           num_files=number_parallel_games)
+
+        self._remove_individual_files(f"games_{device_name}", "pgn", number_parallel_games)
+        self._remove_individual_files(f"gameIdx_{device_name}", "txt", number_parallel_games)
+
+        self.move_game_data_to_export_dir(export_dir, device_name)
 
     def compress_dataset(self, device_name: str):
         """

--- a/engine/src/rl/fileio.py
+++ b/engine/src/rl/fileio.py
@@ -364,12 +364,12 @@ class FileIO:
             filename = self.binary_dir + f"{file_prefix}_{i}.{suffix}"
             os.remove(filename)
 
-    def _merge_and_compress_zarr_datasets(self, input_prefix, output_path, num_files, compression='lz4', clevel=5):
+    def _merge_and_compress_zarr_datasets(self, device_name, input_prefix: str, num_files: int, compression='lz4', clevel=5):
         """
         Combines multiple uncompressed Zarr directories into a single compressed ZipStore.
 
+        :param device_name: Device name (e.g. "gpu0")
         :param input_prefix: The prefix before the index (e.g., "data_gpu0")
-        :param output_path: Path for the final compressed file (e.g., "data_gpu0_final.zip")
         :param num_files: Number of input files to process
         :param compression: Compression algorithm for Blosc
         :param clevel: Compression level (1-9)
@@ -389,7 +389,7 @@ class FileIO:
             logging.error("No source files found to merge.")
             return False
 
-        export_dir, time_stamp = self.create_export_dir(phase, device_name)
+        export_dir, time_stamp = self.create_export_dir("", device_name)
         zarr_path = export_dir + time_stamp + ".zip"
 
         # 2. Setup compressor and destination store
@@ -434,22 +434,28 @@ class FileIO:
                 # Check for data integrity
                 if np.isnan(data_chunk).any():
                     nan_detected = True
-                    logging.warning(f"NaN detected in {key} of a source file!")
+                    logging.error(f"NaN detected in {key} of a source file!")
 
                 num_rows = data_chunk.shape[0]
                 # Write to the specific pre-calculated slice in the destination
                 target_ds[current_offset: current_offset + num_rows] = data_chunk
                 current_offset += num_rows
 
+        if nan_detected is True:
+            logging.error("NaN value detected in file %s.zip" % time_stamp)
+            new_export_dir = self.binary_dir + time_stamp
+            os.rename(export_dir, new_export_dir)
+            export_dir = new_export_dir
+
         store.close()
-        logging.info(f"Successfully exported compressed dataset to: {output_path}")
+        logging.info(f"Successfully exported compressed dataset to: {zarr_path}")
         return export_dir
 
     def combine_dataset_and_files(self, device_name: str, number_parallel_games: int):
         """
         Combines the dataset as well as pgn and txt-files into a single file each.
         :param device_name: The currently active device name (context_device-id)
-        :param number_parallel_games: How many separate files have been generated
+        :param number_parallel_games: How many files have been generated
         :return:
         """
 
@@ -462,12 +468,12 @@ class FileIO:
         self._merge_game_idx_files(
             output_filename=f"gameIdx_{device_name}.txt",
             input_prefix=f"gameIdx_{device_name}",
-            num_files=8
+            num_files=number_parallel_games
         )
 
-        export_dir = self._merge_and_compress_zarr_datasets(input_prefix=f"data_{device_name}",
-                                                           output_path=f"data_{device_name}.zip",
-                                                           num_files=number_parallel_games)
+        export_dir = self._merge_and_compress_zarr_datasets(device_name=device_name,
+                                                            input_prefix=f"data_{device_name}",
+                                                            num_files=number_parallel_games)
 
         self._remove_individual_files(f"games_{device_name}", "pgn", number_parallel_games)
         self._remove_individual_files(f"gameIdx_{device_name}", "txt", number_parallel_games)

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -24,7 +24,7 @@ from engine.src.rl.binaryio import BinaryIO
 from engine.src.rl.fileio import FileIO
 from DeepCrazyhouse.configs.main_config import main_config
 from DeepCrazyhouse.configs.train_config import rl_train_config
-from DeepCrazyhouse.configs.rl_config import RLConfig, UCIConfigArena
+from DeepCrazyhouse.configs.rl_config import RLConfig, UCIConfigArena, UCIConfig
 from engine.src.rl.rl_training import update_network
 
 
@@ -245,6 +245,7 @@ def main():
     """
     args = parse_args(sys.argv[1:])
     rl_config = RLConfig()
+    uci_config = UCIConfig()
 
     if not os.path.exists(rl_config.binary_dir):
         raise Exception(f'Your given binary_dir: {rl_config.binary_dir} does not exist. '
@@ -285,6 +286,8 @@ def main():
             break
 
         rl_loop.binary_io.generate_games()
+        if uci_config.Number_Parallel_Games > 1:
+            rl_loop.file_io.combine_dataset_and_files(rl_loop.device_name, uci_config.Number_Parallel_Games)
         rl_loop.file_io.compress_dataset(rl_loop.device_name)
 
 

--- a/engine/src/rl/rl_loop.py
+++ b/engine/src/rl/rl_loop.py
@@ -288,7 +288,8 @@ def main():
         rl_loop.binary_io.generate_games()
         if uci_config.Number_Parallel_Games > 1:
             rl_loop.file_io.combine_dataset_and_files(rl_loop.device_name, uci_config.Number_Parallel_Games)
-        rl_loop.file_io.compress_dataset(rl_loop.device_name)
+        else:
+            rl_loop.file_io.compress_dataset(rl_loop.device_name)
 
 
 if __name__ == "__main__":

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -191,7 +191,7 @@ void SelfPlay::reset_search_params(bool isQuickSearch)
     }
 }
 
-void SelfPlay::generate_game(int variant, bool verbose, std::mutex& selfplayFileMutex)
+void SelfPlay::generate_game(int variant, bool verbose, std::mutex* selfplayFileMutex)
 {
     chrono::steady_clock::time_point gameStartTime = chrono::steady_clock::now();
 
@@ -247,13 +247,13 @@ void SelfPlay::generate_game(int variant, bool verbose, std::mutex& selfplayFile
 
     // export all training samples of the generated game
     for (size_t idx = 0; idx < this->exporters.size(); ++idx) {
-        std::lock_guard<std::mutex> lock(selfplayFileMutex);
+        std::lock_guard<std::mutex> lock(*selfplayFileMutex);
         exporters[idx]->export_game_samples(gameResult);
     }
 
     set_game_result_to_pgn(gameResult);
     {
-        std::lock_guard<std::mutex> lock(selfplayFileMutex);
+        std::lock_guard<std::mutex> lock(*selfplayFileMutex);
         write_game_to_pgn(filenamePGNSelfplay, verbose);
     }
     clean_up(gamePGN, mctsAgent);
@@ -370,7 +370,7 @@ size_t SelfPlay::max_samples_per_iteration() const
     return rlSettings->numberChunks * rlSettings->chunkSize;
 }
 
-void SelfPlay::go(size_t numberOfGames, int variant, std::mutex& selfplayFileMutex)
+void SelfPlay::go(size_t numberOfGames, int variant, std::mutex* selfplayFileMutex)
 {
     generatedSamples = 0;
     reset_speed_statistics();
@@ -492,8 +492,8 @@ void apply_raw_policy_temp(EvalInfo &eval, float rawPolicyProbTemp)
     }
 }
 
-void run_selfplay_thread(Selfplay& selfPlay, size_t numberOfGames, int variant, std::mutex& selfplayFileMutex))
+void run_selfplay_thread(SelfPlay* selfPlay, size_t numberOfGames, int variant, std::mutex* selfplayFileMutex)
 {
-    selfPlay.go(numberOfGames, variant, selfplayFileMutex);
+    selfPlay->go(numberOfGames, variant, selfplayFileMutex);
 }
 #endif

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -368,7 +368,7 @@ void SelfPlay::export_number_generated_games() const
 
 size_t SelfPlay::max_samples_per_iteration() const
 {
-    return rlSettings->numberChunks * rlSettings->chunkSize;
+    return (rlSettings->numberChunks / searchSettings->numberParallelGames) * rlSettings->chunkSize;
 }
 
 void SelfPlay::go(size_t numberOfGames, int variant)

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -80,7 +80,7 @@ string load_random_fen(string filepath)
 
 
 SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, const SearchSettings* searchSettings, SearchLimits* searchLimits, const PlaySettings* playSettings,
-                   const RLSettings* rlSettings, OptionsMap& options):
+                   const RLSettings* rlSettings, OptionsMap& options, size_t* gameIdx, size_t* startIdx):
     rawAgent(rawAgent), mctsAgent(mctsAgent), searchSettings(searchSettings), searchLimits(searchLimits), playSettings(playSettings),
     rlSettings(rlSettings), gameIdx(0), gamesPerMin(0), samplesPerMin(0), options(options), generatedSamples(0)
 {
@@ -112,6 +112,7 @@ SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, const SearchSett
     gamePGN.site = "Darmstadt, GER";
     gamePGN.round = "?";
     gamePGN.is960 = is960;
+
     for (size_t idx = 0; idx < mctsAgent->get_num_phases(); ++idx) {
         string fileNameExport = string("data_") + mctsAgent->get_device_name() + string(".zarr");
         if (mctsAgent->get_num_phases() > 1) {
@@ -120,6 +121,7 @@ SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, const SearchSett
         this->exporters.push_back(make_unique<TrainDataExporter>(fileNameExport,
                                                                  mctsAgent->get_num_phases(),
                                                                  searchSettings->gamePhaseDefinition,
+                                                                 gameIdx, startIdx,
                                                                  rlSettings->numberChunks, rlSettings->chunkSize));
     }
     filenamePGNSelfplay = string("games_") + mctsAgent->get_device_name() + string(".pgn");

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -189,7 +189,7 @@ void SelfPlay::reset_search_params(bool isQuickSearch)
     }
 }
 
-void SelfPlay::generate_game(int variant, bool verbose)
+void SelfPlay::generate_game(int variant, bool verbose, std::mutex& selfplayFileMutex)
 {
     chrono::steady_clock::time_point gameStartTime = chrono::steady_clock::now();
 
@@ -245,11 +245,15 @@ void SelfPlay::generate_game(int variant, bool verbose)
 
     // export all training samples of the generated game
     for (size_t idx = 0; idx < this->exporters.size(); ++idx) {
+        std::lock_guard<std::mutex> lock(file_write_mutex);
         exporters[idx]->export_game_samples(gameResult);
     }
 
     set_game_result_to_pgn(gameResult);
-    write_game_to_pgn(filenamePGNSelfplay, verbose);
+    {
+        std::lock_guard<std::mutex> lock(file_write_mutex);
+        write_game_to_pgn(filenamePGNSelfplay, verbose);
+    }
     clean_up(gamePGN, mctsAgent);
 
     // measure time statistics
@@ -364,7 +368,7 @@ size_t SelfPlay::max_samples_per_iteration() const
     return rlSettings->numberChunks * rlSettings->chunkSize;
 }
 
-void SelfPlay::go(size_t numberOfGames, int variant)
+void SelfPlay::go(size_t numberOfGames, int variant, std::mutex& selfplayFileMutex)
 {
     generatedSamples = 0;
     reset_speed_statistics();

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -113,20 +113,24 @@ SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, const SearchSett
     gamePGN.round = "?";
     gamePGN.is960 = is960;
 
+    string agentSpecifier = "";
+    if (searchSettings->numberParallelGames > 1) {
+        agentSpecifier = string("_") + std::to_string(mctsAgent->get_agent_id());
+    }
+
     for (size_t idx = 0; idx < mctsAgent->get_num_phases(); ++idx) {
-        string fileNameExport = string("data_") + mctsAgent->get_device_name() + string(".zarr");
+        string fileNameExport = string("data_") + mctsAgent->get_device_name() + agentSpecifier + string(".zarr");
         if (mctsAgent->get_num_phases() > 1) {
             fileNameExport = string("phase") + std::to_string(idx) + string("/") + fileNameExport;
         }
         this->exporters.push_back(make_unique<TrainDataExporter>(fileNameExport,
                                                                  mctsAgent->get_num_phases(),
                                                                  searchSettings->gamePhaseDefinition,
-                                                                 gameIdx, startIdx,
-                                                                 rlSettings->numberChunks, rlSettings->chunkSize));
+                                                                 rlSettings->numberChunks / searchSettings->numberParallelGames, rlSettings->chunkSize));
     }
-    filenamePGNSelfplay = string("games_") + mctsAgent->get_device_name() + string(".pgn");
-    filenamePGNArena = string("arena_games_")+ mctsAgent->get_device_name() + string(".pgn");
-    fileNameGameIdx = string("gameIdx_") + mctsAgent->get_device_name() + string(".txt");
+    filenamePGNSelfplay = string("games_") + mctsAgent->get_device_name() + agentSpecifier + string(".pgn");
+    filenamePGNArena = string("arena_games_")+ mctsAgent->get_device_name() + agentSpecifier + string(".pgn");
+    fileNameGameIdx = string("gameIdx_") + mctsAgent->get_device_name() + agentSpecifier + string(".txt");
 
     // delete content of files
     ofstream pgnFile;
@@ -191,7 +195,7 @@ void SelfPlay::reset_search_params(bool isQuickSearch)
     }
 }
 
-void SelfPlay::generate_game(int variant, bool verbose, std::mutex* selfplayFileMutex)
+void SelfPlay::generate_game(int variant, bool verbose)
 {
     chrono::steady_clock::time_point gameStartTime = chrono::steady_clock::now();
 
@@ -249,15 +253,12 @@ void SelfPlay::generate_game(int variant, bool verbose, std::mutex* selfplayFile
 
     // export all training samples of the generated game
     for (size_t idx = 0; idx < this->exporters.size(); ++idx) {
-        std::lock_guard<std::mutex> lock(*selfplayFileMutex);
         exporters[idx]->export_game_samples(gameResult);
     }
 
     set_game_result_to_pgn(gameResult);
-    {
-        std::lock_guard<std::mutex> lock(*selfplayFileMutex);
-        write_game_to_pgn(filenamePGNSelfplay, verbose);
-    }
+    write_game_to_pgn(filenamePGNSelfplay, verbose);
+
     clean_up(gamePGN, mctsAgent);
 
     // measure time statistics
@@ -338,7 +339,7 @@ void SelfPlay::set_game_result_to_pgn(Result res)
 
 void SelfPlay::reset_speed_statistics()
 {
-    *gameIdx = 0;
+    gameIdx = 0;
     gamesPerMin = 0;
     samplesPerMin = 0;
 }
@@ -346,13 +347,13 @@ void SelfPlay::reset_speed_statistics()
 void SelfPlay::speed_statistic_report(float elapsedTimeMin, size_t generatedSamples)
 {
     // compute running cumulative average
-    gamesPerMin = (*gameIdx * gamesPerMin + (1 / elapsedTimeMin)) / (*gameIdx + 1);
-    samplesPerMin = (*gameIdx * samplesPerMin + (generatedSamples / elapsedTimeMin)) / (*gameIdx + 1);
+    gamesPerMin = (gameIdx * gamesPerMin + (1 / elapsedTimeMin)) / (gameIdx + 1);
+    samplesPerMin = (gameIdx * samplesPerMin + (generatedSamples / elapsedTimeMin)) / (gameIdx + 1);
 
     cout << "    games    |  games/min  | samples/min " << endl
          << "-------------+-------------+-------------" << endl
          << std::setprecision(5)
-         << setw(13) << *gameIdx << '|'
+         << setw(13) << gameIdx << '|'
          << setw(13) << gamesPerMin << '|'
          << setw(13) << samplesPerMin << endl << endl;
 }
@@ -361,7 +362,7 @@ void SelfPlay::export_number_generated_games() const
 {
     ofstream gameIdxFile;
     gameIdxFile.open(fileNameGameIdx);
-    gameIdxFile << *gameIdx;
+    gameIdxFile << gameIdx;
     gameIdxFile.close();
 }
 
@@ -371,24 +372,22 @@ size_t SelfPlay::max_samples_per_iteration() const
     return rlSettings->numberChunks * rlSettings->chunkSize;
 }
 
-void SelfPlay::go(size_t numberOfGames, int variant, std::mutex* selfplayFileMutex)
+void SelfPlay::go(size_t numberOfGames, int variant)
 {
     generatedSamples = 0;
-    {
-        std::lock_guard<std::mutex> lock(*selfplayFileMutex);
-        reset_speed_statistics();
-    }
+    reset_speed_statistics();
+
     gamePGN.white = mctsAgent->get_name();
     gamePGN.black = mctsAgent->get_name();
 
     if (numberOfGames == 0) {
         while(generatedSamples < max_samples_per_iteration()) {
-            generate_game(variant, true, selfplayFileMutex);
+            generate_game(variant, true);
         }
     }
     else {
         for (size_t idx = 0; idx < numberOfGames; ++idx) {
-            generate_game(variant, true, selfplayFileMutex);
+            generate_game(variant, true);
         }
     }
     export_number_generated_games();
@@ -496,8 +495,8 @@ void apply_raw_policy_temp(EvalInfo &eval, float rawPolicyProbTemp)
     }
 }
 
-void run_selfplay_thread(SelfPlay* selfPlay, size_t numberOfGames, int variant, std::mutex* selfplayFileMutex)
+void run_selfplay_thread(SelfPlay* selfPlay, size_t numberOfGames, int variant)
 {
-    selfPlay->go(numberOfGames, variant, selfplayFileMutex);
+    selfPlay->go(numberOfGames, variant);
 }
 #endif

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -264,6 +264,7 @@ void SelfPlay::generate_game(int variant, bool verbose)
         const float elapsedTimeMin = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - gameStartTime).count() / 60000.f;
         speed_statistic_report(elapsedTimeMin, generatedSamples - generatedSamplesBeforeGame);
     }
+    ++gameIdx;
 }
 
 Result SelfPlay::generate_arena_game(MCTSAgent* whitePlayer, MCTSAgent* blackPlayer, int variant, bool verbose, const string& fen)

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -82,7 +82,7 @@ string load_random_fen(string filepath)
 SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, const SearchSettings* searchSettings, SearchLimits* searchLimits, const PlaySettings* playSettings,
                    const RLSettings* rlSettings, OptionsMap& options, size_t* gameIdx, size_t* startIdx):
     rawAgent(rawAgent), mctsAgent(mctsAgent), searchSettings(searchSettings), searchLimits(searchLimits), playSettings(playSettings),
-    rlSettings(rlSettings), gameIdx(0), gamesPerMin(0), samplesPerMin(0), options(options), generatedSamples(0)
+    rlSettings(rlSettings), gameIdx(gameIdx), gamesPerMin(0), samplesPerMin(0), options(options), generatedSamples(0)
 {
     is960 = options["UCI_Chess960"];
     string suffix960 = "";
@@ -265,7 +265,6 @@ void SelfPlay::generate_game(int variant, bool verbose, std::mutex* selfplayFile
         const float elapsedTimeMin = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - gameStartTime).count() / 60000.f;
         speed_statistic_report(elapsedTimeMin, generatedSamples - generatedSamplesBeforeGame);
     }
-    ++gameIdx;
 }
 
 Result SelfPlay::generate_arena_game(MCTSAgent* whitePlayer, MCTSAgent* blackPlayer, int variant, bool verbose, const string& fen)
@@ -339,7 +338,7 @@ void SelfPlay::set_game_result_to_pgn(Result res)
 
 void SelfPlay::reset_speed_statistics()
 {
-    gameIdx = 0;
+    *gameIdx = 0;
     gamesPerMin = 0;
     samplesPerMin = 0;
 }
@@ -347,13 +346,13 @@ void SelfPlay::reset_speed_statistics()
 void SelfPlay::speed_statistic_report(float elapsedTimeMin, size_t generatedSamples)
 {
     // compute running cumulative average
-    gamesPerMin = (gameIdx * gamesPerMin + (1 / elapsedTimeMin)) / (gameIdx + 1);
-    samplesPerMin = (gameIdx * samplesPerMin + (generatedSamples / elapsedTimeMin)) / (gameIdx + 1);
+    gamesPerMin = (*gameIdx * gamesPerMin + (1 / elapsedTimeMin)) / (*gameIdx + 1);
+    samplesPerMin = (*gameIdx * samplesPerMin + (generatedSamples / elapsedTimeMin)) / (*gameIdx + 1);
 
     cout << "    games    |  games/min  | samples/min " << endl
          << "-------------+-------------+-------------" << endl
          << std::setprecision(5)
-         << setw(13) << gameIdx << '|'
+         << setw(13) << *gameIdx << '|'
          << setw(13) << gamesPerMin << '|'
          << setw(13) << samplesPerMin << endl << endl;
 }
@@ -362,7 +361,7 @@ void SelfPlay::export_number_generated_games() const
 {
     ofstream gameIdxFile;
     gameIdxFile.open(fileNameGameIdx);
-    gameIdxFile << gameIdx;
+    gameIdxFile << *gameIdx;
     gameIdxFile.close();
 }
 
@@ -375,7 +374,10 @@ size_t SelfPlay::max_samples_per_iteration() const
 void SelfPlay::go(size_t numberOfGames, int variant, std::mutex* selfplayFileMutex)
 {
     generatedSamples = 0;
-    reset_speed_statistics();
+    {
+        std::lock_guard<std::mutex> lock(*selfplayFileMutex);
+        reset_speed_statistics();
+    }
     gamePGN.white = mctsAgent->get_name();
     gamePGN.black = mctsAgent->get_name();
 

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -80,9 +80,9 @@ string load_random_fen(string filepath)
 
 
 SelfPlay::SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, const SearchSettings* searchSettings, SearchLimits* searchLimits, const PlaySettings* playSettings,
-                   const RLSettings* rlSettings, OptionsMap& options, size_t* gameIdx, size_t* startIdx):
+                   const RLSettings* rlSettings, OptionsMap& options):
     rawAgent(rawAgent), mctsAgent(mctsAgent), searchSettings(searchSettings), searchLimits(searchLimits), playSettings(playSettings),
-    rlSettings(rlSettings), gameIdx(gameIdx), gamesPerMin(0), samplesPerMin(0), options(options), generatedSamples(0)
+    rlSettings(rlSettings), gameIdx(0), gamesPerMin(0), samplesPerMin(0), options(options), generatedSamples(0)
 {
     is960 = options["UCI_Chess960"];
     string suffix960 = "";
@@ -205,9 +205,7 @@ void SelfPlay::generate_game(int variant, bool verbose)
     srand(unsigned(int(time(nullptr))));
     // load position from file if epd filepath was set
     string startingFen = load_random_fen(rlSettings->epdFilePath);
-    selfplayFileMutex->lock();
     unique_ptr<StateObj> state = init_starting_state_from_raw_policy(*rawAgent, ply, gamePGN, variant, is960, rlSettings->rawPolicyProbabilityTemperature, startingFen);
-    selfplayFileMutex->unlock();
     EvalInfo evalInfo;
     Result gameResult;
     for (size_t idx = 0; idx < this->exporters.size(); ++idx) {

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -201,7 +201,9 @@ void SelfPlay::generate_game(int variant, bool verbose, std::mutex* selfplayFile
     srand(unsigned(int(time(nullptr))));
     // load position from file if epd filepath was set
     string startingFen = load_random_fen(rlSettings->epdFilePath);
+    selfplayFileMutex->lock();
     unique_ptr<StateObj> state = init_starting_state_from_raw_policy(*rawAgent, ply, gamePGN, variant, is960, rlSettings->rawPolicyProbabilityTemperature, startingFen);
+    selfplayFileMutex->unlock();
     EvalInfo evalInfo;
     Result gameResult;
     for (size_t idx = 0; idx < this->exporters.size(); ++idx) {

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -474,7 +474,7 @@ unique_ptr<StateObj> init_starting_state_from_fixed_move(GamePGN &gamePGN, int v
 size_t clip_ply(size_t ply, size_t maxPly)
 {
     if (ply > maxPly) {
-        return size_t(rand()) % maxPly;
+        return min(ply, maxPly);
     }
     return ply;
 }

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -245,13 +245,13 @@ void SelfPlay::generate_game(int variant, bool verbose, std::mutex& selfplayFile
 
     // export all training samples of the generated game
     for (size_t idx = 0; idx < this->exporters.size(); ++idx) {
-        std::lock_guard<std::mutex> lock(file_write_mutex);
+        std::lock_guard<std::mutex> lock(selfplayFileMutex);
         exporters[idx]->export_game_samples(gameResult);
     }
 
     set_game_result_to_pgn(gameResult);
     {
-        std::lock_guard<std::mutex> lock(file_write_mutex);
+        std::lock_guard<std::mutex> lock(selfplayFileMutex);
         write_game_to_pgn(filenamePGNSelfplay, verbose);
     }
     clean_up(gamePGN, mctsAgent);
@@ -377,12 +377,12 @@ void SelfPlay::go(size_t numberOfGames, int variant, std::mutex& selfplayFileMut
 
     if (numberOfGames == 0) {
         while(generatedSamples < max_samples_per_iteration()) {
-            generate_game(variant, true);
+            generate_game(variant, true, selfplayFileMutex);
         }
     }
     else {
         for (size_t idx = 0; idx < numberOfGames; ++idx) {
-            generate_game(variant, true);
+            generate_game(variant, true, selfplayFileMutex);
         }
     }
     export_number_generated_games();

--- a/engine/src/rl/selfplay.cpp
+++ b/engine/src/rl/selfplay.cpp
@@ -489,4 +489,9 @@ void apply_raw_policy_temp(EvalInfo &eval, float rawPolicyProbTemp)
         apply_temperature(eval.policyProbSmall, temp);
     }
 }
+
+void run_selfplay_thread(Selfplay& selfPlay, size_t numberOfGames, int variant, std::mutex& selfplayFileMutex))
+{
+    selfPlay.go(numberOfGames, variant, selfplayFileMutex);
+}
 #endif

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -105,10 +105,20 @@ public:
      * @param playSettings Playing setting configuration struct
      * @param RLSettings Additional settings for reinforcement learning usage
      * @param options Object holding all UCI options
+     * @param gameIdx Pointer to the shared game index
+     * @param startIdx Pointer to the shared startIdx
      */
     SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, const SearchSettings* searchSettings, SearchLimits* searchLimits, const PlaySettings* playSettings,
-             const RLSettings* rlSettings, OptionsMap& options);
+             const RLSettings* rlSettings, OptionsMap& options, size_t* gameIdx, size_t* startIdx);
     ~SelfPlay();
+
+    // avoid copyiing of the SelfplayObject due to owning std::unique_ptr (e.g. TrainDataExporter)
+    SelfPlay(const SelfPlay&) = delete;
+    SelfPlay& operator=(const SelfPlay&) = delete;
+
+    // optional, but recommended: Allow move semantic explicitly
+    SelfPlay(SelfPlay&&) = default;
+    SelfPlay& operator=(SelfPlay&&) = default;
 
     /**
      * @brief go Starts the self play game generation for a given number of games

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -79,7 +79,7 @@ private:
     string filenamePGNSelfplay;
     string filenamePGNArena;
     string fileNameGameIdx;
-    size_t* gameIdx;
+    size_t gameIdx;
     float gamesPerMin;
     float samplesPerMin;
     size_t backupNodes;
@@ -109,7 +109,7 @@ public:
      * @param startIdx Pointer to the shared startIdx
      */
     SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, const SearchSettings* searchSettings, SearchLimits* searchLimits, const PlaySettings* playSettings,
-             const RLSettings* rlSettings, OptionsMap& options, size_t* gameIdx, size_t* startIdx);
+             const RLSettings* rlSettings, OptionsMap& options);
     ~SelfPlay();
 
     // avoid copyiing of the SelfplayObject due to owning std::unique_ptr (e.g. TrainDataExporter)
@@ -126,7 +126,7 @@ public:
      * @param int variant to generate games for
      * @param std::mutex& Mutex that coordinates the writing of files and export
      */
-    void go(size_t numberOfGames, int variant, std::mutex* selfplayFileMutex);
+    void go(size_t numberOfGames, int variant);
 
     /**
      * @brief go_arena Starts comparision matches between the original mctsAgent with the old NN weights and

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -105,8 +105,6 @@ public:
      * @param playSettings Playing setting configuration struct
      * @param RLSettings Additional settings for reinforcement learning usage
      * @param options Object holding all UCI options
-     * @param gameIdx Pointer to the shared game index
-     * @param startIdx Pointer to the shared startIdx
      */
     SelfPlay(RawNetAgent* rawAgent, MCTSAgent* mctsAgent, const SearchSettings* searchSettings, SearchLimits* searchLimits, const PlaySettings* playSettings,
              const RLSettings* rlSettings, OptionsMap& options);
@@ -145,7 +143,7 @@ private:
      * @param variant Current chess variant
      * @param selfplayFileMutex Mutex that coordinates writing to files
      */
-    void generate_game(int variant, bool verbose, std::mutex* selfplayFileMutex);
+    void generate_game(int variant, bool verbose);
 
     /**
      * @brief generate_arena_game Generates a game of the current NN weights vs the new acquired weights
@@ -226,9 +224,8 @@ private:
  * @param selfPlay selfplay object
  * @param numberOfGames How many games should be generated
  * @param variant What (chess) variant to play
- * @param selfplayFileMutex Common mutex that coordinates the writing to files
  */
-void run_selfplay_thread(SelfPlay* selfPlay, size_t numberOfGames, int variant, std::mutex* selfplayFileMutex);
+void run_selfplay_thread(SelfPlay* selfPlay, size_t numberOfGames, int variant);
 
 #endif
 

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -114,8 +114,9 @@ public:
      * @brief go Starts the self play game generation for a given number of games
      * @param numberOfGames Number of games to generate
      * @param int variant to generate games for
+     * @param std::mutex& Mutex that coordinates the writing of files and export
      */
-    void go(size_t numberOfGames, int variant);
+    void go(size_t numberOfGames, int variant, std::mutex& selfplayFileMutex);
 
     /**
      * @brief go_arena Starts comparision matches between the original mctsAgent with the old NN weights and
@@ -132,8 +133,9 @@ private:
     /**
      * @brief generate_game Generates a new game in self play mode
      * @param variant Current chess variant
+     * @param selfplayFileMutex Mutex that coordinates writing to files
      */
-    void generate_game(int variant, bool verbose);
+    void generate_game(int variant, bool verbose, std::mutex& selfplayFileMutex);
 
     /**
      * @brief generate_arena_game Generates a game of the current NN weights vs the new acquired weights

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -126,7 +126,7 @@ public:
      * @param int variant to generate games for
      * @param std::mutex& Mutex that coordinates the writing of files and export
      */
-    void go(size_t numberOfGames, int variant, std::mutex& selfplayFileMutex);
+    void go(size_t numberOfGames, int variant, std::mutex* selfplayFileMutex);
 
     /**
      * @brief go_arena Starts comparision matches between the original mctsAgent with the old NN weights and
@@ -145,7 +145,7 @@ private:
      * @param variant Current chess variant
      * @param selfplayFileMutex Mutex that coordinates writing to files
      */
-    void generate_game(int variant, bool verbose, std::mutex& selfplayFileMutex);
+    void generate_game(int variant, bool verbose, std::mutex* selfplayFileMutex);
 
     /**
      * @brief generate_arena_game Generates a game of the current NN weights vs the new acquired weights
@@ -223,9 +223,12 @@ private:
 
 /**
  * @brief run_selfplay_thread
- * @param selfPlay
+ * @param selfPlay selfplay object
+ * @param numberOfGames How many games should be generated
+ * @param variant What (chess) variant to play
+ * @param selfplayFileMutex Common mutex that coordinates the writing to files
  */
-void run_selfplay_thread(Selfplay& selfPlay, size_t numberOfGames, int variant, std::mutex& selfplayFileMutex));
+void run_selfplay_thread(SelfPlay* selfPlay, size_t numberOfGames, int variant, std::mutex* selfplayFileMutex);
 
 #endif
 

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -79,7 +79,7 @@ private:
     string filenamePGNSelfplay;
     string filenamePGNArena;
     string fileNameGameIdx;
-    size_t gameIdx;
+    size_t* gameIdx;
     float gamesPerMin;
     float samplesPerMin;
     size_t backupNodes;

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -210,6 +210,13 @@ private:
      */
     void reset_search_params(bool isQuickSearch);
 };
+
+/**
+ * @brief run_selfplay_thread
+ * @param selfPlay
+ */
+void run_selfplay_thread(Selfplay& selfPlay, size_t numberOfGames, int variant, std::mutex& selfplayFileMutex));
+
 #endif
 
 /**

--- a/engine/src/rl/selfplay.h
+++ b/engine/src/rl/selfplay.h
@@ -148,10 +148,10 @@ private:
 
     /**
      * @brief write_game_to_pgn Writes the game log to a pgn file
-     * @param pngFileName Filename to export
+     * @param pgnFileName Filename to export
      * @param verbose If true, game will also be printed to stdout
      */
-    void write_game_to_pgn(const std::string& pngFileName, bool verbose);
+    void write_game_to_pgn(const std::string& pgnFileName, bool verbose);
 
     /**
      * @brief set_game_result Sets the game result to the gamePGN object

--- a/engine/src/rl/traindataexporter.cpp
+++ b/engine/src/rl/traindataexporter.cpp
@@ -108,7 +108,7 @@ void TrainDataExporter::export_game_samples(Result result) {
         return;
     }
 
-    if (*startIdx >= numberSamples) {
+    if (*startIdx+curSampleIdx >= numberSamples) {
         info_string("Extended number of maximum samples");
         return;
     }

--- a/engine/src/rl/traindataexporter.cpp
+++ b/engine/src/rl/traindataexporter.cpp
@@ -129,7 +129,7 @@ void TrainDataExporter::export_game_samples(Result result) {
     z5::multiarray::writeSubarray<int16_t>(dPhaseVector, gamePhaseVector, offset.begin());
 
     *startIdx += curSampleIdx;
-    *gameIdx++;
+    *gameIdx = *gameIdx + 1;
     save_start_idx();
 }
 

--- a/engine/src/rl/traindataexporter.cpp
+++ b/engine/src/rl/traindataexporter.cpp
@@ -31,7 +31,7 @@
 
 void TrainDataExporter::save_sample(const StateObj* pos, const EvalInfo& eval)
 {
-    if (*startIdx+curSampleIdx >= numberSamples) {
+    if (startIdx+curSampleIdx >= numberSamples) {
         info_string("Extended number of maximum samples");
         return;
     }
@@ -108,7 +108,7 @@ void TrainDataExporter::export_game_samples(Result result) {
         return;
     }
 
-    if (*startIdx+curSampleIdx >= numberSamples) {
+    if (startIdx >= numberSamples) {
         info_string("Extended number of maximum samples");
         return;
     }
@@ -118,26 +118,26 @@ void TrainDataExporter::export_game_samples(Result result) {
     apply_result_to_plys_to_end();
 
     // write value to roi
-    z5::types::ShapeType offset = { *startIdx };
-    z5::types::ShapeType offsetPlanes = { *startIdx, 0, 0, 0 };
+    z5::types::ShapeType offset = { startIdx };
+    z5::types::ShapeType offsetPlanes = { startIdx, 0, 0, 0 };
     z5::multiarray::writeSubarray<int16_t>(dx, gameX, offsetPlanes.begin());
     z5::multiarray::writeSubarray<int16_t>(dValue, gameValue, offset.begin());
     z5::multiarray::writeSubarray<float>(dbestMoveQ, gameBestMoveQ, offset.begin());
-    z5::types::ShapeType offsetPolicy = { *startIdx, 0 };
+    z5::types::ShapeType offsetPolicy = { startIdx, 0 };
     z5::multiarray::writeSubarray<float>(dPolicy, gamePolicy, offsetPolicy.begin());
     z5::multiarray::writeSubarray<int16_t>(dPlysToEnd, gamePlysToEnd, offset.begin());
     z5::multiarray::writeSubarray<int16_t>(dPhaseVector, gamePhaseVector, offset.begin());
 
-    *startIdx += curSampleIdx;
-    *gameIdx = *gameIdx + 1;
+    startIdx += curSampleIdx;
+    gameIdx++;
     save_start_idx();
 }
 
-TrainDataExporter::TrainDataExporter(const string& fileName, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t* gameIdx, size_t* startIdx, size_t numberChunks, size_t chunkSize):
+TrainDataExporter::TrainDataExporter(const string& fileName, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t numberChunks, size_t chunkSize):
     numPhases(numPhases),
     gamePhaseDefinition(gamePhaseDefinition),
-    gameIdx(gameIdx),
-    startIdx(startIdx),
+    gameIdx(0),
+    startIdx(0),
     numberChunks(numberChunks),
     chunkSize(chunkSize),
     numberSamples(numberChunks * chunkSize),
@@ -163,7 +163,7 @@ size_t TrainDataExporter::get_number_samples() const
 
 bool TrainDataExporter::is_file_full()
 {
-    return *startIdx >= numberSamples;
+    return startIdx >= numberSamples;
 }
 
 void TrainDataExporter::new_game()
@@ -224,8 +224,8 @@ void TrainDataExporter::save_start_idx()
 {
     // gameStartIdx
     // write value to roi
-    z5::types::ShapeType offsetStartIdx = { *gameIdx };
-    xt::xarray<int32_t> arrayGameStartIdx({ 1 }, int32_t(*startIdx));
+    z5::types::ShapeType offsetStartIdx = { gameIdx };
+    xt::xarray<int32_t> arrayGameStartIdx({ 1 }, int32_t(startIdx));
     z5::multiarray::writeSubarray<int32_t>(dStartIndex, arrayGameStartIdx, offsetStartIdx.begin());
 }
 

--- a/engine/src/rl/traindataexporter.cpp
+++ b/engine/src/rl/traindataexporter.cpp
@@ -108,7 +108,7 @@ void TrainDataExporter::export_game_samples(Result result) {
         return;
     }
 
-    if (startIdx >= numberSamples) {
+    if (*startIdx >= numberSamples) {
         info_string("Extended number of maximum samples");
         return;
     }
@@ -118,30 +118,31 @@ void TrainDataExporter::export_game_samples(Result result) {
     apply_result_to_plys_to_end();
 
     // write value to roi
-    z5::types::ShapeType offset = { startIdx };
-    z5::types::ShapeType offsetPlanes = { startIdx, 0, 0, 0 };
+    z5::types::ShapeType offset = { *startIdx };
+    z5::types::ShapeType offsetPlanes = { *startIdx, 0, 0, 0 };
     z5::multiarray::writeSubarray<int16_t>(dx, gameX, offsetPlanes.begin());
     z5::multiarray::writeSubarray<int16_t>(dValue, gameValue, offset.begin());
     z5::multiarray::writeSubarray<float>(dbestMoveQ, gameBestMoveQ, offset.begin());
-    z5::types::ShapeType offsetPolicy = { startIdx, 0 };
+    z5::types::ShapeType offsetPolicy = { *startIdx, 0 };
     z5::multiarray::writeSubarray<float>(dPolicy, gamePolicy, offsetPolicy.begin());
     z5::multiarray::writeSubarray<int16_t>(dPlysToEnd, gamePlysToEnd, offset.begin());
     z5::multiarray::writeSubarray<int16_t>(dPhaseVector, gamePhaseVector, offset.begin());
 
-    startIdx += curSampleIdx;
-    gameIdx++;
+    *startIdx += curSampleIdx;
+    *gameIdx++;
     save_start_idx();
 }
 
-TrainDataExporter::TrainDataExporter(const string& fileName, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t numberChunks, size_t chunkSize):
+TrainDataExporter::TrainDataExporter(const string& fileName, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t numberChunks, size_t chunkSize,
+                                     size_t* gameIdx, size_t* startIdx):
     numPhases(numPhases),
     gamePhaseDefinition(gamePhaseDefinition),
     numberChunks(numberChunks),
     chunkSize(chunkSize),
     numberSamples(numberChunks * chunkSize),
     firstMove(true),
-    gameIdx(0),
-    startIdx(0),
+    gameIdx(gameIdx),
+    startIdx(startIdx),
     curSampleIdx(0)
 {
     // get handle to a File on the filesystem
@@ -224,7 +225,7 @@ void TrainDataExporter::save_start_idx()
 {
     // gameStartIdx
     // write value to roi
-    z5::types::ShapeType offsetStartIdx = { gameIdx };
+    z5::types::ShapeType offsetStartIdx = { *gameIdx };
     xt::xarray<int32_t> arrayGameStartIdx({ 1 }, int32_t(startIdx));
     z5::multiarray::writeSubarray<int32_t>(dStartIndex, arrayGameStartIdx, offsetStartIdx.begin());
 }

--- a/engine/src/rl/traindataexporter.cpp
+++ b/engine/src/rl/traindataexporter.cpp
@@ -31,7 +31,7 @@
 
 void TrainDataExporter::save_sample(const StateObj* pos, const EvalInfo& eval)
 {
-    if (startIdx+curSampleIdx >= numberSamples) {
+    if (*startIdx+curSampleIdx >= numberSamples) {
         info_string("Extended number of maximum samples");
         return;
     }
@@ -133,16 +133,15 @@ void TrainDataExporter::export_game_samples(Result result) {
     save_start_idx();
 }
 
-TrainDataExporter::TrainDataExporter(const string& fileName, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t numberChunks, size_t chunkSize,
-                                     size_t* gameIdx, size_t* startIdx):
+TrainDataExporter::TrainDataExporter(const string& fileName, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t* gameIdx, size_t* startIdx, size_t numberChunks, size_t chunkSize):
     numPhases(numPhases),
     gamePhaseDefinition(gamePhaseDefinition),
+    gameIdx(gameIdx),
+    startIdx(startIdx),
     numberChunks(numberChunks),
     chunkSize(chunkSize),
     numberSamples(numberChunks * chunkSize),
     firstMove(true),
-    gameIdx(gameIdx),
-    startIdx(startIdx),
     curSampleIdx(0)
 {
     // get handle to a File on the filesystem
@@ -164,7 +163,7 @@ size_t TrainDataExporter::get_number_samples() const
 
 bool TrainDataExporter::is_file_full()
 {
-    return startIdx >= numberSamples;
+    return *startIdx >= numberSamples;
 }
 
 void TrainDataExporter::new_game()
@@ -226,7 +225,7 @@ void TrainDataExporter::save_start_idx()
     // gameStartIdx
     // write value to roi
     z5::types::ShapeType offsetStartIdx = { *gameIdx };
-    xt::xarray<int32_t> arrayGameStartIdx({ 1 }, int32_t(startIdx));
+    xt::xarray<int32_t> arrayGameStartIdx({ 1 }, int32_t(*startIdx));
     z5::multiarray::writeSubarray<int32_t>(dStartIndex, arrayGameStartIdx, offsetStartIdx.begin());
 }
 

--- a/engine/src/rl/traindataexporter.h
+++ b/engine/src/rl/traindataexporter.h
@@ -70,9 +70,9 @@ private:
     bool firstMove;
 
     // current number of games - 1
-    size_t gameIdx;
+    size_t* gameIdx;
     // current sample index to insert
-    size_t startIdx;
+    size_t* startIdx;
     // current sample index of the current game
     size_t curSampleIdx;
 

--- a/engine/src/rl/traindataexporter.h
+++ b/engine/src/rl/traindataexporter.h
@@ -152,6 +152,8 @@ public:
      * @param fileNameExport File name of the uncompressed data to be exported in (e.g. "data.zarr")
      * @param numPhases Number of game phases to support for exporting
      * @param gamePhaseDefinition Game phase definition to use
+     * @param gameIdx Pointer to the shared game counter
+     * @param startIdx Pointer to the shared index to export data
      * @param numberChunks Defines how many chunks a single file should contain.
      * The product of the number of chunks and its chunk size yields the total number of samples of a file.
      * @param chunkSize Defines the chunk size of a single chunk

--- a/engine/src/rl/traindataexporter.h
+++ b/engine/src/rl/traindataexporter.h
@@ -50,10 +50,6 @@ class TrainDataExporter
 private:
     unsigned int numPhases;
     GamePhaseDefinition gamePhaseDefinition;
-    // current number of games - 1
-    size_t* gameIdx;
-    // current sample index to insert
-    size_t* startIdx;
     size_t numberChunks;
     size_t chunkSize;
     size_t numberSamples;
@@ -73,6 +69,10 @@ private:
     xt::xarray<int16_t> gamePhaseVector;
     bool firstMove;
 
+    // current number of games - 1
+    size_t gameIdx;
+    // current sample index to insert
+    size_t startIdx;
     // current sample index of the current game
     size_t curSampleIdx;
 
@@ -158,7 +158,7 @@ public:
      * The product of the number of chunks and its chunk size yields the total number of samples of a file.
      * @param chunkSize Defines the chunk size of a single chunk
      */
-    TrainDataExporter(const string& fileNameExport, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t* gameIdx, size_t* startIdx, size_t numberChunks=200, size_t chunkSize=128);
+    TrainDataExporter(const string& fileNameExport, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t numberChunks=200, size_t chunkSize=128);
 
     /**
      * @brief export_pos Saves a given board position, policy and Q-value to the specific game arrays

--- a/engine/src/rl/traindataexporter.h
+++ b/engine/src/rl/traindataexporter.h
@@ -50,6 +50,10 @@ class TrainDataExporter
 private:
     unsigned int numPhases;
     GamePhaseDefinition gamePhaseDefinition;
+    // current number of games - 1
+    size_t* gameIdx;
+    // current sample index to insert
+    size_t* startIdx;
     size_t numberChunks;
     size_t chunkSize;
     size_t numberSamples;
@@ -69,10 +73,6 @@ private:
     xt::xarray<int16_t> gamePhaseVector;
     bool firstMove;
 
-    // current number of games - 1
-    size_t* gameIdx;
-    // current sample index to insert
-    size_t* startIdx;
     // current sample index of the current game
     size_t curSampleIdx;
 
@@ -156,7 +156,7 @@ public:
      * The product of the number of chunks and its chunk size yields the total number of samples of a file.
      * @param chunkSize Defines the chunk size of a single chunk
      */
-    TrainDataExporter(const string& fileNameExport, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t numberChunks=200, size_t chunkSize=128);
+    TrainDataExporter(const string& fileNameExport, unsigned int numPhases, GamePhaseDefinition gamePhaseDefinition, size_t* gameIdx, size_t* startIdx, size_t numberChunks=200, size_t chunkSize=128);
 
     /**
      * @brief export_pos Saves a given board position, policy and Q-value to the specific game arrays

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -419,21 +419,12 @@ size_t SearchThread::select_nn_index()
     return nnUser->phaseToNetsIndex.at(majorityPhase);
 }
 
-void SearchThread::handle_fwd_pass()
+void fwd_pass_queue(InferenceQueue* inferenceQueue, NeuralNetAPIUser* nnUser, size_t batchCount, size_t agentID, const SearchSettings* searchSettings)
 {
-    if (newNodes->size() == 0) {
-        return;
-    }
-    if (searchSettings->numberParallelGames == 1) {
-        nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
-        return;
-    }
-
-    // allocate a small local input buffer of size inputSize (float vector)
     InferenceRequest request;
     request.inputPlanes = nnUser->inputPlanes + agentID * searchSettings->get_local_batch_size() * StateConstants::NB_VALUES_TOTAL();
     request.inputSize = StateConstants::NB_VALUES_TOTAL();
-    request.batchCount  = newNodes->size();
+    request.batchCount  = batchCount;
     request.agentID = agentID;
 
     auto future = request.promise.get_future();
@@ -463,6 +454,20 @@ void SearchThread::handle_fwd_pass()
                result.auxiliaryOutputs.data(),
                StateConstants::NB_AUXILIARY_OUTPUTS() * result.valueOutputs.size() * sizeof(float));
     }
+}
+
+void SearchThread::handle_fwd_pass()
+{
+    if (newNodes->size() == 0) {
+        return;
+    }
+    if (searchSettings->numberParallelGames == 1) {
+        nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+        return;
+    }
+
+    // allocate a small local input buffer of size inputSize (float vector)
+    fwd_pass_queue(inferenceQueue, nnUser.get(), newNodes->size(), agentID, searchSettings);
 
     /*
     // Wait for all threads to arrive, one thread performs inference

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -165,7 +165,7 @@ Node* SearchThread::get_starting_node(Node* currentNode, NodeDescription& descri
 
 unsigned int SearchThread::compute_offset()
 {
-    return agentID * searchSettings->get_local_batch_size() + newNodes->size() * nnUser->nets.front()->get_nb_input_values_total();
+    return agentID * searchSettings->get_local_batch_size() * nnUser->nets.front()->get_nb_input_values_total() + newNodes->size() * nnUser->nets.front()->get_nb_input_values_total();
 }
 
 Node* SearchThread::get_new_child_to_evaluate(NodeDescription& description)
@@ -310,8 +310,18 @@ void fill_nn_results(size_t batchIdx, bool isPolicyMap, const float* valueOutput
 void SearchThread::set_nn_results_to_child_nodes()
 {
     size_t batchIdx = 0;
+    size_t policyOffset;
+    if (nnUser->nets.front()->is_policy_map()) {
+        policyOffset = agentID * searchSettings->get_local_batch_size() * StateConstants::NB_LABELS_POLICY_MAP();
+    }
+    else {
+        policyOffset = agentID * searchSettings->get_local_batch_size() * StateConstants::NB_LABELS();
+    }
+
     for (auto node: *newNodes) {
-        fill_nn_results(batchIdx, nnUser->nets.front()->is_policy_map(), nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs, node,
+        fill_nn_results(batchIdx, nnUser->nets.front()->is_policy_map(), nnUser->valueOutputs + agentID * searchSettings->get_local_batch_size(),
+                        nnUser->probOutputs + policyOffset,
+                        nnUser->auxiliaryOutputs + agentID * searchSettings->get_local_batch_size() * StateConstants::NB_AUXILIARY_OUTPUTS(), node,
                         tbHits, rootState->mirror_policy(newNodeSideToMove->get_element(batchIdx)),
                         searchSettings, rootNode->is_tablebase());
         ++batchIdx;

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,7 +41,7 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, recursive_mutex* batchMutex):
+SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition):
     agentID(agentID), nnUser(nnUser),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
@@ -52,7 +52,8 @@ SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUs
     terminalNodeCache(searchSettings->get_local_batch_size()*2),
     reachedTablebases(false),
     batchCounter(batchCounter),
-    batchMutex(batchMutex)
+    batchMutex(batchMutex),
+    batchCondition(batchCondition)
 {
     switch (searchSettings->searchPlayerMode) {
     case MODE_SINGLE_PLAYER:
@@ -427,19 +428,17 @@ void SearchThread::handle_fwd_pass()
         }
         return;
     }
-    {
-        std::unique_lock<std::recursive_mutex> lock(*batchMutex);
-        ++*batchCounter;
-        cout << "*batchCounter: " << *batchCounter << endl;
-        if (*batchCounter == searchSettings->numberParallelGames) {
-            // query the network that corresponds to the majority phase
-            nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
-            *batchCounter = 0;
-            batchCondition.notify_all();
-        }
-        else {
-            batchCondition.wait(lock);
-        }
+    std::unique_lock<std::mutex> lock(*batchMutex);
+    ++*batchCounter;
+    cout << "*batchCounter: " << *batchCounter << endl;
+    if (*batchCounter == searchSettings->numberParallelGames) {
+        // query the network that corresponds to the majority phase
+        nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+        *batchCounter = 0;
+        batchCondition->notify_all();
+    }
+    else {
+        batchCondition->wait(lock);
     }
 }
 

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -428,9 +428,9 @@ void SearchThread::handle_fwd_pass()
         }
         return;
     }
+    cout << "*batchCounter: " << *batchCounter << endl;
     std::unique_lock<std::mutex> lock(*batchMutex);
     ++*batchCounter;
-    cout << "*batchCounter: " << *batchCounter << endl;
     if (*batchCounter == searchSettings->numberParallelGames) {
         // query the network that corresponds to the majority phase
         nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,8 +41,8 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const size_t agentId, const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
-    agentId(agentId),
+SearchThread::SearchThread(const size_t agentID, const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
+    agentID(agentID),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
     newNodeSideToMove(make_unique<FixedVector<SideToMove>>(searchSettings->get_local_batch_size())),
@@ -165,7 +165,7 @@ Node* SearchThread::get_starting_node(Node* currentNode, NodeDescription& descri
 
 unsigned int SearchThread::compute_offset()
 {
-    return agentId * searchSettings->get_local_batch_size() + newNodes->size() * nnUser->nets.front()->get_nb_input_values_total();
+    return agentID * searchSettings->get_local_batch_size() + newNodes->size() * nnUser->nets.front()->get_nb_input_values_total();
 }
 
 Node* SearchThread::get_new_child_to_evaluate(NodeDescription& description)
@@ -415,7 +415,7 @@ void SearchThread::thread_iteration()
 #ifndef SEARCH_UCT
     if (newNodes->size() != 0) {
 
-        if (agentId == 0) {
+        if (agentID == 0) {
             // query the network that corresponds to the majority phase
             nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
         }
@@ -481,6 +481,11 @@ ChildIdx SearchThread::select_enhanced_move(Node* currentNode) const {
         currentNode->set_as_inspected();
     }
     return uint16_t(-1);
+}
+
+void SearchThread::run_inference(uint_fast16_t iterations)
+{
+    nnUser->run_inference(iterations);
 }
 
 void node_assign_value(Node *node, const float* valueOutputs, size_t& tbHits, size_t batchIdx, bool isRootNodeTB)

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -421,16 +421,17 @@ size_t SearchThread::select_nn_index()
 
 void SearchThread::handle_fwd_pass()
 {
+    if (newNodes->size() == 0) {
+        return;
+    }
     if (searchSettings->numberParallelGames == 1) {
-        if (newNodes->size() != 0) {
-            nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
-        }
+        nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
         return;
     }
 
     // allocate a small local input buffer of size inputSize (float vector)
     InferenceRequest request;
-    request.inputPlanes = nnUser->inputPlanes;
+    request.inputPlanes = nnUser->inputPlanes + agentID * searchSettings->get_local_batch_size() * StateConstants::NB_VALUES_TOTAL();
     request.inputSize = StateConstants::NB_VALUES_TOTAL();
     request.batchCount  = newNodes->size();
     request.agentID = agentID;

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -44,12 +44,12 @@ size_t SearchThread::get_max_depth() const
 SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, ReusableBarrier* batchBarrier, InferenceQueue* inferenceQueue):
     agentID(agentID), nnUser(nnUser),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
-    newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
-    newNodeSideToMove(make_unique<FixedVector<SideToMove>>(searchSettings->get_local_batch_size())),
-    transpositionValues(make_unique<FixedVector<float>>(searchSettings->get_local_batch_size()*2)),
+    newNodes(make_unique<FixedVector<Node*>>(searchSettings->batchSize)),
+    newNodeSideToMove(make_unique<FixedVector<SideToMove>>(searchSettings->batchSize)),
+    transpositionValues(make_unique<FixedVector<float>>(searchSettings->batchSize*2)),
     isRunning(true), mapWithMutex(mapWithMutex), searchSettings(searchSettings),
     tbHits(0), depthSum(0), depthMax(0), visitsPreSearch(0),
-    terminalNodeCache(searchSettings->get_local_batch_size()*2),
+    terminalNodeCache(searchSettings->batchSize*2),
     reachedTablebases(false),
     batchBarrier(batchBarrier),
     inferenceQueue(inferenceQueue)
@@ -165,7 +165,7 @@ Node* SearchThread::get_starting_node(Node* currentNode, NodeDescription& descri
 
 unsigned int SearchThread::compute_offset()
 {
-    return (agentID * searchSettings->get_local_batch_size() + newNodes->size()) * nnUser->nets.front()->get_nb_input_values_total();
+    return (agentID * searchSettings->batchSize + newNodes->size()) * nnUser->nets.front()->get_nb_input_values_total();
 }
 
 Node* SearchThread::get_new_child_to_evaluate(NodeDescription& description)

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,7 +41,7 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
+SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex):
     agentID(agentID), nnUser(nnUser),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
@@ -50,7 +50,9 @@ SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUs
     isRunning(true), mapWithMutex(mapWithMutex), searchSettings(searchSettings),
     tbHits(0), depthSum(0), depthMax(0), visitsPreSearch(0),
     terminalNodeCache(searchSettings->get_local_batch_size()*2),
-    reachedTablebases(false)
+    reachedTablebases(false),
+    batchCounter(batchCounter),
+    batchMutex(batchMutex)
 {
     switch (searchSettings->searchPlayerMode) {
     case MODE_SINGLE_PLAYER:

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -419,41 +419,68 @@ size_t SearchThread::select_nn_index()
     return nnUser->phaseToNetsIndex.at(majorityPhase);
 }
 
-void fwd_pass_queue(InferenceQueue* inferenceQueue, NeuralNetAPIUser* nnUser, size_t batchCount, size_t agentID, const SearchSettings* searchSettings)
+// === PATCHED fwd_pass_queue() ===
+// Fix: InferenceRequest OWNS its input data (no pointer aliasing)
+
+void fwd_pass_queue(InferenceQueue* inferenceQueue,
+                    NeuralNetAPIUser* nnUser,
+                    size_t batchCount,
+                    size_t agentID,
+                    const SearchSettings* searchSettings)
 {
     InferenceRequest request;
-    request.inputPlanes = nnUser->inputPlanes + agentID * searchSettings->get_local_batch_size() * StateConstants::NB_VALUES_TOTAL();
-    request.inputSize = StateConstants::NB_VALUES_TOTAL();
-    request.batchCount  = batchCount;
-    request.agentID = agentID;
 
+    // --- basic metadata ---
+    request.inputSize  = StateConstants::NB_VALUES_TOTAL();
+    request.batchCount = batchCount;
+    request.agentID    = agentID;
+
+    // --- OWNED input buffer ---
+    const size_t localBatchSize = searchSettings->get_local_batch_size();
+    const size_t elems = batchCount * request.inputSize;
+
+    request.inputData.resize(elems);
+
+    const float* src = nnUser->inputPlanes
+        + agentID * localBatchSize * request.inputSize;
+
+    memcpy(request.inputData.data(),
+           src,
+           elems * sizeof(float));
+
+    // --- enqueue & wait synchronously ---
     auto future = request.promise.get_future();
     inferenceQueue->push(std::move(request));
-    // do other CPU work here if possible
+
     InferenceResult result = future.get();
 
-    // copy back inference results
+    // --- copy results back into NN buffers (legacy compatibility) ---
     size_t policySize;
     if (nnUser->nets.front()->is_policy_map()) {
         policySize = StateConstants::NB_LABELS_POLICY_MAP();
-    }
-    else {
+    } else {
         policySize = StateConstants::NB_LABELS();
     }
-    size_t policyOffset = agentID * searchSettings->get_local_batch_size() * policySize;
 
-    memcpy(nnUser->valueOutputs + agentID * searchSettings->get_local_batch_size(),
+    const size_t valueOffset  = agentID * localBatchSize;
+    const size_t policyOffset = agentID * localBatchSize * policySize;
+
+    memcpy(nnUser->valueOutputs + valueOffset,
            result.valueOutputs.data(),
            result.valueOutputs.size() * sizeof(float));
+
     memcpy(nnUser->probOutputs + policyOffset,
            result.probOutputs.data(),
            result.probOutputs.size() * sizeof(float));
-    if (result.auxiliaryOutputs.size() != 0) {
-        memcpy(nnUser->auxiliaryOutputs,
+
+    if (!result.auxiliaryOutputs.empty()) {
+        memcpy(nnUser->auxiliaryOutputs
+                   + agentID * localBatchSize * StateConstants::NB_AUXILIARY_OUTPUTS(),
                result.auxiliaryOutputs.data(),
-               StateConstants::NB_AUXILIARY_OUTPUTS() * result.valueOutputs.size() * sizeof(float));
+               result.auxiliaryOutputs.size() * sizeof(float));
     }
 }
+
 
 void SearchThread::handle_fwd_pass()
 {

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,7 +41,7 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition):
+SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition, barrier<>* batchBarrier):
     agentID(agentID), nnUser(nnUser),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
@@ -53,7 +53,8 @@ SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUs
     reachedTablebases(false),
     batchCounter(batchCounter),
     batchMutex(batchMutex),
-    batchCondition(batchCondition)
+    batchCondition(batchCondition),
+    batchBarrier(batchBarrier)
 {
     switch (searchSettings->searchPlayerMode) {
     case MODE_SINGLE_PLAYER:
@@ -428,18 +429,24 @@ void SearchThread::handle_fwd_pass()
         }
         return;
     }
-    cout << "*batchCounter: " << *batchCounter << endl;
-    std::unique_lock<std::mutex> lock(*batchMutex);
-    *batchCounter = *batchCounter + 1;
-    if (*batchCounter == searchSettings->numberParallelGames) {
+    //cout << "*batchCounter: " << *batchCounter << endl;
+    //std::unique_lock<std::mutex> lock(*batchMutex);
+    //*batchCounter = *batchCounter + 1;
+    // Wait for all threads to arrive, one thread performs inference
+    batchBarrier->arrive_and_wait();
+
+    // Only thread 0 runs inference
+    if (agentID == 0) {
+    //if (*batchCounter == searchSettings->numberParallelGames) {
         // query the network that corresponds to the majority phase
         nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
-        *batchCounter = 0;
-        batchCondition->notify_all();
+        //*batchCounter = 0;
+        //batchCondition->notify_all();
     }
-    else {
-        batchCondition->wait(lock);
-    }
+    //else {
+    //    batchCondition->wait(lock);
+    //}
+    batchBarrier->arrive_and_wait();
 }
 
 void SearchThread::thread_iteration()

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -430,6 +430,7 @@ void SearchThread::handle_fwd_pass()
     {
         std::unique_lock<std::mutex> lock(*batchMutex);
         ++*batchCounter;
+        cout << "*batchCounter: " << *batchCounter << endl;
         if (*batchCounter == searchSettings->numberParallelGames) {
             // query the network that corresponds to the majority phase
             nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -413,12 +413,20 @@ void SearchThread::thread_iteration()
 {
     create_mini_batch();
 #ifndef SEARCH_UCT
-    if (newNodes->size() != 0) {
-
-        if (agentID == 0) {
+    {
+        std::unique_lock<std::mutex> lock(batchMutex);
+        ++*batchCounter;
+        if (*batchCounter == searchSettings->numberParallelGames) {
             // query the network that corresponds to the majority phase
             nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+            *batchCounter = 0;
+            batchCondition.notify_all();
         }
+        else {
+            batchCondition.wait(lock, [this] {});
+        }
+    }
+    if (newNodes->size() != 0) {
         set_nn_results_to_child_nodes();
     }
 #endif

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,7 +41,7 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition, ReusableBarrier* batchBarrier):
+SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, ReusableBarrier* batchBarrier):
     agentID(agentID), nnUser(nnUser),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
@@ -51,9 +51,6 @@ SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUs
     tbHits(0), depthSum(0), depthMax(0), visitsPreSearch(0),
     terminalNodeCache(searchSettings->get_local_batch_size()*2),
     reachedTablebases(false),
-    batchCounter(batchCounter),
-    batchMutex(batchMutex),
-    batchCondition(batchCondition),
     batchBarrier(batchBarrier)
 {
     switch (searchSettings->searchPlayerMode) {
@@ -429,23 +426,14 @@ void SearchThread::handle_fwd_pass()
         }
         return;
     }
-    //cout << "*batchCounter: " << *batchCounter << endl;
-    //std::unique_lock<std::mutex> lock(*batchMutex);
-    //*batchCounter = *batchCounter + 1;
     // Wait for all threads to arrive, one thread performs inference
     batchBarrier->arrive_and_wait();
 
     // Only thread 0 runs inference
     if (agentID == 0) {
-    //if (*batchCounter == searchSettings->numberParallelGames) {
         // query the network that corresponds to the majority phase
         nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
-        //*batchCounter = 0;
-        //batchCondition->notify_all();
     }
-    //else {
-    //    batchCondition->wait(lock);
-    //}
     batchBarrier->arrive_and_wait();
 }
 

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -44,9 +44,9 @@ size_t SearchThread::get_max_depth() const
 SearchThread::SearchThread(const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
     NeuralNetAPIUser(netBatchVector),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
-    newNodes(make_unique<FixedVector<Node*>>(searchSettings->batchSize)),
-    newNodeSideToMove(make_unique<FixedVector<SideToMove>>(searchSettings->batchSize)),
-    transpositionValues(make_unique<FixedVector<float>>(searchSettings->batchSize*2)),
+    newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
+    newNodeSideToMove(make_unique<FixedVector<SideToMove>>(searchSettings->get_local_batch_size())),
+    transpositionValues(make_unique<FixedVector<float>>(searchSettings->get_local_batch_size()*2)),
     isRunning(true), mapWithMutex(mapWithMutex), searchSettings(searchSettings),
     tbHits(0), depthSum(0), depthMax(0), visitsPreSearch(0),
     terminalNodeCache(searchSettings->batchSize*2),

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -517,6 +517,11 @@ shared_ptr<NeuralNetAPIUser> SearchThread::get_nn_user() const
     return nnUser;
 }
 
+void SearchThread::set_agent_id(size_t value)
+{
+    agentID = value;
+}
+
 void node_assign_value(Node *node, const float* valueOutputs, size_t& tbHits, size_t batchIdx, bool isRootNodeTB)
 {
 #ifdef MCTS_TB_SUPPORT

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -412,7 +412,7 @@ void SearchThread::thread_iteration()
     create_mini_batch();
 #ifndef SEARCH_UCT
     {
-        std::unique_lock<std::mutex> lock(batchMutex);
+        std::unique_lock<std::mutex> lock(*batchMutex);
         ++*batchCounter;
         if (*batchCounter == searchSettings->numberParallelGames) {
             // query the network that corresponds to the majority phase
@@ -421,7 +421,7 @@ void SearchThread::thread_iteration()
             batchCondition.notify_all();
         }
         else {
-            batchCondition.wait(lock, [this] {});
+            batchCondition.wait(lock);
         }
     }
     if (newNodes->size() != 0) {

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,7 +41,7 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, ReusableBarrier* batchBarrier):
+SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, ReusableBarrier* batchBarrier, InferenceQueue* inferenceQueue):
     agentID(agentID), nnUser(nnUser),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
@@ -51,7 +51,8 @@ SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUs
     tbHits(0), depthSum(0), depthMax(0), visitsPreSearch(0),
     terminalNodeCache(searchSettings->get_local_batch_size()*2),
     reachedTablebases(false),
-    batchBarrier(batchBarrier)
+    batchBarrier(batchBarrier),
+    inferenceQueue(inferenceQueue)
 {
     switch (searchSettings->searchPlayerMode) {
     case MODE_SINGLE_PLAYER:
@@ -426,6 +427,43 @@ void SearchThread::handle_fwd_pass()
         }
         return;
     }
+
+    // allocate a small local input buffer of size inputSize (float vector)
+    InferenceRequest request;
+    request.inputPlanes = nnUser->inputPlanes;
+    request.inputSize = StateConstants::NB_VALUES_TOTAL();
+    request.batchCount  = newNodes->size();
+    request.agentID = agentID;
+
+    auto future = request.promise.get_future();
+    inferenceQueue->push(std::move(request));
+    // do other CPU work here if possible
+    InferenceResult result = future.get();
+
+    // copy back inference results
+    size_t policyOffset;
+    size_t policySize;
+    if (nnUser->nets.front()->is_policy_map()) {
+        policyOffset = agentID * searchSettings->get_local_batch_size() * StateConstants::NB_LABELS_POLICY_MAP();
+        policySize = StateConstants::NB_LABELS_POLICY_MAP();
+    }
+    else {
+        policyOffset = agentID * searchSettings->get_local_batch_size() * StateConstants::NB_LABELS();
+        policySize = StateConstants::NB_LABELS();
+    }
+    memcpy(nnUser->valueOutputs + agentID * searchSettings->get_local_batch_size(),
+           result.valueOutputs.data(),
+           result.valueOutputs.size() * sizeof(float));
+    memcpy(nnUser->probOutputs + policyOffset,
+           result.probOutputs.data(),
+           policySize * result.valueOutputs.size() * sizeof(float));
+    if (result.auxiliaryOutputs.size() != 0) {
+        memcpy(nnUser->auxiliaryOutputs,
+               result.auxiliaryOutputs.data(),
+               StateConstants::NB_AUXILIARY_OUTPUTS() * result.valueOutputs.size() * sizeof(float));
+    }
+
+    /*
     // Wait for all threads to arrive, one thread performs inference
     batchBarrier->arrive_and_wait();
 
@@ -435,6 +473,7 @@ void SearchThread::handle_fwd_pass()
         nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
     }
     batchBarrier->arrive_and_wait();
+    */
 }
 
 void SearchThread::thread_iteration()

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,17 +41,19 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
-    NeuralNetAPIUser(netBatchVector),
+SearchThread::SearchThread(const size_t agentId, const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
+    agentId(agentId),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
     newNodeSideToMove(make_unique<FixedVector<SideToMove>>(searchSettings->get_local_batch_size())),
     transpositionValues(make_unique<FixedVector<float>>(searchSettings->get_local_batch_size()*2)),
     isRunning(true), mapWithMutex(mapWithMutex), searchSettings(searchSettings),
     tbHits(0), depthSum(0), depthMax(0), visitsPreSearch(0),
-    terminalNodeCache(searchSettings->batchSize*2),
+    terminalNodeCache(searchSettings->get_local_batch_size()*2),
     reachedTablebases(false)
 {
+    nnUser = make_shared<NeuralNetAPIUser>(netBatchVector);
+
     switch (searchSettings->searchPlayerMode) {
     case MODE_SINGLE_PLAYER:
         terminalNodeCache = 1;  // TODO: Check if this is really needed
@@ -161,6 +163,11 @@ Node* SearchThread::get_starting_node(Node* currentNode, NodeDescription& descri
     return currentNode;
 }
 
+unsigned int SearchThread::compute_offset()
+{
+    return agentId * searchSettings->get_local_batch_size() + newNodes->size() * nnUser->nets.front()->get_nb_input_values_total();
+}
+
 Node* SearchThread::get_new_child_to_evaluate(NodeDescription& description)
 {
     description.depth = 0;
@@ -226,9 +233,9 @@ Node* SearchThread::get_new_child_to_evaluate(NodeDescription& description)
 #else
                 // fill a new board in the input_planes vector
                 // we shift the index by nbNNInputValues each time
-                newState->get_state_planes(true, inputPlanes + newNodes->size() * nets.front()->get_nb_input_values_total(), nets.front()->get_version());
-                if (numPhases > 1) {
-                    GamePhase currPhase = newState->get_phase(numPhases, searchSettings->gamePhaseDefinition);
+                newState->get_state_planes(true, nnUser->inputPlanes + compute_offset(), nnUser->nets.front()->get_version());
+                if (nnUser->numPhases > 1) {
+                    GamePhase currPhase = newState->get_phase(nnUser->numPhases, searchSettings->gamePhaseDefinition);
                     phaseCountMap[currPhase]++;
                 }
                 // save a reference newly created list in the temporary list for node creation
@@ -304,7 +311,7 @@ void SearchThread::set_nn_results_to_child_nodes()
 {
     size_t batchIdx = 0;
     for (auto node: *newNodes) {
-        fill_nn_results(batchIdx, nets.front()->is_policy_map(), valueOutputs, probOutputs, auxiliaryOutputs, node,
+        fill_nn_results(batchIdx, nnUser->nets.front()->is_policy_map(), nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs, node,
                         tbHits, rootState->mirror_policy(newNodeSideToMove->get_element(batchIdx)),
                         searchSettings, rootNode->is_tablebase());
         ++batchIdx;
@@ -353,7 +360,7 @@ void SearchThread::create_mini_batch()
     size_t numTerminalNodes = 0;
 
     while (!newNodes->is_full() &&
-           collisionTrajectories.size() != searchSettings->batchSize &&
+           collisionTrajectories.size() != searchSettings->get_local_batch_size() &&
            !transpositionValues->is_full() &&
            numTerminalNodes < terminalNodeCache) {
 
@@ -383,7 +390,7 @@ void SearchThread::create_mini_batch()
 
 size_t SearchThread::select_nn_index()
 {
-    if (nets.size() == 1) {
+    if (nnUser->nets.size() == 1) {
         return 0;
     }
     // determine majority class in current batch
@@ -399,7 +406,7 @@ size_t SearchThread::select_nn_index()
     GamePhase majorityPhase = pr->first;
 
     phaseCountMap.clear();
-    return phaseToNetsIndex.at(majorityPhase);
+    return nnUser->phaseToNetsIndex.at(majorityPhase);
 }
 
 void SearchThread::thread_iteration()
@@ -408,8 +415,10 @@ void SearchThread::thread_iteration()
 #ifndef SEARCH_UCT
     if (newNodes->size() != 0) {
 
-        // query the network that corresponds to the majority phase
-        nets[select_nn_index()]->predict(inputPlanes, valueOutputs, probOutputs, auxiliaryOutputs);
+        if (agentId == 0) {
+            // query the network that corresponds to the majority phase
+            nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+        }
         set_nn_results_to_child_nodes();
     }
 #endif

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -428,7 +428,7 @@ void SearchThread::handle_fwd_pass()
         return;
     }
     {
-        std::unique_lock<std::mutex> lock(*batchMutex);
+        std::unique_lock<std::recursive_mutex> lock(*batchMutex);
         ++*batchCounter;
         cout << "*batchCounter: " << *batchCounter << endl;
         if (*batchCounter == searchSettings->numberParallelGames) {

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,7 +41,7 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex):
+SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, recursive_mutex* batchMutex):
     agentID(agentID), nnUser(nnUser),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,8 +41,8 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const size_t agentID, const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
-    agentID(agentID),
+SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex):
+    agentID(agentID), nnUser(nnUser),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),
     newNodeSideToMove(make_unique<FixedVector<SideToMove>>(searchSettings->get_local_batch_size())),
@@ -52,8 +52,6 @@ SearchThread::SearchThread(const size_t agentID, const vector<unique_ptr<NeuralN
     terminalNodeCache(searchSettings->get_local_batch_size()*2),
     reachedTablebases(false)
 {
-    nnUser = make_shared<NeuralNetAPIUser>(netBatchVector);
-
     switch (searchSettings->searchPlayerMode) {
     case MODE_SINGLE_PLAYER:
         terminalNodeCache = 1;  // TODO: Check if this is really needed
@@ -494,6 +492,11 @@ ChildIdx SearchThread::select_enhanced_move(Node* currentNode) const {
 void SearchThread::run_inference(uint_fast16_t iterations)
 {
     nnUser->run_inference(iterations);
+}
+
+shared_ptr<NeuralNetAPIUser> SearchThread::get_nn_user() const
+{
+    return nnUser;
 }
 
 void node_assign_value(Node *node, const float* valueOutputs, size_t& tbHits, size_t batchIdx, bool isRootNodeTB)

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -407,10 +407,14 @@ size_t SearchThread::select_nn_index()
     return nnUser->phaseToNetsIndex.at(majorityPhase);
 }
 
-void SearchThread::thread_iteration()
+void SearchThread::handle_fwd_pass()
 {
-    create_mini_batch();
-#ifndef SEARCH_UCT
+    if (searchSettings->numberParallelGames == 1) {
+        if (newNodes->size() != 0) {
+            nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);
+        }
+        return;
+    }
     {
         std::unique_lock<std::mutex> lock(*batchMutex);
         ++*batchCounter;
@@ -424,6 +428,13 @@ void SearchThread::thread_iteration()
             batchCondition.wait(lock);
         }
     }
+}
+
+void SearchThread::thread_iteration()
+{
+    create_mini_batch();
+#ifndef SEARCH_UCT
+    handle_fwd_pass();
     if (newNodes->size() != 0) {
         set_nn_results_to_child_nodes();
     }

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -457,7 +457,7 @@ void SearchThread::handle_fwd_pass()
            result.valueOutputs.size() * sizeof(float));
     memcpy(nnUser->probOutputs + policyOffset,
            result.probOutputs.data(),
-           policySize * result.valueOutputs.size() * sizeof(float));
+           result.probOutputs.size() * sizeof(float));
     if (result.auxiliaryOutputs.size() != 0) {
         memcpy(nnUser->auxiliaryOutputs,
                result.auxiliaryOutputs.data(),

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -312,16 +312,16 @@ void SearchThread::set_nn_results_to_child_nodes()
     size_t batchIdx = 0;
     size_t policyOffset;
     if (nnUser->nets.front()->is_policy_map()) {
-        policyOffset = agentID * searchSettings->get_local_batch_size() * StateConstants::NB_LABELS_POLICY_MAP();
+        policyOffset = agentID * searchSettings->batchSize * StateConstants::NB_LABELS_POLICY_MAP();
     }
     else {
-        policyOffset = agentID * searchSettings->get_local_batch_size() * StateConstants::NB_LABELS();
+        policyOffset = agentID * searchSettings->batchSize * StateConstants::NB_LABELS();
     }
 
     for (auto node: *newNodes) {
-        fill_nn_results(batchIdx, nnUser->nets.front()->is_policy_map(), nnUser->valueOutputs + agentID * searchSettings->get_local_batch_size(),
+        fill_nn_results(batchIdx, nnUser->nets.front()->is_policy_map(), nnUser->valueOutputs + agentID * searchSettings->batchSize,
                         nnUser->probOutputs + policyOffset,
-                        nnUser->auxiliaryOutputs + agentID * searchSettings->get_local_batch_size() * StateConstants::NB_AUXILIARY_OUTPUTS(), node,
+                        nnUser->auxiliaryOutputs + agentID * searchSettings->batchSize * StateConstants::NB_AUXILIARY_OUTPUTS(), node,
                         tbHits, rootState->mirror_policy(newNodeSideToMove->get_element(batchIdx)),
                         searchSettings, rootNode->is_tablebase());
         ++batchIdx;
@@ -370,7 +370,7 @@ void SearchThread::create_mini_batch()
     size_t numTerminalNodes = 0;
 
     while (!newNodes->is_full() &&
-           collisionTrajectories.size() != searchSettings->get_local_batch_size() &&
+           collisionTrajectories.size() != searchSettings->batchSize &&
            !transpositionValues->is_full() &&
            numTerminalNodes < terminalNodeCache) {
 
@@ -436,7 +436,7 @@ void fwd_pass_queue(InferenceQueue* inferenceQueue,
     request.agentID    = agentID;
 
     // --- OWNED input buffer ---
-    const size_t localBatchSize = searchSettings->get_local_batch_size();
+    const size_t localBatchSize = searchSettings->batchSize;
     const size_t elems = batchCount * request.inputSize;
 
     request.inputData.resize(elems);

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -41,7 +41,7 @@ size_t SearchThread::get_max_depth() const
     return depthMax;
 }
 
-SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition, barrier<>* batchBarrier):
+SearchThread::SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition, ReusableBarrier* batchBarrier):
     agentID(agentID), nnUser(nnUser),
     rootNode(nullptr), rootState(nullptr), newState(nullptr),  // will be be set via setter methods
     newNodes(make_unique<FixedVector<Node*>>(searchSettings->get_local_batch_size())),

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -430,7 +430,7 @@ void SearchThread::handle_fwd_pass()
     }
     cout << "*batchCounter: " << *batchCounter << endl;
     std::unique_lock<std::mutex> lock(*batchMutex);
-    ++*batchCounter;
+    *batchCounter = *batchCounter + 1;
     if (*batchCounter == searchSettings->numberParallelGames) {
         // query the network that corresponds to the majority phase
         nnUser->nets[select_nn_index()]->predict(nnUser->inputPlanes, nnUser->valueOutputs, nnUser->probOutputs, nnUser->auxiliaryOutputs);

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -433,16 +433,15 @@ void fwd_pass_queue(InferenceQueue* inferenceQueue, NeuralNetAPIUser* nnUser, si
     InferenceResult result = future.get();
 
     // copy back inference results
-    size_t policyOffset;
     size_t policySize;
     if (nnUser->nets.front()->is_policy_map()) {
-        policyOffset = agentID * searchSettings->get_local_batch_size() * StateConstants::NB_LABELS_POLICY_MAP();
         policySize = StateConstants::NB_LABELS_POLICY_MAP();
     }
     else {
-        policyOffset = agentID * searchSettings->get_local_batch_size() * StateConstants::NB_LABELS();
         policySize = StateConstants::NB_LABELS();
     }
+    size_t policyOffset = agentID * searchSettings->get_local_batch_size() * policySize;
+
     memcpy(nnUser->valueOutputs + agentID * searchSettings->get_local_batch_size(),
            result.valueOutputs.data(),
            result.valueOutputs.size() * sizeof(float));

--- a/engine/src/searchthread.cpp
+++ b/engine/src/searchthread.cpp
@@ -164,7 +164,7 @@ Node* SearchThread::get_starting_node(Node* currentNode, NodeDescription& descri
 
 unsigned int SearchThread::compute_offset()
 {
-    return agentID * searchSettings->get_local_batch_size() * nnUser->nets.front()->get_nb_input_values_total() + newNodes->size() * nnUser->nets.front()->get_nb_input_values_total();
+    return (agentID * searchSettings->get_local_batch_size() + newNodes->size()) * nnUser->nets.front()->get_nb_input_values_total();
 }
 
 Node* SearchThread::get_new_child_to_evaluate(NodeDescription& description)

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -83,7 +83,7 @@ private:
     size_t visitsPreSearch;
     uint_fast32_t terminalNodeCache;  // TODO: better add "const" classifier here is possible
     bool reachedTablebases;
-    const size_t agentID;
+    size_t agentID;
 
     ReusableBarrier* batchBarrier;  // non-owning
 public:
@@ -171,6 +171,7 @@ public:
 
     shared_ptr<NeuralNetAPIUser> get_nn_user() const;
 
+    void set_agent_id(size_t value);
 private:
 
     /**

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -95,11 +95,11 @@ public:
     /**
      * @brief SearchThread
      * @param agentID Agent index which is used to determine the block section in the mini batch
-     * @param netBatchVector vector of Network API objects which provide the prediction of the neural network
+     * @param NeuralNetAPIUser Neural network API user object that may store multiple phase networks
      * @param searchSettings Given settings for this search run
      * @param MapWithMutex Handle to the hash table
      */
-    SearchThread(const size_t agentID, const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex);
+    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.
@@ -170,6 +170,8 @@ public:
      * @param iterations Number of iterations
      */
     void run_inference(uint_fast16_t iterations);
+
+    shared_ptr<NeuralNetAPIUser> get_nn_user() const;
 
 private:
     /**

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -89,9 +89,9 @@ private:
     // batchCounter that coordinates all search threads
     size_t* batchCounter;
     // mutex that protects the batchCounter access
-    recursive_mutex* batchMutex;
+    mutex* batchMutex;
     // condition variable for every except one to wait
-    std::condition_variable batchCondition;
+    condition_variable* batchCondition;
 public:
     /**
      * @brief SearchThread
@@ -101,8 +101,9 @@ public:
      * @param MapWithMutex Handle to the hash table
      * @param batchCounter BatchCounter that coordinates all search threads
      * @param batchMutex mutex that protects the batchCounter access
+     * @param batchCondition Condition variable which manages waiting and running
      */
-    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, recursive_mutex* batchMutex);
+    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -175,6 +175,12 @@ public:
     shared_ptr<NeuralNetAPIUser> get_nn_user() const;
 
 private:
+
+    /**
+     * @brief handle_fwd_pass Handles the forward pass for neural network prediction
+     */
+    void handle_fwd_pass();
+
     /**
      * @brief set_nn_results_to_child_nodes Sets the neural network value evaluation and policy prediction vector for every newly expanded nodes
      */

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -28,13 +28,14 @@
 #ifndef SEARCHTHREAD_H
 #define SEARCHTHREAD_H
 
+#include <mutex>
+#include <condition_variable>
 #include "node.h"
 #include "constants.h"
 #include "neuralnetapi.h"
 #include "config/searchlimits.h"
 #include "util/fixedvector.h"
 #include "nn/neuralnetapiuser.h"
-
 
 enum NodeBackup : uint8_t {
     NODE_COLLISION,

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -175,6 +175,7 @@ public:
     shared_ptr<NeuralNetAPIUser> get_nn_user() const;
 
     void set_agent_id(size_t value);
+    
 private:
 
     /**
@@ -263,5 +264,7 @@ inline void random_playout(Node* currentNode, ChildIdx& childIdx);
  * @return random depth while the probability of choosing higher depths decreases exponetially
  */
 size_t get_random_depth();
+
+void fwd_pass_queue(InferenceQueue* inferenceQueue, NeuralNetAPIUser* nnUser, size_t batchCount, size_t agentID, const SearchSettings* searchSettings);
 
 #endif // SEARCHTHREAD_H

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -84,6 +84,13 @@ private:
     uint_fast32_t terminalNodeCache;  // TODO: better add "const" classifier here is possible
     bool reachedTablebases;
     const size_t agentID;
+
+    // batchCounter that coordinates all search threads
+    size_t* batchCounter;
+    // mutex that protects the batchCounter access
+    mutex* batchMutex;
+    // condition variable for every except one to wait
+    std::condition_variable batchCondition;
 public:
     /**
      * @brief SearchThread

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -51,12 +51,13 @@ struct NodeDescription
     size_t depth;
 };
 
-class SearchThread : public NeuralNetAPIUser
+class SearchThread
 {
 private:
     Node* rootNode;
     StateObj* rootState;
     unique_ptr<StateObj> newState;
+    shared_ptr<NeuralNetAPIUser> nnUser;
 
     // list of all node objects which have been selected for expansion
     unique_ptr<FixedVector<Node*>> newNodes;
@@ -82,14 +83,16 @@ private:
     size_t visitsPreSearch;
     uint_fast32_t terminalNodeCache;  // TODO: better add "const" classifier here is possible
     bool reachedTablebases;
+    const size_t agentId;
 public:
     /**
      * @brief SearchThread
+     * @param agentId Agent index which is used to determine the block section in the mini batch
      * @param netBatchVector vector of Network API objects which provide the prediction of the neural network
      * @param searchSettings Given settings for this search run
      * @param MapWithMutex Handle to the hash table
      */
-    SearchThread(const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex);
+    SearchThread(const size_t agentId, const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.
@@ -203,6 +206,12 @@ private:
      * @return Majority phase index or 0
      */
     size_t select_nn_index();
+
+    /**
+     * @brief compute_offset Helper function that computes the offset for editing the input representation
+     * @return offset
+     */
+    unsigned int compute_offset();
 };
 
 void run_search_thread(SearchThread *t);

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -35,6 +35,7 @@
 #include "util/fixedvector.h"
 #include "nn/neuralnetapiuser.h"
 #include "util/reusablebarrier.h"
+#include "inference/inferencequeue.h"
 
 enum NodeBackup : uint8_t {
     NODE_COLLISION,
@@ -86,6 +87,7 @@ private:
     size_t agentID;
 
     ReusableBarrier* batchBarrier;  // non-owning
+    InferenceQueue* inferenceQueue;
 public:
     /**
      * @brief SearchThread
@@ -96,8 +98,9 @@ public:
      * @param batchCounter BatchCounter that coordinates all search threads
      * @param batchMutex mutex that protects the batchCounter access
      * @param batchCondition Condition variable which manages waiting and running
+     * @param inferenceQueue Queue that manages inference requests
      */
-    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, ReusableBarrier* batchBarrier);
+    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, ReusableBarrier* batchBarrier, InferenceQueue* inferenceQueue);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -99,8 +99,10 @@ public:
      * @param NeuralNetAPIUser Neural network API user object that may store multiple phase networks
      * @param searchSettings Given settings for this search run
      * @param MapWithMutex Handle to the hash table
+     * @param batchCounter BatchCounter that coordinates all search threads
+     * @param batchMutex mutex that protects the batchCounter access
      */
-    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex);
+    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -28,13 +28,13 @@
 #ifndef SEARCHTHREAD_H
 #define SEARCHTHREAD_H
 
-#include <barrier>
 #include "node.h"
 #include "constants.h"
 #include "neuralnetapi.h"
 #include "config/searchlimits.h"
 #include "util/fixedvector.h"
 #include "nn/neuralnetapiuser.h"
+#include "util/reusablebarrier.h"
 
 enum NodeBackup : uint8_t {
     NODE_COLLISION,
@@ -92,7 +92,7 @@ private:
     // condition variable for every except one to wait
     condition_variable* batchCondition;
 
-    barrier<>* batchBarrier;  // non-owning
+    ReusableBarrier* batchBarrier;  // non-owning
 public:
     /**
      * @brief SearchThread
@@ -104,7 +104,7 @@ public:
      * @param batchMutex mutex that protects the batchCounter access
      * @param batchCondition Condition variable which manages waiting and running
      */
-    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition, barrier<>* batchBarrier);
+    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition, ReusableBarrier* batchBarrier);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -83,16 +83,16 @@ private:
     size_t visitsPreSearch;
     uint_fast32_t terminalNodeCache;  // TODO: better add "const" classifier here is possible
     bool reachedTablebases;
-    const size_t agentId;
+    const size_t agentID;
 public:
     /**
      * @brief SearchThread
-     * @param agentId Agent index which is used to determine the block section in the mini batch
+     * @param agentID Agent index which is used to determine the block section in the mini batch
      * @param netBatchVector vector of Network API objects which provide the prediction of the neural network
      * @param searchSettings Given settings for this search run
      * @param MapWithMutex Handle to the hash table
      */
-    SearchThread(const size_t agentId, const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex);
+    SearchThread(const size_t agentID, const vector<unique_ptr<NeuralNetAPI>>& netBatchVector, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.
@@ -157,6 +157,12 @@ public:
     size_t get_max_depth() const;
 
     Node* get_starting_node(Node* currentNode, NodeDescription& description, ChildIdx& childIdx);
+
+    /**
+     * @brief run_inference Wrapper function for nnUser->run_inference()
+     * @param iterations Number of iterations
+     */
+    void run_inference(uint_fast16_t iterations);
 
 private:
     /**

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -102,7 +102,7 @@ public:
      * @param batchCounter BatchCounter that coordinates all search threads
      * @param batchMutex mutex that protects the batchCounter access
      */
-    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex);
+    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, recursive_mutex* batchMutex);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -28,8 +28,7 @@
 #ifndef SEARCHTHREAD_H
 #define SEARCHTHREAD_H
 
-#include <mutex>
-#include <condition_variable>
+#include <barrier>
 #include "node.h"
 #include "constants.h"
 #include "neuralnetapi.h"
@@ -92,6 +91,8 @@ private:
     mutex* batchMutex;
     // condition variable for every except one to wait
     condition_variable* batchCondition;
+
+    barrier<>* batchBarrier;  // non-owning
 public:
     /**
      * @brief SearchThread
@@ -103,7 +104,7 @@ public:
      * @param batchMutex mutex that protects the batchCounter access
      * @param batchCondition Condition variable which manages waiting and running
      */
-    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition);
+    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition, barrier<>* batchBarrier);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -89,7 +89,7 @@ private:
     // batchCounter that coordinates all search threads
     size_t* batchCounter;
     // mutex that protects the batchCounter access
-    mutex* batchMutex;
+    recursive_mutex* batchMutex;
     // condition variable for every except one to wait
     std::condition_variable batchCondition;
 public:

--- a/engine/src/searchthread.h
+++ b/engine/src/searchthread.h
@@ -85,13 +85,6 @@ private:
     bool reachedTablebases;
     const size_t agentID;
 
-    // batchCounter that coordinates all search threads
-    size_t* batchCounter;
-    // mutex that protects the batchCounter access
-    mutex* batchMutex;
-    // condition variable for every except one to wait
-    condition_variable* batchCondition;
-
     ReusableBarrier* batchBarrier;  // non-owning
 public:
     /**
@@ -104,7 +97,7 @@ public:
      * @param batchMutex mutex that protects the batchCounter access
      * @param batchCondition Condition variable which manages waiting and running
      */
-    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, size_t* batchCounter, mutex* batchMutex, condition_variable* batchCondition, ReusableBarrier* batchBarrier);
+    SearchThread(const size_t agentID, const shared_ptr<NeuralNetAPIUser> nnUser, const SearchSettings* searchSettings, MapWithMutex* mapWithMutex, ReusableBarrier* batchBarrier);
 
     /**
      * @brief create_mini_batch Creates a mini-batch of new unexplored nodes.

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -374,7 +374,7 @@ void CrazyAra::selfplay(istringstream &is)
     size_t numberOfGames;
     is >> numberOfGames;
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
-        gameThreads.emplace_back(thread(run_selfplay_thread, selfPlays[idx].get(), numberOfGames / NUMBER_OF_PARALLEL_GAMES, variant, &selfplayFileMutex));
+        gameThreads.emplace_back(thread(run_selfplay_thread, selfPlays[idx].get(), numberOfGames / NUMBER_OF_PARALLEL_GAMES, variant));
     }
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         gameThreads[idx].join();
@@ -385,9 +385,7 @@ void CrazyAra::selfplay(istringstream &is)
 void CrazyAra::arena(istringstream &is)
 {
     prepare_search_config_structs();
-    size_t gameIdx = 0;
-    size_t startIdx = 0;
-    SelfPlay selfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx);
+    SelfPlay selfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options);
     fill_nn_vectors(Options["Model_Directory_Contender"], netSingleContenderVector, netBatchesContenderVector);
     mctsAgentContender = create_new_mcts_agent(netSingleContenderVector, netBatchesContenderVector, &searchSettings);
     size_t numberOfGames;
@@ -441,9 +439,7 @@ void CrazyAra::multimodel_arena(istringstream &is, const string &modelDirectory1
         mcts2 = create_new_mcts_agent(netSingleContenderVector, netBatchesContenderVector, &searchSettings, static_cast<MCTSAgentType>(type));
     }
 
-    size_t gameIdx = 0;
-    size_t startIdx = 0;
-    SelfPlay selfPlay(rawAgent.get(), mcts1.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx);
+    SelfPlay selfPlay(rawAgent.get(), mcts1.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options);
     size_t numberOfGames;
     is >> numberOfGames;
     TournamentResult tournamentResult = selfPlay.go_arena(mcts2.get(), numberOfGames, variant);

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -171,7 +171,7 @@ void CrazyAra::inference(istringstream &is)
     info_string("batch-size:", searchSettings.batchSize);
     mctsAgent->get_nn_user()->run_inference(warmupIterations);
     const chrono::steady_clock::time_point start = chrono::steady_clock::now();
-    mctsAgent->searchThreads.front()->nnUser->run_inference(iterations);
+    mctsAgent->searchThreads.front()->run_inference(iterations);
     const chrono::steady_clock::time_point end = chrono::steady_clock::now();
     const size_t elapsedMS = chrono::duration_cast<chrono::milliseconds>(end - start).count();
     info_string("Inference results");

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -360,6 +360,7 @@ void CrazyAra::selfplay(istringstream &is)
 
     prepare_search_config_structs();
 
+    vector<thread> gameThreads;
     vector<SelfPlay> selfPlays;
 
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
@@ -367,12 +368,15 @@ void CrazyAra::selfplay(istringstream &is)
         localMCTSAgent->set_agent_id(idx);
         unique_ptr<RawNetAgent> localRawAgent = make_unique<RawNetAgent>(*rawAgent.get());   // Deep Copy
         localRawAgent->set_agent_id(idx);
-        selfPlays.push_back(SelfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options));
+        selfPlays.emplace_back(SelfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options));
     }
     size_t numberOfGames;
     is >> numberOfGames;
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
-        selfPlays[idx].go(numberOfGames, variant, selfplayFileMutex);
+        gameThreads.emplace_back(thread(run_selfplay_thread, selfplays[idx], numberOfGames, variant, selfplayFileMutex));
+    }
+    for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
+        gameThreads[idx].join();
     }
     cout << "readyok" << endl;
 }

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -362,12 +362,16 @@ void CrazyAra::selfplay(istringstream &is)
 
     vector<SelfPlay> selfPlays;
 
+    // shared resource for all selfplay objects
+    size_t gameIdx = 0;
+    size_t startIdx = 0;
+
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         unique_ptr<MCTSAgent> localMCTSAgent = make_unique<MCTSAgent>(*mctsAgent.get()); // Deep Copy
         localMCTSAgent->set_agent_id(idx);
         unique_ptr<RawNetAgent> localRawAgent = make_unique<RawNetAgent>(*rawAgent.get());   // Deep Copy
         localRawAgent->set_agent_id(idx);
-        selfPlays.push_back(SelfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options));
+        selfPlays.push_back(SelfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx));
     }
     size_t numberOfGames;
     is >> numberOfGames;
@@ -380,7 +384,9 @@ void CrazyAra::selfplay(istringstream &is)
 void CrazyAra::arena(istringstream &is)
 {
     prepare_search_config_structs();
-    SelfPlay selfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options);
+    size_t gameIdx = 0;
+    size_t startIdx = 0;
+    SelfPlay selfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx);
     fill_nn_vectors(Options["Model_Directory_Contender"], netSingleContenderVector, netBatchesContenderVector);
     mctsAgentContender = create_new_mcts_agent(netSingleContenderVector, netBatchesContenderVector, &searchSettings);
     size_t numberOfGames;
@@ -434,7 +440,9 @@ void CrazyAra::multimodel_arena(istringstream &is, const string &modelDirectory1
         mcts2 = create_new_mcts_agent(netSingleContenderVector, netBatchesContenderVector, &searchSettings, static_cast<MCTSAgentType>(type));
     }
 
-    SelfPlay selfPlay(rawAgent.get(), mcts1.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options);
+    size_t gameIdx = 0;
+    size_t startIdx = 0;
+    SelfPlay selfPlay(rawAgent.get(), mcts1.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx);
     size_t numberOfGames;
     is >> numberOfGames;
     TournamentResult tournamentResult = selfPlay.go_arena(mcts2.get(), numberOfGames, variant);

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -360,25 +360,25 @@ void CrazyAra::selfplay(istringstream &is)
     prepare_search_config_structs();
 
     vector<thread> gameThreads;
-    vector<SelfPlay> selfPlays;
-    vector<MCTSAgent> mctsAgents;
-    vector<RawNetAgent> rawAgents;
+    vector<unique_ptr<SelfPlay>> selfPlays;
+    vector<unique_ptr<MCTSAgent>> mctsAgents;
+    vector<unique_ptr<RawNetAgent>> rawAgents;
 
     // shared resource for all selfplay objects
     size_t gameIdx = 0;
     size_t startIdx = 0;
 
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
-        mctsAgents.emplace_back(MCTSAgent(*mctsAgent.get())); // Deep Copy
-        mctsAgents[idx].set_agent_id(idx);
-        rawAgents.emplace_back(RawNetAgent(*rawAgent.get()));   // Deep Copy
-        rawAgents[idx].set_agent_id(idx);
-        selfPlays.emplace_back(SelfPlay(&rawAgents.back(), &mctsAgents.back(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx));
+        mctsAgents.emplace_back(make_unique<MCTSAgent>(*mctsAgent.get())); // Deep Copy
+        mctsAgents[idx]->set_agent_id(idx);
+        rawAgents.emplace_back(make_unique<RawNetAgent>(*rawAgent.get()));   // Deep Copy
+        rawAgents[idx]->set_agent_id(idx);
+        selfPlays.emplace_back(make_unique<SelfPlay>(rawAgents[idx].get(), mctsAgents[idx].get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx));
     }
     size_t numberOfGames;
     is >> numberOfGames;
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
-        gameThreads.emplace_back(thread(run_selfplay_thread, &selfPlays[idx], numberOfGames / NUMBER_OF_PARALLEL_GAMES, variant, &selfplayFileMutex));
+        gameThreads.emplace_back(thread(run_selfplay_thread, selfPlays[idx].get(), numberOfGames / NUMBER_OF_PARALLEL_GAMES, variant, &selfplayFileMutex));
     }
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         gameThreads[idx].join();

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -356,7 +356,6 @@ void CrazyAra::activeuci()
 void CrazyAra::selfplay(istringstream &is)
 {
     const size_t NUMBER_OF_PARALLEL_GAMES = Options["Number_Parallel_Games"];
-    const size_t GLOBAL_BATCH_SIZE = Options["Batch_Size"];
 
     prepare_search_config_structs();
 

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -364,16 +364,12 @@ void CrazyAra::selfplay(istringstream &is)
     vector<unique_ptr<MCTSAgent>> mctsAgents;
     vector<unique_ptr<RawNetAgent>> rawAgents;
 
-    // shared resource for all selfplay objects
-    size_t gameIdx = 0;
-    size_t startIdx = 0;
-
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         mctsAgents.emplace_back(make_unique<MCTSAgent>(*mctsAgent.get())); // Deep Copy
         mctsAgents[idx]->set_agent_id(idx);
         rawAgents.emplace_back(make_unique<RawNetAgent>(*rawAgent.get()));   // Deep Copy
         rawAgents[idx]->set_agent_id(idx);
-        selfPlays.emplace_back(make_unique<SelfPlay>(rawAgents[idx].get(), mctsAgents[idx].get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx));
+        selfPlays.emplace_back(make_unique<SelfPlay>(rawAgents[idx].get(), mctsAgents[idx].get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options));
     }
     size_t numberOfGames;
     is >> numberOfGames;

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -169,7 +169,7 @@ void CrazyAra::inference(istringstream &is)
     info_string("running", warmupIterations, "warmup iteration...");
     info_string("running", iterations, "iterations...");
     info_string("batch-size:", searchSettings.batchSize);
-    mctsAgent->run_inference(warmupIterations);
+    mctsAgent->get_nn_user()->run_inference(warmupIterations);
     const chrono::steady_clock::time_point start = chrono::steady_clock::now();
     mctsAgent->searchThreads.front()->run_inference(iterations);
     const chrono::steady_clock::time_point end = chrono::steady_clock::now();
@@ -355,8 +355,18 @@ void CrazyAra::activeuci()
 #ifdef USE_RL
 void CrazyAra::selfplay(istringstream &is)
 {
+    const size_t NUMBER_OF_PARALLEL_GAMES = Options["Number_Parallel_Games"];
+    const size_t GLOBAL_BATCH_SIZE = Options["Batch_Size"];
+
     prepare_search_config_structs();
-    SelfPlay selfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options);
+
+    for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
+        unique_ptr<MCTSAgent> localMCTSAgent = make_unique<MCTSAgent>(*mctsAgent.get()); // Deep Copy
+        localMCTSAgent.set_id(idx);
+        unique_ptr<RawNetAgent> localRawAgent = make_unique<RawNetAgent>(*rawAgent.get());   // Deep Copy
+        localRawAgent.set_id(idx);
+        SelfPlay selfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options);
+    }
     size_t numberOfGames;
     is >> numberOfGames;
     selfPlay.go(numberOfGames, variant);
@@ -757,6 +767,7 @@ void CrazyAra::init_search_settings()
     searchSettings.allowEarlyStopping = Options["Allow_Early_Stopping"];
     useRawNetwork = Options["Use_Raw_Network"];
     searchSettings.useNPSTimemanager = Options["Use_NPS_Time_Manager"];
+    searchSettings.numberParallelGames = Options["Number_Parallel_Games"];
     if (string(Options["SyzygyPath"]).empty() || string(Options["SyzygyPath"]) == "<empty>") {
         searchSettings.useTablebase = false;
     }

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -371,15 +371,15 @@ void CrazyAra::selfplay(istringstream &is)
 
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         mctsAgents.emplace_back(MCTSAgent(*mctsAgent.get())); // Deep Copy
-        mctsAgents.back()->set_agent_id(idx);
+        mctsAgents.back().set_agent_id(idx);
         rawAgents.emplace_back(RawNetAgent(*rawAgent.get()));   // Deep Copy
-        rawAgents.back()->set_agent_id(idx);
+        rawAgents.back().set_agent_id(idx);
         selfPlays.emplace_back(SelfPlay(&rawAgents.back(), &mctsAgents.back(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx));
     }
     size_t numberOfGames;
     is >> numberOfGames;
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
-        gameThreads.emplace_back(thread(run_selfplay_thread, selfplays[idx], numberOfGames, variant, selfplayFileMutex));
+        gameThreads.emplace_back(thread(run_selfplay_thread, &selfPlays[idx], numberOfGames, variant, &selfplayFileMutex));
     }
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         gameThreads[idx].join();

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -378,7 +378,7 @@ void CrazyAra::selfplay(istringstream &is)
     size_t numberOfGames;
     is >> numberOfGames;
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
-        gameThreads.emplace_back(thread(run_selfplay_thread, &selfPlays[idx], numberOfGames, variant, &selfplayFileMutex));
+        gameThreads.emplace_back(thread(run_selfplay_thread, &selfPlays[idx], numberOfGames / NUMBER_OF_PARALLEL_GAMES, variant, &selfplayFileMutex));
     }
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         gameThreads[idx].join();

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -370,9 +370,9 @@ void CrazyAra::selfplay(istringstream &is)
 
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         mctsAgents.emplace_back(MCTSAgent(*mctsAgent.get())); // Deep Copy
-        mctsAgents.back().set_agent_id(idx);
+        mctsAgents[idx].set_agent_id(idx);
         rawAgents.emplace_back(RawNetAgent(*rawAgent.get()));   // Deep Copy
-        rawAgents.back().set_agent_id(idx);
+        rawAgents[idx].set_agent_id(idx);
         selfPlays.emplace_back(SelfPlay(&rawAgents.back(), &mctsAgents.back(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx));
     }
     size_t numberOfGames;

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -362,17 +362,19 @@ void CrazyAra::selfplay(istringstream &is)
 
     vector<thread> gameThreads;
     vector<SelfPlay> selfPlays;
+    vector<MCTSAgent> mctsAgents;
+    vector<RawNetAgent> rawAgents;
 
     // shared resource for all selfplay objects
     size_t gameIdx = 0;
     size_t startIdx = 0;
 
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
-        unique_ptr<MCTSAgent> localMCTSAgent = make_unique<MCTSAgent>(*mctsAgent.get()); // Deep Copy
-        localMCTSAgent->set_agent_id(idx);
-        unique_ptr<RawNetAgent> localRawAgent = make_unique<RawNetAgent>(*rawAgent.get());   // Deep Copy
-        localRawAgent->set_agent_id(idx);
-        selfPlays.emplace_back(SelfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options));
+        mctsAgents.emplace_back(MCTSAgent(*mctsAgent.get())); // Deep Copy
+        mctsAgents.back()->set_agent_id(idx);
+        rawAgents.emplace_back(RawNetAgent(*rawAgent.get()));   // Deep Copy
+        rawAgents.back()->set_agent_id(idx);
+        selfPlays.emplace_back(SelfPlay(&rawAgents.back(), &mctsAgents.back(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options, &gameIdx, &startIdx));
     }
     size_t numberOfGames;
     is >> numberOfGames;

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -168,7 +168,7 @@ void CrazyAra::inference(istringstream &is)
     }
     info_string("running", warmupIterations, "warmup iteration...");
     info_string("running", iterations, "iterations...");
-    info_string("batch-size:", searchSettings.batchSize);
+    info_string("main batch-size:", searchSettings.get_main_batch_size());
     mctsAgent->get_nn_user()->run_inference(warmupIterations);
     const chrono::steady_clock::time_point start = chrono::steady_clock::now();
     mctsAgent->searchThreads.front()->run_inference(iterations);
@@ -177,7 +177,7 @@ void CrazyAra::inference(istringstream &is)
     info_string("Inference results");
     info_string("-----------------");
     info_string("Elapsed time:", elapsedMS/1000.0, "s");
-    info_string("Evaluations per second:", (iterations/double(elapsedMS))*1000*searchSettings.batchSize, "nps");
+    info_string("Evaluations per second:", (iterations/double(elapsedMS))*1000*searchSettings.get_main_batch_size(), "nps");
 }
 
 void CrazyAra::go(StateObj* state, istringstream &is,  EvalInfo& evalInfo)
@@ -573,7 +573,7 @@ void CrazyAra::fill_single_nn_vector(const string& modelDirectory, vector<unique
     size_t idx = 0;
     for (int deviceId = int(Options["First_Device_ID"]); deviceId <= int(Options["Last_Device_ID"]); ++deviceId) {
         for (size_t i = 0; i < size_t(Options["Threads"]); ++i) {
-            unique_ptr<NeuralNetAPI> netBatchesTmp = create_new_net(modelDirectory, deviceId, searchSettings.batchSize);
+            unique_ptr<NeuralNetAPI> netBatchesTmp = create_new_net(modelDirectory, deviceId, searchSettings.get_main_batch_size());
             netBatchesTmp->validate_neural_network();
             netBatchesVector[idx].push_back(std::move(netBatchesTmp));
             ++idx;

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -171,7 +171,7 @@ void CrazyAra::inference(istringstream &is)
     info_string("batch-size:", searchSettings.batchSize);
     mctsAgent->get_nn_user()->run_inference(warmupIterations);
     const chrono::steady_clock::time_point start = chrono::steady_clock::now();
-    mctsAgent->searchThreads.front()->run_inference(iterations);
+    mctsAgent->searchThreads.front()->nnUser->run_inference(iterations);
     const chrono::steady_clock::time_point end = chrono::steady_clock::now();
     const size_t elapsedMS = chrono::duration_cast<chrono::milliseconds>(end - start).count();
     info_string("Inference results");

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -374,7 +374,7 @@ void CrazyAra::selfplay(istringstream &is)
     size_t numberOfGames;
     is >> numberOfGames;
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
-        gameThreads.emplace_back(thread(run_selfplay_thread, selfPlays[idx].get(), numberOfGames / NUMBER_OF_PARALLEL_GAMES, variant));
+        gameThreads.emplace_back(thread(run_selfplay_thread, selfPlays[idx].get(), numberOfGames, variant));
     }
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         gameThreads[idx].join();

--- a/engine/src/uci/crazyara.cpp
+++ b/engine/src/uci/crazyara.cpp
@@ -360,16 +360,20 @@ void CrazyAra::selfplay(istringstream &is)
 
     prepare_search_config_structs();
 
+    vector<SelfPlay> selfPlays;
+
     for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
         unique_ptr<MCTSAgent> localMCTSAgent = make_unique<MCTSAgent>(*mctsAgent.get()); // Deep Copy
-        localMCTSAgent.set_id(idx);
+        localMCTSAgent->set_agent_id(idx);
         unique_ptr<RawNetAgent> localRawAgent = make_unique<RawNetAgent>(*rawAgent.get());   // Deep Copy
-        localRawAgent.set_id(idx);
-        SelfPlay selfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options);
+        localRawAgent->set_agent_id(idx);
+        selfPlays.push_back(SelfPlay(rawAgent.get(), mctsAgent.get(), &searchSettings, &searchLimits, &playSettings, &rlSettings, Options));
     }
     size_t numberOfGames;
     is >> numberOfGames;
-    selfPlay.go(numberOfGames, variant);
+    for (size_t idx = 0; idx < NUMBER_OF_PARALLEL_GAMES; ++idx) {
+        selfPlays[idx].go(numberOfGames, variant, selfplayFileMutex);
+    }
     cout << "readyok" << endl;
 }
 

--- a/engine/src/uci/crazyara.h
+++ b/engine/src/uci/crazyara.h
@@ -89,8 +89,6 @@ private:
     unique_ptr<MCTSAgent> mctsAgentContender;
     vector<vector<unique_ptr<NeuralNetAPI>>> netBatchesContenderVector;
     RLSettings rlSettings;
-    // global for writing and exporting data
-    std::mutex selfplayFileMutex;
 #endif
     SearchSettings searchSettings;
     SearchLimits searchLimits;

--- a/engine/src/uci/crazyara.h
+++ b/engine/src/uci/crazyara.h
@@ -89,6 +89,8 @@ private:
     unique_ptr<MCTSAgent> mctsAgentContender;
     vector<vector<unique_ptr<NeuralNetAPI>>> netBatchesContenderVector;
     RLSettings rlSettings;
+    // global for writing and exporting data
+    std::mutex selfplayFileMutex;
 #endif
     SearchSettings searchSettings;
     SearchLimits searchLimits;

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -67,7 +67,7 @@ void OptionsUCI::init(OptionsMap &o)
 {
     o["Allow_Early_Stopping"]          << Option(true);
 #ifdef USE_RL
-    o["Batch_Size"]                    << Option(8, 1, 8192);
+    o["Batch_Size"]                    << Option(64, 1, 8192);
 #else
 #ifdef OPENVINO
     o["Batch_Size"]                    << Option(16, 1, 8192);

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -140,6 +140,9 @@ void OptionsUCI::init(OptionsMap &o)
     o["Nodes"]                         << Option(0, 0, 99999999);
 #endif
     o["Nodes_Limit"]                   << Option(0, 0, 999999999);
+#ifdef USE_RL
+    o["Number_Parallel_Games"]         << Option(8, 1, 999);
+#endif
 #ifdef TENSORRT
     o["Precision"]                     << Option("float16", {"float32", "float16", "int8"});
 #else

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -207,7 +207,7 @@ void OptionsUCI::init(OptionsMap &o)
     o["Centi_Resign_Probability"]      << Option(90, 0, 100);
     o["Centi_Resign_Threshold"]        << Option(-90, -100, 100);
     o["EPD_File_Path"]                 << Option("<empty>");
-    o["MaxInitPly"]                    << Option(30, 0, 99999);
+    o["MaxInitPly"]                    << Option(0, 0, 99999);  // 30
     o["MeanInitPly"]                   << Option(15, 0, 99999);
 #ifdef MODE_LICHESS
     o["Model_Directory_Contender"]     << Option((string("model_contender/" + engineName + "/") + get_first_variant_with_model()).c_str());

--- a/engine/src/uci/optionsuci.cpp
+++ b/engine/src/uci/optionsuci.cpp
@@ -67,7 +67,7 @@ void OptionsUCI::init(OptionsMap &o)
 {
     o["Allow_Early_Stopping"]          << Option(true);
 #ifdef USE_RL
-    o["Batch_Size"]                    << Option(64, 1, 8192);
+    o["Batch_Size"]                    << Option(8, 1, 8192);
 #else
 #ifdef OPENVINO
     o["Batch_Size"]                    << Option(16, 1, 8192);

--- a/engine/src/util/reusablebarrier.cpp
+++ b/engine/src/util/reusablebarrier.cpp
@@ -1,0 +1,49 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: reusablebarrier.h
+ * Created on 09.12.2025
+ * @author: queensgambit
+ *
+ * The reusable barrier is a helper class as a replacement for the barrier class available in C++ 2020.
+ */
+
+
+#include "reusablebarrier.h"
+
+ReusableBarrier::ReusableBarrier(std::size_t count)
+    : threshold(count), count(count), generation(0)
+{
+
+}
+
+void ReusableBarrier::arrive_and_wait()
+{
+    std::unique_lock<std::mutex> lock(mtx);
+    auto gen = generation;
+
+    if (--count == 0) {
+        generation++;
+        count = threshold;
+        cv.notify_all();
+    } else {
+        cv.wait(lock, [this, gen] { return gen != generation; });
+    }
+}

--- a/engine/src/util/reusablebarrier.h
+++ b/engine/src/util/reusablebarrier.h
@@ -1,0 +1,49 @@
+/*
+  CrazyAra, a deep learning chess variant engine
+  Copyright (C) 2018       Johannes Czech, Moritz Willig, Alena Beyer
+  Copyright (C) 2019-2020  Johannes Czech
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * @file: reusablebarrier.h
+ * Created on 09.12.2025
+ * @author: queensgambit
+ *
+ * The reusable barrier is a helper class as a replacement for the barrier class available in C++ 2020.
+ */
+
+#ifndef REUSABLEBARRIER_H
+#define REUSABLEBARRIER_H
+
+#include <mutex>
+#include <condition_variable>
+
+class ReusableBarrier {
+public:
+    explicit ReusableBarrier(std::size_t count);
+
+    void arrive_and_wait();
+
+private:
+    std::mutex mtx;
+    std::condition_variable cv;
+    const std::size_t threshold;
+    std::size_t count;
+    std::size_t generation;
+};
+
+
+#endif // REUSABLEBARRIER_H


### PR DESCRIPTION
This PR allows generating multiple games on a single GPU.
You need to set the variable `Number_Parallel_Games` (default: 8) to configure how many games you want to run in parallel. No change of `Batch_Size` is necessary, as it automatically increases the usual `Batch_Size` by times `Number_Parallel_Games`, i.e., times 8.
The individual parallel games are exported into separate files and later merged into a single file via Python.

The `rlSettings->numberChunks` is divided by `searchSettings->numberParallelGames` for each `TrainDataExporter` object. On the GPU, it uses a queue and a future.get() setup to handle the requests.

Generating one RL package on an Nvidia A100 takes 3 hours and 15 minutes by default. When using a parallelization of 8, it takes 1 hour and 15 minutes, resulting in an approximate threefold speed up.

Note, the parallel RL loop is not compatible with the Mixture of Experts (MoE) setup.
It also includes a small version of the A0 resnet.
